### PR TITLE
feat: support CPA auth import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,3 @@
 # Validation
 
 After modifying any `.zig` file, always run `zig build run -- list` to verify the changes work correctly.
-
-# Execution Lock
-
-- The active task for this branch must follow `plans/2026-03-20-import-cpa-auth.md`.
-- Keep that plan file updated with the current checklist state and progress log as the task advances.
-- Continue executing from the latest recorded progress in that plan until every checklist item is complete.
-- Remove this execution-lock section after the plan is fully completed and validated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,10 @@
 # Validation
 
 After modifying any `.zig` file, always run `zig build run -- list` to verify the changes work correctly.
+
+# Execution Lock
+
+- The active task for this branch must follow `plans/2026-03-20-import-cpa-auth.md`.
+- Keep that plan file updated with the current checklist state and progress log as the task advances.
+- Continue executing from the latest recorded progress in that plan until every checklist item is complete.
+- Remove this execution-lock section after the plan is fully completed and validated.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ codex-auth list # list all accounts
 codex-auth login # run `codex login`, then add the current account
 codex-auth switch [<email>] # switch active account (interactive or partial/fragment match)
 codex-auth import <path> [--alias <alias>] # smart import: file -> single import, folder -> batch import
+codex-auth import --cpa [<path>] # import CPA flat token JSON from one file or directory
 codex-auth import --purge [<path>] # rebuild registry.json from auth files for the current version
 codex-auth remove # remove accounts (interactive multi-select)
 codex-auth status # show auto-switch/service/api usage status
@@ -101,6 +102,14 @@ Batch import from a folder:
 
 ```shell
 codex-auth import /path/to/auth-exports
+```
+
+Import CPA exports directly:
+
+```shell
+codex-auth import --cpa                  # scan ~/.cli-proxy-api/*.json
+codex-auth import --cpa /path/to/cpa-dir
+codex-auth import --cpa /path/to/cpa.json --alias personal
 ```
 
 Typical batch import output:
@@ -220,6 +229,15 @@ Upgrade notes:
 
 If you have token files from `~/.cli-proxy-api/token*.json`, this repository includes a helper script that can convert them into a format codex-auth can read.
 
+The CLI can also import the flat cli-proxy-api / CPA JSON files directly:
+
+```shell
+codex-auth import --cpa                  # default source: ~/.cli-proxy-api
+codex-auth import --cpa /path/to/cpa-dir # scans direct child .json files
+```
+
+Each CPA file is converted in memory to the standard auth snapshot shape before it is written into `~/.codex/accounts/`. Missing or empty `refresh_token` values are skipped as `MissingRefreshToken`.
+
 The script is not bundled in the published npm package, so run it from a clone of this repository:
 
 ```shell
@@ -234,6 +252,8 @@ Then import and switch:
 
 ```shell
 codex-auth import /tmp/tokens/
