### PR TITLE
feat(ui): display workspace id fallback for team accounts

### DIFF
--- a/src/format.zig
+++ b/src/format.zig
@@ -19,9 +19,19 @@ fn colorEnabled() bool {
     return std.fs.File.stdout().isTty();
 }
 
-fn planDisplay(rec: *const registry.AccountRecord, missing: []const u8) []const u8 {
-    if (registry.resolvePlan(rec)) |p| return @tagName(p);
-    return missing;
+fn planDisplayAlloc(allocator: std.mem.Allocator, rec: *const registry.AccountRecord, missing: []const u8) ![]u8 {
+    if (registry.resolvePlan(rec)) |p| {
+        const tag = @tagName(p);
+        if (p == .team or p == .enterprise or p == .business) {
+            if (rec.chatgpt_account_id.len >= 8) {
+                return std.fmt.allocPrint(allocator, "{s} ({s})", .{ tag, rec.chatgpt_account_id[0..8] });
+            } else {
+                return std.fmt.allocPrint(allocator, "{s} ({s})", .{ tag, rec.chatgpt_account_id });
+            }
+        }
+        return allocator.dupe(u8, tag);
+    }
+    return allocator.dupe(u8, missing);
 }
 
 pub fn printAccounts(allocator: std.mem.Allocator, reg: *registry.Registry, fmt: cli.OutputFormat) !void {
@@ -58,7 +68,8 @@ fn printAccountsTable(reg: *registry.Registry) !void {
         widths[0] = @max(widths[0], row.account_cell.len + indent);
         if (row.account_index) |account_idx| {
             const rec = reg.accounts.items[account_idx];
-            const plan = planDisplay(&rec, "-");
+            const plan = try planDisplayAlloc(std.heap.page_allocator, &rec, "-");
+            defer std.heap.page_allocator.free(plan);
             const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
             const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
             const rate_5h_str = try formatRateLimitFullAlloc(rate_5h);
@@ -112,7 +123,8 @@ fn printAccountsTable(reg: *registry.Registry) !void {
     for (display.rows) |row| {
         if (row.account_index) |account_idx| {
             const rec = reg.accounts.items[account_idx];
-            const plan = planDisplay(&rec, "-");
+            const plan = try planDisplayAlloc(std.heap.page_allocator, &rec, "-");
+            defer std.heap.page_allocator.free(plan);
             const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
             const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
             const rate_5h_str = try formatRateLimitUiAlloc(rate_5h, widths[2]);
@@ -194,7 +206,8 @@ fn printAccountsCsv(reg: *registry.Registry) !void {
         const account_key = rec.account_key;
         const chatgpt_account_id = rec.chatgpt_account_id;
         const chatgpt_user_id = rec.chatgpt_user_id;
-        const plan = planDisplay(&rec, "");
+        const plan = try planDisplayAlloc(std.heap.page_allocator, &rec, "");
+        defer std.heap.page_allocator.free(plan);
         const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
         const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
         const rate_5h_str = try formatRateLimitStatusAlloc(rate_5h);
@@ -218,7 +231,8 @@ fn printAccountsCompact(reg: *registry.Registry) !void {
     for (reg.accounts.items) |rec| {
         const active = if (reg.active_account_key) |k| std.mem.eql(u8, k, rec.account_key) else false;
         const email = rec.email;
-        const plan = planDisplay(&rec, "-");
+        const plan = try planDisplayAlloc(std.heap.page_allocator, &rec, "-");
+        defer std.heap.page_allocator.free(plan);
         const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
         const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
         const rate_5h_str = try formatRateLimitStatusAlloc(rate_5h);

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -1577,7 +1577,7 @@ pub fn syncActiveAccountFromAuth(allocator: std.mem.Allocator, codex_home: []con
         changed = true;
     }
 
-    if (!std.mem.eql(u8, reg.accounts.items[idx].email, email)) {
+    if (reg.accounts.items[idx].email.len == 0 or !std.mem.eql(u8, reg.accounts.items[idx].email, email)) {
         const new_email = try allocator.dupe(u8, email);
         allocator.free(reg.accounts.items[idx].email);
         reg.accounts.items[idx].email = new_email;


### PR DESCRIPTION
When proxy tokens elide team_name or organization claims, this feature ensures that identical alias imports are prominently distinguishable by falling back to the 8-character ChatGPT Account (Workspace) UUID in the CLI listing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Display workspace ID fallback for team/enterprise/business accounts in account listings
> - Adds `planDisplayAlloc` in [format.zig](https://github.com/Loongphy/codex-auth/pull/29/files#diff-419d25c4d671f56fa42804e7b6a9c454cb738e6c3e38111c3955daaa48caa6eb) to replace the non-allocating `planDisplay`. For team, enterprise, or business plans, it appends the first 8 characters of `chatgpt_account_id` in parentheses to the plan tag.
> - Updates all three account renderers (table, CSV, compact) to use the new allocating function with corresponding `free` calls.
> - Fixes `syncActiveAccountFromAuth` in [registry.zig](https://github.com/Loongphy/codex-auth/pull/29/files#diff-8eb40bbdcf9cd7dcc83c47e58afc4ceebae09629a3c4c18389be387309d47f52) to update a stored email when it was previously empty.
> - Risk: all three renderers can now return allocation errors where they previously could not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 196ba57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->