### PR TITLE
fix: activate first account after purge

### DIFF
--- a/docs/implement.md
+++ b/docs/implement.md
@@ -98,6 +98,7 @@ This document describes how `codex-auth` stores accounts, synchronizes auth file
 - When `--purge` is used without a path, the source defaults to `~/.codex/accounts/` and scans direct child auth files from that directory: current account snapshots (`*.auth.json`) plus `auth.json.bak.*` backups.
 - If `~/.codex/accounts/` is missing during `--purge`, it is treated as an empty snapshot set and the command still attempts to import the current `~/.codex/auth.json`.
 - `--purge` always tries to import the current `~/.codex/auth.json` last; if it is parseable, that account's `record_key` becomes `active_account_key`.
+- If `--purge` rebuilds accounts successfully but still has no active account afterward, it activates the first rebuilt account in sorted order and rewrites `~/.codex/auth.json` through the normal switch path, preserving the previous file as `auth.json.bak.*` when the contents changed.
 - When multiple scanned auth files map to the same `record_key`, `--purge` keeps only the newest snapshot for that account before rebuilding `registry.json`.
 - `--purge` rebuilds `registry.json` and rewrites imported snapshots into the current `accounts/<account file key>.auth.json` naming/layout for each auth file it can parse successfully.
 - Rebuilt `registry.json` account entries are ordered by normalized `email`, then `account_key`.

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -754,6 +754,9 @@ pub fn purgeRegistryFromImportSource(
     }
 
     sortAccountsByEmail(&reg);
+    if (reg.active_account_key == null and reg.accounts.items.len > 0) {
+        try activateAccountByKey(allocator, codex_home, &reg, reg.accounts.items[0].account_key);
+    }
     try saveRegistry(allocator, codex_home, &reg);
     return report;
 }

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -421,6 +421,85 @@ test "Scenario: Given single-file import missing email when running import then 
     try std.testing.expect(std.mem.indexOf(u8, result.stderr, "  ✗ skipped   token_bob.wilson.alpha@email.com: MissingEmail\n") != null);
 }
 
+test "Scenario: Given purge with no recoverable active auth when running import then it activates the first rebuilt account and backs up auth json" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+    try tmp.dir.makePath(".codex/accounts");
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+
+    const zed_auth = try bdd.authJsonWithEmailPlan(gpa, "zed@example.com", "team");
+    defer gpa.free(zed_auth);
+    const zed_key = try bdd.accountKeyForEmailAlloc(gpa, "zed@example.com");
+    defer gpa.free(zed_key);
+    const zed_snapshot_path = try registry.accountAuthPath(gpa, codex_home, zed_key);
+    defer gpa.free(zed_snapshot_path);
+    try std.fs.cwd().writeFile(.{ .sub_path = zed_snapshot_path, .data = zed_auth });
+
+    const alpha_auth = try bdd.authJsonWithEmailPlan(gpa, "alpha@example.com", "plus");
+    defer gpa.free(alpha_auth);
+    const alpha_key = try bdd.accountKeyForEmailAlloc(gpa, "alpha@example.com");
+    defer gpa.free(alpha_key);
+    const alpha_snapshot_path = try registry.accountAuthPath(gpa, codex_home, alpha_key);
+    defer gpa.free(alpha_snapshot_path);
+    try std.fs.cwd().writeFile(.{ .sub_path = alpha_snapshot_path, .data = alpha_auth });
+
+    const stale_auth = "{\"broken\":true}";
+    try tmp.dir.writeFile(.{ .sub_path = ".codex/auth.json", .data = stale_auth });
+
+    const result = try runCliWithIsolatedHome(gpa, project_root, home_root, &[_][]const u8{ "import", "--purge" });
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectSuccess(result);
+    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "Import Summary: 2 imported, 0 updated, 0 skipped (total 2 files)\n") != null);
+    try std.testing.expectEqualStrings("", result.stderr);
+
+    const active_auth_path = try authJsonPathAlloc(gpa, home_root);
+    defer gpa.free(active_auth_path);
+    const active_auth = try bdd.readFileAlloc(gpa, active_auth_path);
+    defer gpa.free(active_auth);
+    try std.testing.expectEqualStrings(alpha_auth, active_auth);
+
+    try std.testing.expectEqual(@as(usize, 1), try countAuthBackups(tmp.dir, ".codex/accounts"));
+
+    var backup_name: ?[]u8 = null;
+    defer if (backup_name) |name| gpa.free(name);
+
+    var accounts = try tmp.dir.openDir(".codex/accounts", .{ .iterate = true });
+    defer accounts.close();
+    var it = accounts.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.startsWith(u8, entry.name, "auth.json.bak.")) continue;
+        backup_name = try gpa.dupe(u8, entry.name);
+        break;
+    }
+    try std.testing.expect(backup_name != null);
+
+    const backup_rel = try std.fs.path.join(gpa, &[_][]const u8{ ".codex", "accounts", backup_name.? });
+    defer gpa.free(backup_rel);
+    var backup_file = try tmp.dir.openFile(backup_rel, .{});
+    defer backup_file.close();
+    const backup_contents = try backup_file.readToEndAlloc(gpa, 10 * 1024 * 1024);
+    defer gpa.free(backup_contents);
+    try std.testing.expectEqualStrings(stale_auth, backup_contents);
+
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expect(loaded.active_account_key != null);
+    try std.testing.expect(std.mem.eql(u8, loaded.active_account_key.?, alpha_key));
+}
+
 test "Scenario: Given directory import with new updated and invalid files when running import then stdout and stderr split the report" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);