+# or import the CPA files directly without a conversion step
+codex-auth import --cpa
 codex-auth switch
 ```
 

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -107,6 +107,14 @@ This document describes how `codex-auth` stores accounts, synchronizes auth file
 - `codex-auth import <path>` auto-detects the path type:
   - file path: imports one auth/config file.
   - directory path: batch imports config files from that directory.
+- `codex-auth import --cpa [<path>]` imports flat CPA token JSON:
+  - explicit file path: imports one CPA JSON file
+  - explicit directory path: batch imports direct child `.json` files from that directory
+  - omitted path: defaults to `~/.cli-proxy-api` and scans direct child `.json` files there
+- CPA imports convert each source file in memory to the current standard auth snapshot layout before writing `accounts/<account file key>.auth.json`.
+- CPA conversion expects the flat fields `id_token`, `access_token`, `refresh_token`, `account_id`, and `last_refresh`; `refresh_token` is required and missing/empty values are skipped as `MissingRefreshToken`.
+- CPA imports keep the current report formatting and stream split used by standard imports.
+- `--cpa` cannot be combined with `--purge`.
 - `codex-auth import --purge [<path>]` rebuilds `registry.json` from scratch using the imported auth set for the current binary format.
 - During `--purge`, `auto_switch` and `api` configuration are carried forward from an existing `registry.json`; account snapshots, stored usage, active-account activation time, and per-account local rollout dedupe state are cleared and rebuilt from auth files.
 - When `--purge` is used without a path, the source defaults to `~/.codex/accounts/` and scans direct child auth files from that directory: current account snapshots (`*.auth.json`) plus `auth.json.bak.*` backups.

--- a/plans/2026-03-20-import-cpa-auth.md
+++ b/plans/2026-03-20-import-cpa-auth.md
@@ -57,6 +57,8 @@ Implement CPA-format auth import for `codex-auth`, ship it behind `import --cpa`
 - 2026-03-20: Created bootstrap commit `3618744`, opened Draft PR #21, and captured the initial PR snapshot (CI pending, no review threads).
 - 2026-03-20: Implemented `import --cpa`, updated docs/tests, and passed `zig test src/main.zig -lc`, `zig build`, and `zig build run -- list`.
 - 2026-03-20: Pushed implementation commit `cbd3314`, waited for PR #21 checks to turn green, and confirmed there were still no unresolved review threads before cleanup.
+- 2026-03-20: Fixed the missing-default-CPA-source behavior in commit `a54aea9`, re-ran the PR loop, and confirmed PR #21 was green with no unresolved review threads.
+- 2026-03-20: Added a repeat-import CPA regression test during an extra branch-vs-`main` review pass and re-entered the PR loop for final verification.
 
 ## Testing and validation
 - `zig test src/main.zig -lc`

--- a/plans/2026-03-20-import-cpa-auth.md
+++ b/plans/2026-03-20-import-cpa-auth.md
@@ -1,0 +1,80 @@
+---
+name: import-cpa-auth
+description: Add CPA-format auth import support and drive the branch through the full PR review and CI loop
+---
+
+# Plan
+
+Implement CPA-format auth import for `codex-auth`, ship it behind `import --cpa`, and drive the branch from bootstrap through a green Draft PR with no unresolved actionable review threads.
+
+## Requirements
+- Add `codex-auth import --cpa [<path>]`.
+- In CPA mode, allow the path to be omitted and default the source to `~/.cli-proxy-api`.
+- For CPA directory imports, scan all direct child `.json` files only, non-recursively, in sorted filename order.
+- Treat each CPA file as the flat token JSON shape implied by `scripts/convert_tokens.sh`.
+- Convert CPA JSON to the current standard auth snapshot format in memory before importing.
+- Require `refresh_token` during CPA conversion; skip missing or empty values as `MissingRefreshToken`.
+- Keep the existing import stdout/stderr reporting model unchanged.
+- Keep existing non-CPA import behavior unchanged.
+- Reject `--cpa` together with `--purge`.
+- Keep this plan file updated so it reflects the latest implementation and PR-loop progress.
+
+## Scope
+- In: CLI parsing/help changes, CPA conversion/import logic, docs updates, tests, Draft PR creation, CI/review-loop handling, and temporary `AGENTS.md` execution-lock management.
+- Out: unrelated import redesigns, unrelated PR feedback outside this branch diff unless required to make the PR green, and permanent `AGENTS.md` workflow changes.
+
+## Files and entry points
+- `src/cli.zig` for CLI parsing/help text and import dispatch options
+- `src/auth.zig` for auth parsing helpers and CPA-to-standard conversion
+- `src/registry.zig` and `src/main.zig` for import execution, default-source resolution, and report handling
+- `src/tests/` plus `README.md` and `docs/implement.md` for validation and documentation coverage
+
+## Data model / API changes
+- Extend import parsing with an explicit CPA mode so `handleImport` can choose standard import vs CPA import.
+- Add an internal CPA conversion helper that emits standard auth JSON containing:
+  - `auth_mode`
+  - `OPENAI_API_KEY`
+  - `tokens.id_token`
+  - `tokens.access_token`
+  - `tokens.refresh_token`
+  - `tokens.account_id`
+  - `last_refresh`
+- Keep account identity derived from the converted auth JWT claims, not from the top-level CPA `email`.
+
+## Action items
+- [x] Add this plan file and keep implementation aligned with it.
+- [x] Add a temporary execution-lock section to `AGENTS.md` that points at this plan until the task is complete.
+- [ ] Commit the bootstrap changes and create a Draft PR targeting `main`.
+- [ ] Implement `import --cpa [<path>]` and the underlying CPA conversion/import flow.
+- [ ] Update docs and help text for the new flag and default source behavior.
+- [ ] Add or adjust tests for CPA parsing, import behavior, and CLI output.
+- [ ] Run local validation for the touched Zig code and supporting docs/tests.
+- [ ] Push implementation changes and process PR review comments plus CI until green.
+- [ ] Remove the temporary `AGENTS.md` execution lock once the work is complete and validated.
+
+## Progress log
+- 2026-03-20: Captured the execution plan and locked `AGENTS.md` to it before any code changes.
+
+## Testing and validation
+- `zig test src/main.zig -lc`
+- `zig build`
+- `zig build run -- list`
+- Add or update tests for:
+  - `import --cpa` CLI parsing/help
+  - single-file CPA import
+  - directory CPA import
+  - repeated CPA import -> `updated`
+  - missing `refresh_token` -> `MissingRefreshToken`
+  - omitted-path CPA import using `~/.cli-proxy-api`
+  - stored snapshots using the standard nested auth JSON layout
+
+## Risks and edge cases
+- The converted snapshot written under `accounts/` must be the standard auth format, not the original CPA source bytes.
+- Default-source resolution must use the real user home directory, not `~/.codex`.
+- Directory CPA import should keep the existing import report ordering and stream split.
+- The temporary `AGENTS.md` execution lock must be removed before the task is finally declared done.
+
+## Assumptions
+- The plan file remains in `plans/` after completion.
+- Review comments that are stale or not reasonable are not “fixed” blindly; only actionable comments are addressed and resolved.
+- The first PR created from `feat/import-cpa-auth` is the PR used for the entire review loop.

--- a/plans/2026-03-20-import-cpa-auth.md
+++ b/plans/2026-03-20-import-cpa-auth.md
@@ -44,16 +44,18 @@ Implement CPA-format auth import for `codex-auth`, ship it behind `import --cpa`
 ## Action items
 - [x] Add this plan file and keep implementation aligned with it.
 - [x] Add a temporary execution-lock section to `AGENTS.md` that points at this plan until the task is complete.
-- [ ] Commit the bootstrap changes and create a Draft PR targeting `main`.
-- [ ] Implement `import --cpa [<path>]` and the underlying CPA conversion/import flow.
-- [ ] Update docs and help text for the new flag and default source behavior.
-- [ ] Add or adjust tests for CPA parsing, import behavior, and CLI output.
-- [ ] Run local validation for the touched Zig code and supporting docs/tests.
+- [x] Commit the bootstrap changes and create a Draft PR targeting `main`.
+- [x] Implement `import --cpa [<path>]` and the underlying CPA conversion/import flow.
+- [x] Update docs and help text for the new flag and default source behavior.
+- [x] Add or adjust tests for CPA parsing, import behavior, and CLI output.
+- [x] Run local validation for the touched Zig code and supporting docs/tests.
 - [ ] Push implementation changes and process PR review comments plus CI until green.
 - [ ] Remove the temporary `AGENTS.md` execution lock once the work is complete and validated.
 
 ## Progress log
 - 2026-03-20: Captured the execution plan and locked `AGENTS.md` to it before any code changes.
+- 2026-03-20: Created bootstrap commit `3618744`, opened Draft PR #21, and captured the initial PR snapshot (CI pending, no review threads).
+- 2026-03-20: Implemented `import --cpa`, updated docs/tests, and passed `zig test src/main.zig -lc`, `zig build`, and `zig build run -- list`.
 
 ## Testing and validation
 - `zig test src/main.zig -lc`

--- a/plans/2026-03-20-import-cpa-auth.md
+++ b/plans/2026-03-20-import-cpa-auth.md
@@ -49,13 +49,14 @@ Implement CPA-format auth import for `codex-auth`, ship it behind `import --cpa`
 - [x] Update docs and help text for the new flag and default source behavior.
 - [x] Add or adjust tests for CPA parsing, import behavior, and CLI output.
 - [x] Run local validation for the touched Zig code and supporting docs/tests.
-- [ ] Push implementation changes and process PR review comments plus CI until green.
-- [ ] Remove the temporary `AGENTS.md` execution lock once the work is complete and validated.
+- [x] Push implementation changes and process PR review comments plus CI until green.
+- [x] Remove the temporary `AGENTS.md` execution lock once the work is complete and validated.
 
 ## Progress log
 - 2026-03-20: Captured the execution plan and locked `AGENTS.md` to it before any code changes.
 - 2026-03-20: Created bootstrap commit `3618744`, opened Draft PR #21, and captured the initial PR snapshot (CI pending, no review threads).
 - 2026-03-20: Implemented `import --cpa`, updated docs/tests, and passed `zig test src/main.zig -lc`, `zig build`, and `zig build run -- list`.
+- 2026-03-20: Pushed implementation commit `cbd3314`, waited for PR #21 checks to turn green, and confirmed there were still no unresolved review threads before cleanup.
 
 ## Testing and validation
 - `zig test src/main.zig -lc`

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -19,6 +19,18 @@ pub const AuthInfo = struct {
     }
 };
 
+const StandardAuthJson = struct {
+    auth_mode: []const u8,
+    OPENAI_API_KEY: ?[]const u8,
+    tokens: struct {
+        id_token: []const u8,
+        access_token: []const u8,
+        refresh_token: []const u8,
+        account_id: []const u8,
+    },
+    last_refresh: []const u8,
+};
+
 fn normalizeEmailAlloc(allocator: std.mem.Allocator, email: []const u8) ![]u8 {
     var buf = try allocator.alloc(u8, email.len);
     for (email, 0..) |ch, i| {
@@ -42,6 +54,10 @@ pub fn parseAuthInfo(allocator: std.mem.Allocator, auth_path: []const u8) !AuthI
     const data = try file.readToEndAlloc(allocator, 10 * 1024 * 1024);
     defer allocator.free(data);
 
+    return try parseAuthInfoData(allocator, data);
+}
+
+pub fn parseAuthInfoData(allocator: std.mem.Allocator, data: []const u8) !AuthInfo {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
     defer parsed.deinit();
     const root = parsed.value;
@@ -195,6 +211,36 @@ pub fn parseAuthInfo(allocator: std.mem.Allocator, auth_path: []const u8) !AuthI
     };
 }
 
+pub fn convertCpaAuthJson(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return error.InvalidCpaFormat,
+    };
+
+    const refresh_token = jsonStringField(obj, "refresh_token") orelse return error.MissingRefreshToken;
+    if (refresh_token.len == 0) return error.MissingRefreshToken;
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+
+    try std.json.Stringify.value(StandardAuthJson{
+        .auth_mode = "chatgpt",
+        .OPENAI_API_KEY = null,
+        .tokens = .{
+            .id_token = jsonStringFieldOrDefault(obj, "id_token"),
+            .access_token = jsonStringFieldOrDefault(obj, "access_token"),
+            .refresh_token = refresh_token,
+            .account_id = jsonStringFieldOrDefault(obj, "account_id"),
+        },
+        .last_refresh = jsonStringFieldOrDefault(obj, "last_refresh"),
+    }, .{ .whitespace = .indent_2 }, &out.writer);
+    try out.writer.writeAll("\n");
+    return try out.toOwnedSlice();
+}
+
 pub fn decodeJwtPayload(allocator: std.mem.Allocator, jwt: []const u8) ![]u8 {
     var it = std.mem.splitScalar(u8, jwt, '.');
     _ = it.next();
@@ -223,4 +269,16 @@ fn parsePlanType(s: []const u8) registry.PlanType {
     if (std.ascii.eqlIgnoreCase(s, "enterprise")) return .enterprise;
     if (std.ascii.eqlIgnoreCase(s, "edu")) return .edu;
     return .unknown;
+}
+
+fn jsonStringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn jsonStringFieldOrDefault(obj: std.json.ObjectMap, key: []const u8) []const u8 {
+    return jsonStringField(obj, key) orelse "";
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -36,10 +36,12 @@ pub const OutputFormat = enum { table, json, csv, compact };
 pub const ListOptions = struct {};
 pub const LoginInvocation = enum { login, add_alias };
 pub const LoginOptions = struct { invocation: LoginInvocation };
+pub const ImportSource = enum { standard, cpa };
 pub const ImportOptions = struct {
     auth_path: ?[]u8,
     alias: ?[]u8,
     purge: bool,
+    source: ImportSource,
 };
 pub const SwitchOptions = struct { query: ?[]u8 };
 pub const RemoveOptions = struct {};
@@ -99,6 +101,7 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Comm
         var auth_path: ?[]u8 = null;
         var alias: ?[]u8 = null;
         var purge = false;
+        var source: ImportSource = .standard;
         var i: usize = 2;
         while (i < args.len) : (i += 1) {
             const arg = std.mem.sliceTo(args[i], 0);
@@ -108,6 +111,13 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Comm
                 i += 1;
             } else if (std.mem.eql(u8, arg, "--purge")) {
                 purge = true;
+            } else if (std.mem.eql(u8, arg, "--cpa")) {
+                if (source == .cpa) {
+                    if (auth_path) |p| allocator.free(p);
+                    if (alias) |a| allocator.free(a);
+                    return Command{ .help = {} };
+                }
+                source = .cpa;
             } else if (std.mem.startsWith(u8, arg, "-")) {
                 if (auth_path) |p| allocator.free(p);
                 if (alias) |a| allocator.free(a);
@@ -121,7 +131,12 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Comm
                 auth_path = try allocator.dupe(u8, arg);
             }
         }
-        if (auth_path == null and !purge) {
+        if (purge and source == .cpa) {
+            if (auth_path) |p| allocator.free(p);
+            if (alias) |a| allocator.free(a);
+            return Command{ .help = {} };
+        }
+        if (auth_path == null and !purge and source == .standard) {
             if (alias) |a| allocator.free(a);
             return Command{ .help = {} };
         }
@@ -129,6 +144,7 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Comm
             .auth_path = auth_path,
             .alias = alias,
             .purge = purge,
+            .source = source,
         } };
     }
 
@@ -315,6 +331,7 @@ pub fn writeHelp(
     };
     const import_details = [_]HelpEntry{
         .{ .name = "<path>", .description = "Import one file or batch import a directory" },
+        .{ .name = "--cpa [<path>]", .description = "Import CPA flat token JSON from one file or directory" },
         .{ .name = "--alias <alias>", .description = "Set alias for single-file import" },
         .{ .name = "--purge [<path>]", .description = "Rebuild `registry.json` from auth files" },
     };
@@ -340,6 +357,7 @@ pub fn writeHelp(
     try writeHelpEntry(out, use_color, child_indent, import_detail_col, import_details[0].name, import_details[0].description);
     try writeHelpEntry(out, use_color, child_indent, import_detail_col, import_details[1].name, import_details[1].description);
     try writeHelpEntry(out, use_color, child_indent, import_detail_col, import_details[2].name, import_details[2].description);
+    try writeHelpEntry(out, use_color, child_indent, import_detail_col, import_details[3].name, import_details[3].description);
     try writeHelpEntry(out, use_color, parent_indent, command_col, commands[5].name, commands[5].description);
     try writeHelpEntry(out, use_color, parent_indent, command_col, commands[6].name, commands[6].description);
     try writeHelpEntry(out, use_color, parent_indent, command_col, commands[7].name, commands[7].description);

--- a/src/main.zig
+++ b/src/main.zig
@@ -153,7 +153,10 @@ fn handleImport(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
 
     var reg = try registry.loadRegistry(allocator, codex_home);
     defer reg.deinit(allocator);
-    var report = try registry.importAuthPath(allocator, codex_home, &reg, opts.auth_path.?, opts.alias);
+    var report = switch (opts.source) {
+        .standard => try registry.importAuthPath(allocator, codex_home, &reg, opts.auth_path.?, opts.alias),
+        .cpa => try registry.importCpaPath(allocator, codex_home, &reg, opts.auth_path, opts.alias),
+    };
     defer report.deinit(allocator);
     if (report.appliedCount() > 0) {
         try registry.saveRegistry(allocator, codex_home, &reg);

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -925,7 +925,7 @@ pub fn importCpaPath(
         }
         const default_path = try defaultCpaImportPath(allocator);
         defer allocator.free(default_path);
-        return try importCpaDirectory(allocator, codex_home, reg, default_path, "~/.cli-proxy-api", true);
+        return try importCpaDirectory(allocator, codex_home, reg, default_path, "~/.cli-proxy-api", false);
     }
 
     const path = auth_path.?;

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -291,6 +291,12 @@ pub fn copyFile(src: []const u8, dest: []const u8) !void {
     try std.fs.cwd().copyFile(src, std.fs.cwd(), dest, .{});
 }
 
+fn writeFile(path: []const u8, data: []const u8) !void {
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(data);
+}
+
 const max_backups: usize = 5;
 
 pub const CleanSummary = struct {
@@ -876,9 +882,11 @@ fn isImportValidationError(err: anyerror) bool {
     return switch (err) {
         error.SyntaxError,
         error.UnexpectedEndOfInput,
+        error.InvalidCpaFormat,
         error.MissingEmail,
         error.MissingChatgptUserId,
         error.MissingAccountId,
+        error.MissingRefreshToken,
         error.AccountIdMismatch,
         error.InvalidJwt,
         error.InvalidBase64,
@@ -902,6 +910,57 @@ fn isImportSourceFileError(err: anyerror) bool {
 
 fn isImportSkippableBatchEntryError(err: anyerror) bool {
     return isImportValidationError(err) or isImportSourceFileError(err);
+}
+
+pub fn importCpaPath(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *Registry,
+    auth_path: ?[]const u8,
+    explicit_alias: ?[]const u8,
+) !ImportReport {
+    if (auth_path == null) {
+        if (explicit_alias != null) {
+            std.log.warn("--alias is ignored when importing a directory: {s}", .{"~/.cli-proxy-api"});
+        }
+        const default_path = try defaultCpaImportPath(allocator);
+        defer allocator.free(default_path);
+        return try importCpaDirectory(allocator, codex_home, reg, default_path, "~/.cli-proxy-api", true);
+    }
+
+    const path = auth_path.?;
+    const stat = std.fs.cwd().statFile(path) catch |err| switch (err) {
+        error.IsDir => {
+            if (explicit_alias != null) {
+                std.log.warn("--alias is ignored when importing a directory: {s}", .{path});
+            }
+            return try importCpaDirectory(allocator, codex_home, reg, path, path, false);
+        },
+        else => return err,
+    };
+    if (stat.kind == .directory) {
+        if (explicit_alias != null) {
+            std.log.warn("--alias is ignored when importing a directory: {s}", .{path});
+        }
+        return try importCpaDirectory(allocator, codex_home, reg, path, path, false);
+    }
+
+    var report = ImportReport.init(.single_file);
+    errdefer report.deinit(allocator);
+
+    const outcome = importCpaFile(allocator, codex_home, reg, path, explicit_alias) catch |err| {
+        if (!isImportValidationError(err) and !isImportSourceFileError(err)) return err;
+        const label = try importDisplayLabel(allocator, path);
+        defer allocator.free(label);
+        try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+        report.failure = err;
+        return report;
+    };
+
+    const label = try importDisplayLabel(allocator, path);
+    defer allocator.free(label);
+    try report.addEvent(allocator, label, outcome, null);
+    return report;
 }
 
 pub fn importAuthPath(
@@ -945,6 +1004,59 @@ pub fn importAuthPath(
     return report;
 }
 
+fn defaultCpaImportPath(allocator: std.mem.Allocator) ![]u8 {
+    const home = try resolveUserHome(allocator);
+    defer allocator.free(home);
+    return try std.fs.path.join(allocator, &[_][]const u8{ home, ".cli-proxy-api" });
+}
+
+fn importCpaFile(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *Registry,
+    auth_file: []const u8,
+    explicit_alias: ?[]const u8,
+) !ImportOutcome {
+    var file = try std.fs.cwd().openFile(auth_file, .{});
+    defer file.close();
+
+    const data = try file.readToEndAlloc(allocator, 10 * 1024 * 1024);
+    defer allocator.free(data);
+
+    const converted = try @import("auth.zig").convertCpaAuthJson(allocator, data);
+    defer allocator.free(converted);
+
+    const info = try @import("auth.zig").parseAuthInfoData(allocator, converted);
+    defer info.deinit(allocator);
+
+    return try importConvertedAuthInfo(allocator, codex_home, reg, explicit_alias, &info, converted);
+}
+
+fn importConvertedAuthInfo(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *Registry,
+    explicit_alias: ?[]const u8,
+    info: *const @import("auth.zig").AuthInfo,
+    auth_data: []const u8,
+) !ImportOutcome {
+    _ = info.email orelse return error.MissingEmail;
+    const record_key = info.record_key orelse return error.MissingChatgptUserId;
+
+    const alias = explicit_alias orelse "";
+    const existed = findAccountIndexByAccountKey(reg, record_key) != null;
+
+    const dest = try accountAuthPath(allocator, codex_home, record_key);
+    defer allocator.free(dest);
+
+    try ensureAccountsDir(allocator, codex_home);
+    try writeFile(dest, auth_data);
+
+    const record = try accountFromAuth(allocator, alias, info);
+    try upsertAccount(allocator, reg, record);
+    return if (existed) .updated else .imported;
+}
+
 fn importAuthFile(
     allocator: std.mem.Allocator,
     codex_home: []const u8,
@@ -980,6 +1092,55 @@ fn importAuthInfo(
     const record = try accountFromAuth(allocator, alias, info);
     try upsertAccount(allocator, reg, record);
     return if (existed) .updated else .imported;
+}
+
+fn importCpaDirectory(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *Registry,
+    dir_path: []const u8,
+    source_label: []const u8,
+    missing_ok: bool,
+) !ImportReport {
+    var report = ImportReport.init(.scanned);
+    errdefer report.deinit(allocator);
+    report.source_label = try allocator.dupe(u8, source_label);
+
+    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => if (missing_ok) return report else return err,
+        else => return err,
+    };
+    defer dir.close();
+
+    var names = std.ArrayList([]u8).empty;
+    defer {
+        for (names.items) |name| allocator.free(name);
+        names.deinit(allocator);
+    }
+
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind != .file and entry.kind != .sym_link) continue;
+        if (!isImportConfigFile(entry.name)) continue;
+        try names.append(allocator, try allocator.dupe(u8, entry.name));
+    }
+
+    std.sort.insertion([]u8, names.items, {}, importFileNameLessThan);
+
+    for (names.items) |name| {
+        const file_path = try std.fs.path.join(allocator, &[_][]const u8{ dir_path, name });
+        defer allocator.free(file_path);
+        const label = try importDisplayLabelFromName(allocator, name);
+        defer allocator.free(label);
+        const outcome = importCpaFile(allocator, codex_home, reg, file_path, null) catch |err| {
+            if (!isImportSkippableBatchEntryError(err)) return err;
+            try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+            continue;
+        };
+        try report.addEvent(allocator, label, outcome, null);
+    }
+
+    return report;
 }
 
 fn importAuthDirectory(

--- a/src/tests/auth_test.zig
+++ b/src/tests/auth_test.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const auth = @import("../auth.zig");
+const bdd = @import("bdd_helpers.zig");
 
 fn b64url(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
     const encoder = std.base64.url_safe_no_pad.Encoder;
@@ -120,4 +121,32 @@ test "parse auth info frees allocations on account mismatch" {
     defer gpa.free(auth_path);
 
     try std.testing.expectError(error.AccountIdMismatch, auth.parseAuthInfo(gpa, auth_path));
+}
+
+test "convert cpa auth json produces a parseable standard auth snapshot" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try bdd.cpaJsonWithEmailPlan(gpa, "cpa@example.com", "team");
+    defer gpa.free(cpa_json);
+
+    const converted = try auth.convertCpaAuthJson(gpa, cpa_json);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"auth_mode\": \"chatgpt\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"refresh_token\": \"refresh-cpa@example.com\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"account_id\":") != null);
+
+    const info = try auth.parseAuthInfoData(gpa, converted);
+    defer info.deinit(gpa);
+    try std.testing.expect(info.email != null);
+    try std.testing.expect(std.mem.eql(u8, info.email.?, "cpa@example.com"));
+    try std.testing.expect(info.record_key != null);
+    try std.testing.expect(info.auth_mode == .chatgpt);
+}
+
+test "convert cpa auth json requires refresh token" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try bdd.cpaJsonWithoutRefreshToken(gpa, "missing-refresh@example.com", "plus");
+    defer gpa.free(cpa_json);
+
+    try std.testing.expectError(error.MissingRefreshToken, auth.convertCpaAuthJson(gpa, cpa_json));
 }

--- a/src/tests/bdd_helpers.zig
+++ b/src/tests/bdd_helpers.zig
@@ -80,6 +80,52 @@ pub fn authJsonWithEmailPlan(allocator: std.mem.Allocator, email: []const u8, pl
     );
 }
 
+pub fn cpaJsonWithEmailPlan(allocator: std.mem.Allocator, email: []const u8, plan: []const u8) ![]u8 {
+    const chatgpt_account_id = try chatgptAccountIdForEmailAlloc(allocator, email);
+    defer allocator.free(chatgpt_account_id);
+    const chatgpt_user_id = try chatgptUserIdForEmailAlloc(allocator, email);
+    defer allocator.free(chatgpt_user_id);
+    const access_token = try std.fmt.allocPrint(allocator, "access-{s}", .{email});
+    defer allocator.free(access_token);
+    const refresh_token = try std.fmt.allocPrint(allocator, "refresh-{s}", .{email});
+    defer allocator.free(refresh_token);
+    const payload = try std.fmt.allocPrint(
+        allocator,
+        "{{\"email\":\"{s}\",\"https://api.openai.com/auth\":{{\"chatgpt_account_id\":\"{s}\",\"chatgpt_user_id\":\"{s}\",\"user_id\":\"{s}\",\"chatgpt_plan_type\":\"{s}\"}}}}",
+        .{ email, chatgpt_account_id, chatgpt_user_id, chatgpt_user_id, plan },
+    );
+    defer allocator.free(payload);
+    const auth = try authJsonFromPayload(allocator, payload);
+    defer allocator.free(auth);
+    return try std.fmt.allocPrint(
+        allocator,
+        "{{\"email\":\"{s}\",\"id_token\":\"{s}\",\"access_token\":\"{s}\",\"refresh_token\":\"{s}\",\"account_id\":\"{s}\",\"last_refresh\":\"2026-03-20T00:00:00Z\"}}",
+        .{ email, extractToken(auth), access_token, refresh_token, chatgpt_account_id },
+    );
+}
+
+pub fn cpaJsonWithoutRefreshToken(allocator: std.mem.Allocator, email: []const u8, plan: []const u8) ![]u8 {
+    const chatgpt_account_id = try chatgptAccountIdForEmailAlloc(allocator, email);
+    defer allocator.free(chatgpt_account_id);
+    const chatgpt_user_id = try chatgptUserIdForEmailAlloc(allocator, email);
+    defer allocator.free(chatgpt_user_id);
+    const access_token = try std.fmt.allocPrint(allocator, "access-{s}", .{email});
+    defer allocator.free(access_token);
+    const payload = try std.fmt.allocPrint(
+        allocator,
+        "{{\"email\":\"{s}\",\"https://api.openai.com/auth\":{{\"chatgpt_account_id\":\"{s}\",\"chatgpt_user_id\":\"{s}\",\"user_id\":\"{s}\",\"chatgpt_plan_type\":\"{s}\"}}}}",
+        .{ email, chatgpt_account_id, chatgpt_user_id, chatgpt_user_id, plan },
+    );
+    defer allocator.free(payload);
+    const auth = try authJsonFromPayload(allocator, payload);
+    defer allocator.free(auth);
+    return try std.fmt.allocPrint(
+        allocator,
+        "{{\"email\":\"{s}\",\"id_token\":\"{s}\",\"access_token\":\"{s}\",\"account_id\":\"{s}\",\"last_refresh\":\"2026-03-20T00:00:00Z\"}}",
+        .{ email, extractToken(auth), access_token, chatgpt_account_id },
+    );
+}
+
 pub fn authJsonWithoutEmail(allocator: std.mem.Allocator) ![]u8 {
     const account_id = "67000000-0000-4000-8000-000000000001";
     const payload =

--- a/src/tests/cli_bdd_test.zig
+++ b/src/tests/cli_bdd_test.zig
@@ -57,6 +57,32 @@ test "Scenario: Given import purge without path when parsing then purge mode is 
     }
 }
 
+test "Scenario: Given import cpa without path when parsing then cpa mode is preserved" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "import", "--cpa" };
+    var cmd = try cli.parseArgs(gpa, &args);
+    defer cli.freeCommand(gpa, &cmd);
+
+    switch (cmd) {
+        .import_auth => |opts| {
+            try std.testing.expect(opts.auth_path == null);
+            try std.testing.expect(opts.alias == null);
+            try std.testing.expect(!opts.purge);
+            try std.testing.expect(opts.source == .cpa);
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "Scenario: Given import cpa with purge when parsing then help command is returned" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "import", "--cpa", "--purge" };
+    var cmd = try cli.parseArgs(gpa, &args);
+    defer cli.freeCommand(gpa, &cmd);
+
+    try std.testing.expect(isHelp(cmd));
+}
+
 test "Scenario: Given import unknown short purge flag when parsing then help command is returned" {
     const gpa = std.testing.allocator;
     const args = [_][:0]const u8{ "codex-auth", "import", "-P", "/tmp/auth.json" };
@@ -127,6 +153,7 @@ test "Scenario: Given help when rendering then login and compatibility notes are
     const help = aw.written();
     try std.testing.expect(std.mem.indexOf(u8, help, "Auto Switch: ON (5h<12%, weekly<8%)") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "Usage API: ON (api-only)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "--cpa [<path>]") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "Warning: Usage refresh is currently using the ChatGPT usage API") == null);
     try std.testing.expect(std.mem.indexOf(u8, help, "`codex-auth config api disable`") == null);
     try std.testing.expect(std.mem.indexOf(u8, help, "login") != null);

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -476,6 +476,94 @@ test "Scenario: Given directory import with a broken symlink when running import
     try std.testing.expect(std.mem.eql(u8, loaded.accounts.items[0].email, "symlink-survivor@example.com"));
 }
 
+test "Scenario: Given cpa directory in default location when running import cpa then it imports from ~/.cli-proxy-api" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+    try tmp.dir.makePath(".cli-proxy-api");
+
+    const first = try bdd.cpaJsonWithEmailPlan(gpa, "default-cpa@example.com", "plus");
+    defer gpa.free(first);
+    const second = try bdd.cpaJsonWithEmailPlan(gpa, "second-cpa@example.com", "team");
+    defer gpa.free(second);
+    const missing_refresh = try bdd.cpaJsonWithoutRefreshToken(gpa, "skip-cpa@example.com", "pro");
+    defer gpa.free(missing_refresh);
+    try tmp.dir.writeFile(.{ .sub_path = ".cli-proxy-api/first.json", .data = first });
+    try tmp.dir.writeFile(.{ .sub_path = ".cli-proxy-api/second.json", .data = second });
+    try tmp.dir.writeFile(.{ .sub_path = ".cli-proxy-api/no-refresh.json", .data = missing_refresh });
+
+    const result = try runCliWithIsolatedHome(gpa, project_root, home_root, &[_][]const u8{ "import", "--cpa" });
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectSuccess(result);
+    try std.testing.expectEqualStrings(
+        "Scanning ~/.cli-proxy-api...\n" ++
+            "  ✓ imported  first\n" ++
+            "  ✓ imported  second\n" ++
+            "Import Summary: 2 imported, 0 updated, 1 skipped (total 3 files)\n",
+        result.stdout,
+    );
+    try std.testing.expectEqualStrings("  ✗ skipped   no-refresh: MissingRefreshToken\n", result.stderr);
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expectEqual(@as(usize, 2), loaded.accounts.items.len);
+}
+
+test "Scenario: Given cpa file import when running import cpa then it stores a standard auth snapshot" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+    try tmp.dir.makePath("imports");
+
+    const cpa_json = try bdd.cpaJsonWithEmailPlan(gpa, "single-file-cpa@example.com", "business");
+    defer gpa.free(cpa_json);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/cpa.json", .data = cpa_json });
+
+    const import_path = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "imports", "cpa.json" });
+    defer gpa.free(import_path);
+
+    const result = try runCliWithIsolatedHome(gpa, project_root, home_root, &[_][]const u8{ "import", "--cpa", import_path, "--alias", "personal" });
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectSuccess(result);
+    try std.testing.expectEqualStrings("  ✓ imported  cpa\n", result.stdout);
+    try std.testing.expectEqualStrings("", result.stderr);
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+    const account_key = try bdd.accountKeyForEmailAlloc(gpa, "single-file-cpa@example.com");
+    defer gpa.free(account_key);
+    const snapshot_path = try registry.accountAuthPath(gpa, codex_home, account_key);
+    defer gpa.free(snapshot_path);
+    const snapshot_data = try bdd.readFileAlloc(gpa, snapshot_path);
+    defer gpa.free(snapshot_data);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot_data, "\"tokens\": {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot_data, "\"refresh_token\": \"refresh-single-file-cpa@example.com\"") != null);
+
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expect(std.mem.eql(u8, loaded.accounts.items[0].alias, "personal"));
+}
+
 test "Scenario: Given default api usage when rendering help then warning stays on stderr" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -520,6 +520,25 @@ test "Scenario: Given cpa directory in default location when running import cpa 
     try std.testing.expectEqual(@as(usize, 2), loaded.accounts.items.len);
 }
 
+test "Scenario: Given missing default cpa directory when running import cpa then it fails" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+
+    const result = try runCliWithIsolatedHome(gpa, project_root, home_root, &[_][]const u8{ "import", "--cpa" });
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectFailure(result);
+}
+
 test "Scenario: Given cpa file import when running import cpa then it stores a standard auth snapshot" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);

--- a/src/tests/registry_test.zig
+++ b/src/tests/registry_test.zig
@@ -840,6 +840,38 @@ test "import cpa path with single file converts to standard auth and keeps expli
     try std.testing.expect(std.mem.indexOf(u8, snapshot_data, "\"refresh_token\": \"refresh-single-cpa@example.com\"") != null);
 }
 
+test "import cpa path with repeated single file reports updated on second import" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+
+    const cpa_json = try bdd.cpaJsonWithEmailPlan(gpa, "repeat-cpa@example.com", "pro");
+    defer gpa.free(cpa_json);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/repeat.json", .data = cpa_json });
+
+    const import_path = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "imports", "repeat.json" });
+    defer gpa.free(import_path);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+
+    var first = try registry.importCpaPath(gpa, codex_home, &reg, import_path, null);
+    defer first.deinit(gpa);
+    try std.testing.expect(first.imported == 1);
+    try std.testing.expect(first.updated == 0);
+    try std.testing.expect(first.events.items[0].outcome == .imported);
+
+    var second = try registry.importCpaPath(gpa, codex_home, &reg, import_path, null);
+    defer second.deinit(gpa);
+    try std.testing.expect(second.imported == 0);
+    try std.testing.expect(second.updated == 1);
+    try std.testing.expect(second.events.items[0].outcome == .updated);
+}
+
 test "import cpa path with directory imports multiple json files and skips bad files" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/tests/registry_test.zig
+++ b/src/tests/registry_test.zig
@@ -803,3 +803,76 @@ test "import auth path with invalid single file keeps failure for non-zero exit 
     try std.testing.expect(report.events.items[0].outcome == .skipped);
     try std.testing.expectEqualStrings("MissingEmail", report.events.items[0].reason.?);
 }
+
+test "import cpa path with single file converts to standard auth and keeps explicit alias" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+
+    const cpa_json = try bdd.cpaJsonWithEmailPlan(gpa, "single-cpa@example.com", "plus");
+    defer gpa.free(cpa_json);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/one.json", .data = cpa_json });
+
+    const one_path = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "imports", "one.json" });
+    defer gpa.free(one_path);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+
+    var report = try registry.importCpaPath(gpa, codex_home, &reg, one_path, "personal");
+    defer report.deinit(gpa);
+    try std.testing.expect(report.render_kind == .single_file);
+    try std.testing.expect(report.imported == 1);
+    try std.testing.expectEqual(@as(usize, 1), reg.accounts.items.len);
+    try std.testing.expect(std.mem.eql(u8, reg.accounts.items[0].alias, "personal"));
+
+    const account_key = try bdd.accountKeyForEmailAlloc(gpa, "single-cpa@example.com");
+    defer gpa.free(account_key);
+    const snapshot_path = try registry.accountAuthPath(gpa, codex_home, account_key);
+    defer gpa.free(snapshot_path);
+    const snapshot_data = try bdd.readFileAlloc(gpa, snapshot_path);
+    defer gpa.free(snapshot_data);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot_data, "\"tokens\": {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot_data, "\"refresh_token\": \"refresh-single-cpa@example.com\"") != null);
+}
+
+test "import cpa path with directory imports multiple json files and skips bad files" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+
+    const a = try bdd.cpaJsonWithEmailPlan(gpa, "a-cpa@example.com", "pro");
+    defer gpa.free(a);
+    const b = try bdd.cpaJsonWithEmailPlan(gpa, "b-cpa@example.com", "team");
+    defer gpa.free(b);
+    const no_refresh = try bdd.cpaJsonWithoutRefreshToken(gpa, "no-refresh@example.com", "plus");
+    defer gpa.free(no_refresh);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/a.json", .data = a });
+    try tmp.dir.writeFile(.{ .sub_path = "imports/b.json", .data = b });
+    try tmp.dir.writeFile(.{ .sub_path = "imports/no-refresh.json", .data = no_refresh });
+    try tmp.dir.writeFile(.{ .sub_path = "imports/bad.json", .data = "{not-json}" });
+    try tmp.dir.writeFile(.{ .sub_path = "imports/readme.txt", .data = "ignored" });
+
+    const imports_dir = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "imports" });
+    defer gpa.free(imports_dir);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+
+    var report = try registry.importCpaPath(gpa, codex_home, &reg, imports_dir, null);
+    defer report.deinit(gpa);
+    try std.testing.expect(report.render_kind == .scanned);
+    try std.testing.expect(report.imported == 2);
+    try std.testing.expect(report.updated == 0);
+    try std.testing.expect(report.skipped == 2);
+    try std.testing.expect(report.total_files == 4);
+    try std.testing.expectEqual(@as(usize, 2), reg.accounts.items.len);
+}


### PR DESCRIPTION
## Summary
- add the execution plan and temporary AGENTS execution lock for CPA(https://github.com/router-for-me/CLIProxyAPI) auth import
- implement `import --cpa [<path>]` with docs and tests in follow-up commits
- drive this branch through the full review and CI loop until green

## Plan
- plan file: `plans/2026-03-20-import-cpa-auth.md`
- `AGENTS.md` is temporarily locked to that plan until the task is complete

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `import --cpa` command to import CPA flat token JSON into the auth registry
> - Adds a new `--cpa [<path>]` flag to the `import` CLI command that accepts a file, directory, or defaults to `~/.cli-proxy-api` when no path is given.
> - Converts CPA flat token JSON in-memory to the standard auth snapshot format via `auth.convertCpaAuthJson`, requiring a non-empty `refresh_token` (skipped with `MissingRefreshToken` otherwise).
> - `registry.importCpaPath` dispatches to single-file or directory import, accumulating an `ImportReport` consistent with existing import semantics; `--alias` is ignored and warned on directory imports.
> - `--cpa` cannot be combined with `--purge`; omitting `<path>` is only permitted in `--cpa` mode.
> - Risk: the default directory `~/.cli-proxy-api` must exist for directory-mode imports; a missing directory is treated as a fatal error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c2bbab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->