--- a/src/tests/purge_test.zig
+++ b/src/tests/purge_test.zig
@@ -495,6 +495,86 @@ test "Scenario: Given purge without path and only auth backups when rebuilding t
     snapshot.close();
 }
 
+test "Scenario: Given purge without a recoverable active auth when rebuilding then it activates the first sorted account and backs up the previous auth" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("accounts");
+
+    const zed_auth = try authJsonWithEmailPlan(gpa, "zed@example.com", "team");
+    defer gpa.free(zed_auth);
+    const zed_record_key = try accountKeyForEmailAlloc(gpa, "zed@example.com");
+    defer gpa.free(zed_record_key);
+    const zed_snapshot_path = try registry.accountAuthPath(gpa, codex_home, zed_record_key);
+    defer gpa.free(zed_snapshot_path);
+    const zed_snapshot_rel = try std.fs.path.relative(gpa, codex_home, zed_snapshot_path);
+    defer gpa.free(zed_snapshot_rel);
+    try tmp.dir.writeFile(.{ .sub_path = zed_snapshot_rel, .data = zed_auth });
+
+    const alpha_auth = try authJsonWithEmailPlan(gpa, "alpha@example.com", "plus");
+    defer gpa.free(alpha_auth);
+    const alpha_record_key = try accountKeyForEmailAlloc(gpa, "alpha@example.com");
+    defer gpa.free(alpha_record_key);
+    const alpha_snapshot_path = try registry.accountAuthPath(gpa, codex_home, alpha_record_key);
+    defer gpa.free(alpha_snapshot_path);
+    const alpha_snapshot_rel = try std.fs.path.relative(gpa, codex_home, alpha_snapshot_path);
+    defer gpa.free(alpha_snapshot_rel);
+    try tmp.dir.writeFile(.{ .sub_path = alpha_snapshot_rel, .data = alpha_auth });
+
+    const stale_auth = "{\"broken\":true}";
+    try tmp.dir.writeFile(.{ .sub_path = "auth.json", .data = stale_auth });
+
+    var report = try registry.purgeRegistryFromImportSource(gpa, codex_home, null, null);
+    defer report.deinit(gpa);
+
+    try std.testing.expectEqual(@as(usize, 2), report.imported);
+    try std.testing.expectEqual(@as(usize, 0), report.updated);
+    try std.testing.expectEqual(@as(usize, 0), report.skipped);
+
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expectEqual(@as(usize, 2), loaded.accounts.items.len);
+    try std.testing.expect(loaded.active_account_key != null);
+    try std.testing.expect(std.mem.eql(u8, loaded.active_account_key.?, alpha_record_key));
+
+    const active_auth_path = try registry.activeAuthPath(gpa, codex_home);
+    defer gpa.free(active_auth_path);
+    var active_file = try std.fs.cwd().openFile(active_auth_path, .{});
+    defer active_file.close();
+    const active_auth = try active_file.readToEndAlloc(gpa, 10 * 1024 * 1024);
+    defer gpa.free(active_auth);
+    try std.testing.expectEqualStrings(alpha_auth, active_auth);
+
+    var backup_name: ?[]u8 = null;
+    defer if (backup_name) |name| gpa.free(name);
+
+    var accounts = try tmp.dir.openDir("accounts", .{ .iterate = true });
+    defer accounts.close();
+    var it = accounts.iterate();
+    var backup_count: usize = 0;
+    while (try it.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.startsWith(u8, entry.name, "auth.json.bak.")) continue;
+        backup_count += 1;
+        if (backup_name == null) {
+            backup_name = try gpa.dupe(u8, entry.name);
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), backup_count);
+    try std.testing.expect(backup_name != null);
+
+    const backup_rel = try std.fs.path.join(gpa, &[_][]const u8{ "accounts", backup_name.? });
+    defer gpa.free(backup_rel);
+    var backup_file = try tmp.dir.openFile(backup_rel, .{});
+    defer backup_file.close();
+    const backup_contents = try backup_file.readToEndAlloc(gpa, 10 * 1024 * 1024);
+    defer gpa.free(backup_contents);
+    try std.testing.expectEqualStrings(stale_auth, backup_contents);
+}
+
 test "Scenario: Given purge without path and an empty snapshot when rebuilding then it reports malformed json and still imports valid backups" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
## Summary
- activate the first rebuilt account after purge when the current auth cannot be recovered
- reuse the normal activate path so auth.json backup behavior stays consistent
- add regression coverage and document the fallback activation behavior

## Testing
- zig build test
- zig build run -- list

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Activate first account after purge when no active account exists
> When `purgeRegistryFromImportSource` rebuilds accounts but none is marked active, it now calls `activateAccountByKey` on the first account in sorted order before saving the registry. This ensures a usable active account after purge instead of leaving the registry in an unauthenticated state. New unit and e2e tests cover the case where a stale `auth.json` is present and two accounts are rebuilt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b61706.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->