### PR TITLE
feat: support CODEX_HOME override

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ npx @loongphy/codex-auth list
 > npm installs already satisfy that requirement.
 > Legacy standalone binary installs need Node.js 18+ on `PATH` when `codex-auth config api enable` is used.
 
+## Storage Root
+
+`codex-auth` uses the same Codex state root as the current process. Resolution order:
+
+1. `CODEX_HOME` when set to a non-empty path
+2. `HOME/.codex`
+3. `USERPROFILE/.codex` on Windows
+
+That means you can isolate auth, registry, config, and session files by running:
+
+```shell
+CODEX_HOME=/path/to/custom-codex codex-auth list
+```
+
 ### Uninstall
 
 #### npm

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ npx @loongphy/codex-auth list
 
 `codex-auth` uses the same Codex state root as the current process. Resolution order:
 
-1. `CODEX_HOME` when set to a non-empty path
+1. `CODEX_HOME` when set to a non-empty existing directory
 2. `HOME/.codex`
 3. `USERPROFILE/.codex` on Windows
 
+When `CODEX_HOME` is set, `codex-auth` follows Codex and requires that directory to already exist.
 That means you can isolate auth, registry, config, and session files by running:
 
 ```shell

--- a/docs/auto-switch.md
+++ b/docs/auto-switch.md
@@ -101,7 +101,7 @@ Platform bootstrap:
 - macOS: `LaunchAgent` with `KeepAlive`
 - Windows: user scheduled task with an `ONLOGON` trigger, restart-on-failure settings, and an unlimited execution time for `codex-auth-auto.exe`, plus an immediate `schtasks /Run` during enablement
 
-Service install paths resolve from the current `codex_home` root. When `CODEX_HOME` is set, the watcher/service files are installed under that override; otherwise the default remains `HOME/.codex` (or `USERPROFILE/.codex` on Windows).
+Service definition files stay in the platform-standard per-user locations. The managed watcher process uses the current `codex_home` root, so when `CODEX_HOME` is set during enablement the watcher keeps reading and writing that override after it starts in the background.
 Foreground commands other than `help`, `version`, `status`, and `daemon` still reconcile the managed service definition after they complete.
 `config auto enable` also prints a short usage-mode note so the user can see whether switching is currently running with default API-backed usage data or local-only fallback semantics.
 When migrating from older Linux/WSL timer-based installs, enable/reconcile also removes the legacy `codex-auth-autoswitch.timer` unit file instead of leaving the old minute timer behind.

--- a/docs/auto-switch.md
+++ b/docs/auto-switch.md
@@ -101,7 +101,7 @@ Platform bootstrap:
 - macOS: `LaunchAgent` with `KeepAlive`
 - Windows: user scheduled task with an `ONLOGON` trigger, restart-on-failure settings, and an unlimited execution time for `codex-auth-auto.exe`, plus an immediate `schtasks /Run` during enablement
 
-Service install paths still resolve from the real user home directory.
+Service install paths resolve from the current `codex_home` root. When `CODEX_HOME` is set, the watcher/service files are installed under that override; otherwise the default remains `HOME/.codex` (or `USERPROFILE/.codex` on Windows).
 Foreground commands other than `help`, `version`, `status`, and `daemon` still reconcile the managed service definition after they complete.
 `config auto enable` also prints a short usage-mode note so the user can see whether switching is currently running with default API-backed usage data or local-only fallback semantics.
 When migrating from older Linux/WSL timer-based installs, enable/reconcile also removes the legacy `codex-auth-autoswitch.timer` unit file instead of leaving the old minute timer behind.

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -10,17 +10,18 @@ This document describes how `codex-auth` stores accounts, synchronizes auth file
 
 ## File Layout
 
-- `~/.codex/auth.json`
-- `~/.codex/accounts/registry.json`
-- `~/.codex/accounts/<account file key>.auth.json`
-- `~/.codex/accounts/auth.json.bak.YYYYMMDD-hhmmss[.N]`
-- `~/.codex/accounts/registry.json.bak.YYYYMMDD-hhmmss[.N]`
-- `~/.codex/sessions/...`
+- `<codex_home>/auth.json`
+- `<codex_home>/accounts/registry.json`
+- `<codex_home>/accounts/<account file key>.auth.json`
+- `<codex_home>/accounts/auth.json.bak.YYYYMMDD-hhmmss[.N]`
+- `<codex_home>/accounts/registry.json.bak.YYYYMMDD-hhmmss[.N]`
+- `<codex_home>/sessions/...`
 
-`codex-auth` resolves `codex_home` from the real user home directory:
+`codex-auth` resolves `codex_home` in this order:
 
-1. `HOME/.codex`
-2. `USERPROFILE/.codex` (Windows fallback)
+1. `CODEX_HOME` when it is set to a non-empty path
+2. `HOME/.codex`
+3. `USERPROFILE/.codex` (Windows fallback)
 
 ## Testing Conventions (BDD Style on std.testing)
 
@@ -216,7 +217,7 @@ The detailed runtime, thresholds, service model, and data-source priority rules 
 This document keeps only the cross-reference points that matter to the rest of the implementation:
 
 - background config still lives in `registry.json` under top-level `auto_switch` and `api` blocks
-- managed services still resolve install paths from the real user home directory
+- managed services resolve from the same `codex_home` root as the active CLI process
 - successful foreground `codex-auth` commands except `help`, `version`, `status`, and `daemon` still reconcile the managed service definition
 - Linux/WSL `config auto enable` still requires a working `systemd --user` session
 

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -19,7 +19,7 @@ This document describes how `codex-auth` stores accounts, synchronizes auth file
 
 `codex-auth` resolves `codex_home` in this order:
 
-1. `CODEX_HOME` when it is set to a non-empty path
+1. `CODEX_HOME` when it is set to a non-empty existing directory
 2. `HOME/.codex`
 3. `USERPROFILE/.codex` (Windows fallback)
 

--- a/docs/test.md
+++ b/docs/test.md
@@ -227,4 +227,4 @@ Get-ScheduledTask -TaskName 'CodexAuthAutoSwitch' -ErrorAction SilentlyContinue
 
 Expected result after disable: no task is returned.
 
-For isolated HOME tests, use `daemon --once` to validate actual switching behavior. The Windows managed service artifacts are installed under the real Windows user profile, so `enable/disable/status` and `daemon --once` together provide the cleanest acceptance signal even though the managed task itself now starts the persistent watcher mode.
+For isolated HOME tests, use `daemon --once` to validate actual switching behavior. The Windows task definition still lives in the real Windows user profile, while the managed watcher itself uses the `codex_home` that was active during enablement. `enable/disable/status` and `daemon --once` together still provide the cleanest acceptance signal.

--- a/src/auto.zig
+++ b/src/auto.zig
@@ -38,6 +38,7 @@ pub const Status = struct {
 };
 
 const service_version_env_name = "CODEX_AUTH_VERSION";
+const codex_home_env_name = "CODEX_HOME";
 
 pub const AutoSwitchAttempt = struct {
     refreshed_candidates: bool,
@@ -2036,12 +2037,11 @@ pub fn deleteAbsoluteFileIfExists(path: []const u8) void {
 }
 
 fn installWindowsService(allocator: std.mem.Allocator, codex_home: []const u8, self_exe: []const u8) !void {
-    _ = codex_home;
     const helper_path = try windowsHelperPath(allocator, self_exe);
     defer allocator.free(helper_path);
     try std.fs.cwd().access(helper_path, .{});
 
-    const register_script = try windowsRegisterTaskScript(allocator, helper_path);
+    const register_script = try windowsRegisterTaskScript(allocator, helper_path, codex_home);
     defer allocator.free(register_script);
     const end_script = try windowsEndTaskScript(allocator);
     defer allocator.free(end_script);
@@ -2125,52 +2125,60 @@ fn queryWindowsRuntimeState(allocator: std.mem.Allocator) RuntimeState {
 }
 
 pub fn linuxUnitText(allocator: std.mem.Allocator, self_exe: []const u8, codex_home: []const u8) ![]u8 {
-    _ = codex_home;
     const exec = try std.fmt.allocPrint(allocator, "\"{s}\" daemon --watch", .{self_exe});
     defer allocator.free(exec);
     const escaped_version = try escapeSystemdValue(allocator, version.app_version);
     defer allocator.free(escaped_version);
+    const escaped_codex_home = try escapeSystemdValue(allocator, codex_home);
+    defer allocator.free(escaped_codex_home);
     return try std.fmt.allocPrint(
         allocator,
-        "[Unit]\nDescription=codex-auth auto-switch watcher\n\n[Service]\nType=simple\nRestart=always\nRestartSec=1\nEnvironment=\"{s}={s}\"\nExecStart={s}\n\n[Install]\nWantedBy=default.target\n",
+        "[Unit]\nDescription=codex-auth auto-switch watcher\n\n[Service]\nType=simple\nRestart=always\nRestartSec=1\nEnvironment=\"{s}={s}\"\nEnvironment=\"{s}={s}\"\nExecStart={s}\n\n[Install]\nWantedBy=default.target\n",
         .{
             service_version_env_name,
             escaped_version,
+            codex_home_env_name,
+            escaped_codex_home,
             exec,
         },
     );
 }
 
 pub fn macPlistText(allocator: std.mem.Allocator, self_exe: []const u8, codex_home: []const u8) ![]u8 {
-    _ = codex_home;
     const exe = try escapeXml(allocator, self_exe);
     defer allocator.free(exe);
     const current_version = try escapeXml(allocator, version.app_version);
     defer allocator.free(current_version);
+    const escaped_codex_home = try escapeXml(allocator, codex_home);
+    defer allocator.free(escaped_codex_home);
     return try std.fmt.allocPrint(
         allocator,
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n  <key>Label</key>\n  <string>{s}</string>\n  <key>ProgramArguments</key>\n  <array>\n    <string>{s}</string>\n    <string>daemon</string>\n    <string>--watch</string>\n  </array>\n  <key>EnvironmentVariables</key>\n  <dict>\n    <key>{s}</key>\n    <string>{s}</string>\n  </dict>\n  <key>RunAtLoad</key>\n  <true/>\n  <key>KeepAlive</key>\n  <true/>\n</dict>\n</plist>\n",
-        .{ mac_label, exe, service_version_env_name, current_version },
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n  <key>Label</key>\n  <string>{s}</string>\n  <key>ProgramArguments</key>\n  <array>\n    <string>{s}</string>\n    <string>daemon</string>\n    <string>--watch</string>\n  </array>\n  <key>EnvironmentVariables</key>\n  <dict>\n    <key>{s}</key>\n    <string>{s}</string>\n    <key>{s}</key>\n    <string>{s}</string>\n  </dict>\n  <key>RunAtLoad</key>\n  <true/>\n  <key>KeepAlive</key>\n  <true/>\n</dict>\n</plist>\n",
+        .{ mac_label, exe, service_version_env_name, current_version, codex_home_env_name, escaped_codex_home },
     );
 }
 
-pub fn windowsTaskAction(allocator: std.mem.Allocator, helper_path: []const u8) ![]u8 {
+pub fn windowsTaskAction(allocator: std.mem.Allocator, helper_path: []const u8, codex_home: []const u8) ![]u8 {
+    const args = try windowsTaskArguments(allocator, codex_home);
+    defer allocator.free(args);
     return try std.fmt.allocPrint(
         allocator,
-        "\"{s}\" --service-version {s}",
-        .{ helper_path, version.app_version },
+        "\"{s}\" {s}",
+        .{ helper_path, args },
     );
 }
 
-pub fn windowsRegisterTaskScript(allocator: std.mem.Allocator, helper_path: []const u8) ![]u8 {
+pub fn windowsRegisterTaskScript(allocator: std.mem.Allocator, helper_path: []const u8, codex_home: []const u8) ![]u8 {
     const escaped_helper_path = try escapePowerShellSingleQuoted(allocator, helper_path);
     defer allocator.free(escaped_helper_path);
-    const escaped_version = try escapePowerShellSingleQuoted(allocator, version.app_version);
-    defer allocator.free(escaped_version);
+    const args = try windowsTaskArguments(allocator, codex_home);
+    defer allocator.free(args);
+    const escaped_args = try escapePowerShellSingleQuoted(allocator, args);
+    defer allocator.free(escaped_args);
     return try std.fmt.allocPrint(
         allocator,
-        "$action = New-ScheduledTaskAction -Execute '{s}' -Argument '--service-version {s}'; $trigger = New-ScheduledTaskTrigger -AtLogOn; $settings = New-ScheduledTaskSettingsSet -RestartCount {s} -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Seconds 0); Register-ScheduledTask -TaskName '{s}' -Action $action -Trigger $trigger -Settings $settings -Force | Out-Null",
-        .{ escaped_helper_path, escaped_version, windows_task_restart_count, windows_task_name },
+        "$action = New-ScheduledTaskAction -Execute '{s}' -Argument '{s}'; $trigger = New-ScheduledTaskTrigger -AtLogOn; $settings = New-ScheduledTaskSettingsSet -RestartCount {s} -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Seconds 0); Register-ScheduledTask -TaskName '{s}' -Action $action -Trigger $trigger -Settings $settings -Force | Out-Null",
+        .{ escaped_helper_path, escaped_args, windows_task_restart_count, windows_task_name },
     );
 }
 
@@ -2309,10 +2317,9 @@ fn macPlistMatches(allocator: std.mem.Allocator, codex_home: []const u8, self_ex
 }
 
 fn windowsTaskMatches(allocator: std.mem.Allocator, codex_home: []const u8, self_exe: []const u8) !bool {
-    _ = codex_home;
     const helper_path = try windowsHelperPath(allocator, self_exe);
     defer allocator.free(helper_path);
-    const expected_action = try windowsExpectedTaskFingerprint(allocator, helper_path);
+    const expected_action = try windowsExpectedTaskFingerprint(allocator, helper_path, codex_home);
     defer allocator.free(expected_action);
     const expected_fingerprint = try windowsExpectedTaskDefinitionFingerprint(allocator, expected_action);
     defer allocator.free(expected_fingerprint);
@@ -2335,12 +2342,10 @@ fn windowsTaskMatches(allocator: std.mem.Allocator, codex_home: []const u8, self
     };
 }
 
-fn windowsExpectedTaskFingerprint(allocator: std.mem.Allocator, helper_path: []const u8) ![]u8 {
-    return try std.fmt.allocPrint(
-        allocator,
-        "{s} --service-version {s}",
-        .{ helper_path, version.app_version },
-    );
+fn windowsExpectedTaskFingerprint(allocator: std.mem.Allocator, helper_path: []const u8, codex_home: []const u8) ![]u8 {
+    const args = try windowsTaskArguments(allocator, codex_home);
+    defer allocator.free(args);
+    return try std.fmt.allocPrint(allocator, "{s} {s}", .{ helper_path, args });
 }
 
 fn windowsExpectedTaskDefinitionFingerprint(allocator: std.mem.Allocator, action: []const u8) ![]u8 {
@@ -2441,6 +2446,51 @@ fn escapeSystemdValue(allocator: std.mem.Allocator, raw: []const u8) ![]u8 {
 
 fn escapePowerShellSingleQuoted(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
     return std.mem.replaceOwned(u8, allocator, input, "'", "''");
+}
+
+fn windowsTaskArguments(allocator: std.mem.Allocator, codex_home: []const u8) ![]u8 {
+    const quoted_codex_home = try quoteWindowsCommandArg(allocator, codex_home);
+    defer allocator.free(quoted_codex_home);
+    return try std.fmt.allocPrint(
+        allocator,
+        "--service-version {s} --codex-home {s}",
+        .{ version.app_version, quoted_codex_home },
+    );
+}
+
+fn quoteWindowsCommandArg(allocator: std.mem.Allocator, arg: []const u8) ![]u8 {
+    const needs_quotes = blk: {
+        if (arg.len == 0) break :blk true;
+        for (arg) |ch| {
+            if (ch <= ' ' or ch == '"') break :blk true;
+        }
+        break :blk false;
+    };
+    if (!needs_quotes) return try allocator.dupe(u8, arg);
+
+    var out = std.ArrayList(u8).empty;
+    defer out.deinit(allocator);
+    try out.append(allocator, '"');
+
+    var backslash_count: usize = 0;
+    for (arg) |byte| {
+        switch (byte) {
+            '\\' => backslash_count += 1,
+            '"' => {
+                try out.appendNTimes(allocator, '\\', backslash_count * 2 + 1);
+                try out.append(allocator, '"');
+                backslash_count = 0;
+            },
+            else => {
+                try out.appendNTimes(allocator, '\\', backslash_count);
+                try out.append(allocator, byte);
+                backslash_count = 0;
+            },
+        }
+    }
+    try out.appendNTimes(allocator, '\\', backslash_count * 2);
+    try out.append(allocator, '"');
+    return try out.toOwnedSlice(allocator);
 }
 
 test "candidate index refreshes cached ranking after a reset window expires" {

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -264,6 +264,41 @@ fn getNonEmptyEnvVarOwned(allocator: std.mem.Allocator, name: []const u8) !?[]u8
     return val;
 }
 
+fn resolveExistingCodexHomeOverride(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const stat = std.fs.cwd().statFile(path) catch |err| switch (err) {
+        error.IsDir => {
+            return std.fs.realpathAlloc(allocator, path) catch |realpath_err| {
+                logCodexHomeResolutionError("failed to canonicalize CODEX_HOME `{s}`: {s}", .{ path, @errorName(realpath_err) });
+                return realpath_err;
+            };
+        },
+        error.FileNotFound => {
+            logCodexHomeResolutionError("CODEX_HOME points to `{s}`, but that path does not exist", .{path});
+            return err;
+        },
+        else => {
+            logCodexHomeResolutionError("failed to read CODEX_HOME `{s}`: {s}", .{ path, @errorName(err) });
+            return err;
+        },
+    };
+    if (stat.kind != .directory) {
+        logCodexHomeResolutionError("CODEX_HOME points to `{s}`, but that path is not a directory", .{path});
+        return error.NotDir;
+    }
+    return std.fs.realpathAlloc(allocator, path) catch |err| {
+        logCodexHomeResolutionError("failed to canonicalize CODEX_HOME `{s}`: {s}", .{ path, @errorName(err) });
+        return err;
+    };
+}
+
+fn logCodexHomeResolutionError(
+    comptime fmt: []const u8,
+    args: anytype,
+) void {
+    if (builtin.is_test) return;
+    std.log.err(fmt, args);
+}
+
 pub fn resolveCodexHomeFromEnv(
     allocator: std.mem.Allocator,
     codex_home_override: ?[]const u8,
@@ -271,7 +306,7 @@ pub fn resolveCodexHomeFromEnv(
     user_profile: ?[]const u8,
 ) ![]u8 {
     if (codex_home_override) |path| {
-        if (path.len != 0) return try allocator.dupe(u8, path);
+        if (path.len != 0) return try resolveExistingCodexHomeOverride(allocator, path);
     }
     if (home) |path| {
         if (path.len != 0) return try std.fs.path.join(allocator, &[_][]const u8{ path, ".codex" });

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -264,10 +264,35 @@ fn getNonEmptyEnvVarOwned(allocator: std.mem.Allocator, name: []const u8) !?[]u8
     return val;
 }
 
+pub fn resolveCodexHomeFromEnv(
+    allocator: std.mem.Allocator,
+    codex_home_override: ?[]const u8,
+    home: ?[]const u8,
+    user_profile: ?[]const u8,
+) ![]u8 {
+    if (codex_home_override) |path| {
+        if (path.len != 0) return try allocator.dupe(u8, path);
+    }
+    if (home) |path| {
+        if (path.len != 0) return try std.fs.path.join(allocator, &[_][]const u8{ path, ".codex" });
+    }
+    if (user_profile) |path| {
+        if (path.len != 0) return try std.fs.path.join(allocator, &[_][]const u8{ path, ".codex" });
+    }
+    return error.EnvironmentVariableNotFound;
+}
+
 pub fn resolveCodexHome(allocator: std.mem.Allocator) ![]u8 {
-    const home = try resolveUserHome(allocator);
-    defer allocator.free(home);
-    return try std.fs.path.join(allocator, &[_][]const u8{ home, ".codex" });
+    const codex_home_override = try getNonEmptyEnvVarOwned(allocator, "CODEX_HOME");
+    defer if (codex_home_override) |path| allocator.free(path);
+
+    const home = try getNonEmptyEnvVarOwned(allocator, "HOME");
+    defer if (home) |path| allocator.free(path);
+
+    const user_profile = try getNonEmptyEnvVarOwned(allocator, "USERPROFILE");
+    defer if (user_profile) |path| allocator.free(path);
+
+    return try resolveCodexHomeFromEnv(allocator, codex_home_override, home, user_profile);
 }
 
 pub fn resolveUserHome(allocator: std.mem.Allocator) ![]u8 {

--- a/src/tests/auto_test.zig
+++ b/src/tests/auto_test.zig
@@ -1365,6 +1365,7 @@ test "Scenario: Given linux service unit when rendering then it keeps a persiste
     try std.testing.expect(std.mem.indexOf(u8, unit, "Type=simple") != null);
     try std.testing.expect(std.mem.indexOf(u8, unit, "Restart=always") != null);
     try std.testing.expect(std.mem.indexOf(u8, unit, "Environment=\"CODEX_AUTH_VERSION=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, unit, "Environment=\"CODEX_HOME=/tmp/custom-codex-home\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, unit, "ExecStart=\"/tmp/codex-auth\" daemon --watch") != null);
     try std.testing.expect(std.mem.indexOf(u8, unit, "[Install]") != null);
     try std.testing.expect(std.mem.indexOf(u8, unit, "WantedBy=default.target") != null);
@@ -1403,27 +1404,31 @@ test "Scenario: Given mac plist when rendering then it includes version metadata
     defer gpa.free(plist);
 
     try std.testing.expect(std.mem.indexOf(u8, plist, "<key>CODEX_AUTH_VERSION</key>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, plist, "<key>CODEX_HOME</key>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, plist, "<string>/tmp/custom-codex-home</string>") != null);
     try std.testing.expect(std.mem.indexOf(u8, plist, "<string>daemon</string>") != null);
 }
 
 test "Scenario: Given windows task action when rendering then it launches the helper directly without cmd" {
     const gpa = std.testing.allocator;
-    const action = try auto.windowsTaskAction(gpa, "C:\\Program Files\\codex-auth\\codex-auth-auto.exe");
+    const action = try auto.windowsTaskAction(gpa, "C:\\Program Files\\codex-auth\\codex-auth-auto.exe", "C:\\Users\\demo\\Codex Home\\");
     defer gpa.free(action);
 
     try std.testing.expect(std.mem.indexOf(u8, action, "cmd.exe /D /C") == null);
     try std.testing.expect(std.mem.indexOf(u8, action, "\"C:\\Program Files\\codex-auth\\codex-auth-auto.exe\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, action, "--service-version ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, action, "--codex-home \"C:\\Users\\demo\\Codex Home\\\\\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, action, "powershell.exe") == null);
     try std.testing.expect(action.len < 262);
 }
 
 test "Scenario: Given windows task register script when rendering then it configures restart-on-failure" {
     const gpa = std.testing.allocator;
-    const script = try auto.windowsRegisterTaskScript(gpa, "C:\\Program Files\\codex-auth\\codex-auth-auto.exe");
+    const script = try auto.windowsRegisterTaskScript(gpa, "C:\\Program Files\\codex-auth\\codex-auth-auto.exe", "C:\\Users\\demo\\Codex Home\\");
     defer gpa.free(script);
 
     try std.testing.expect(std.mem.indexOf(u8, script, "New-ScheduledTaskAction") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "--codex-home \"C:\\Users\\demo\\Codex Home\\\\\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "New-ScheduledTaskTrigger -AtLogOn") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "New-ScheduledTaskSettingsSet -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1)") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "-ExecutionTimeLimit (New-TimeSpan -Seconds 0)") != null);

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -82,12 +82,14 @@ fn writeSuccessfulFakeCodex(dir: std.fs.Dir) !void {
         if (builtin.os.tag == .windows)
             "@echo off\r\n" ++
                 ">\"%HOME%\\fake-codex-argv.txt\" echo %*\r\n" ++
-                "copy /Y \"%HOME%\\fake-auth.json\" \"%HOME%\\.codex\\auth.json\" >NUL\r\n" ++
+                "if not exist \"%CODEX_HOME%\" mkdir \"%CODEX_HOME%\"\r\n" ++
+                "copy /Y \"%HOME%\\fake-auth.json\" \"%CODEX_HOME%\\auth.json\" >NUL\r\n" ++
                 "exit /b 0\r\n"
         else
             "#!/bin/sh\n" ++
                 "printf '%s\\n' \"$*\" > \"$HOME/fake-codex-argv.txt\"\n" ++
-                "cp \"$HOME/fake-auth.json\" \"$HOME/.codex/auth.json\"\n" ++
+                "mkdir -p \"$CODEX_HOME\"\n" ++
+                "cp \"$HOME/fake-auth.json\" \"$CODEX_HOME/auth.json\"\n" ++
                 "exit 0\n";
     const sub_path = fakeCodexCommandPath();
     try dir.writeFile(.{ .sub_path = sub_path, .data = script });
@@ -113,6 +115,9 @@ fn runCliWithIsolatedHome(
     home_root: []const u8,
     args: []const []const u8,
 ) !std.process.Child.RunResult {
+    const codex_home = try codexHomeAlloc(allocator, home_root);
+    defer allocator.free(codex_home);
+
     const exe_path = try builtCliPathAlloc(allocator, project_root);
     defer allocator.free(exe_path);
 
@@ -125,6 +130,7 @@ fn runCliWithIsolatedHome(
     defer env_map.deinit();
     try env_map.put("HOME", home_root);
     try env_map.put("USERPROFILE", home_root);
+    try env_map.put("CODEX_HOME", codex_home);
     try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
     try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
 
@@ -144,6 +150,9 @@ fn runCliWithIsolatedHomeAndPath(
     path_override: []const u8,
     args: []const []const u8,
 ) !std.process.Child.RunResult {
+    const codex_home = try codexHomeAlloc(allocator, home_root);
+    defer allocator.free(codex_home);
+
     const exe_path = try builtCliPathAlloc(allocator, project_root);
     defer allocator.free(exe_path);
 
@@ -156,6 +165,7 @@ fn runCliWithIsolatedHomeAndPath(
     defer env_map.deinit();
     try env_map.put("HOME", home_root);
     try env_map.put("USERPROFILE", home_root);
+    try env_map.put("CODEX_HOME", codex_home);
     try env_map.put("PATH", path_override);
     try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
     try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
@@ -176,6 +186,9 @@ fn runCliWithIsolatedHomeAndStdin(
     args: []const []const u8,
     stdin_data: []const u8,
 ) !std.process.Child.RunResult {
+    const codex_home = try codexHomeAlloc(allocator, home_root);
+    defer allocator.free(codex_home);
+
     const exe_path = try builtCliPathAlloc(allocator, project_root);
     defer allocator.free(exe_path);
 
@@ -188,6 +201,7 @@ fn runCliWithIsolatedHomeAndStdin(
     defer env_map.deinit();
     try env_map.put("HOME", home_root);
     try env_map.put("USERPROFILE", home_root);
+    try env_map.put("CODEX_HOME", codex_home);
     try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
     try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
 

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -109,14 +109,17 @@ fn writeSuccessfulFakeCodex(dir: std.fs.Dir) !void {
         if (builtin.os.tag == .windows)
             "@echo off\r\n" ++
                 ">\"%HOME%\\fake-codex-argv.txt\" echo %*\r\n" ++
-                "if not exist \"%CODEX_HOME%\" mkdir \"%CODEX_HOME%\"\r\n" ++
-                "copy /Y \"%HOME%\\fake-auth.json\" \"%CODEX_HOME%\\auth.json\" >NUL\r\n" ++
+                "set \"CODEX_HOME_DIR=%CODEX_HOME%\"\r\n" ++
+                "if \"%CODEX_HOME_DIR%\"==\"\" set \"CODEX_HOME_DIR=%HOME%\\.codex\"\r\n" ++
+                "if not exist \"%CODEX_HOME_DIR%\" mkdir \"%CODEX_HOME_DIR%\"\r\n" ++
+                "copy /Y \"%HOME%\\fake-auth.json\" \"%CODEX_HOME_DIR%\\auth.json\" >NUL\r\n" ++
                 "exit /b 0\r\n"
         else
             "#!/bin/sh\n" ++
                 "printf '%s\\n' \"$*\" > \"$HOME/fake-codex-argv.txt\"\n" ++
-                "mkdir -p \"$CODEX_HOME\"\n" ++
-                "cp \"$HOME/fake-auth.json\" \"$CODEX_HOME/auth.json\"\n" ++
+                "CODEX_HOME_DIR=\"${CODEX_HOME:-$HOME/.codex}\"\n" ++
+                "mkdir -p \"$CODEX_HOME_DIR\"\n" ++
+                "cp \"$HOME/fake-auth.json\" \"$CODEX_HOME_DIR/auth.json\"\n" ++
                 "exit 0\n";
     const sub_path = fakeCodexCommandPath();
     try dir.writeFile(.{ .sub_path = sub_path, .data = script });
@@ -142,9 +145,29 @@ fn runCliWithIsolatedHome(
     home_root: []const u8,
     args: []const []const u8,
 ) !std.process.Child.RunResult {
-    const codex_home = try codexHomeAlloc(allocator, home_root);
-    defer allocator.free(codex_home);
-    return try runCliWithIsolatedHomeAndCodexHome(allocator, project_root, home_root, codex_home, args);
+    const exe_path = try builtCliPathAlloc(allocator, project_root);
+    defer allocator.free(exe_path);
+
+    var argv = std.ArrayList([]const u8).empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, exe_path);
+    try argv.appendSlice(allocator, args);
+
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("HOME", home_root);
+    try env_map.put("USERPROFILE", home_root);
+    env_map.remove("CODEX_HOME");
+    try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
+    try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
+
+    return try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv.items,
+        .cwd = project_root,
+        .env_map = &env_map,
+        .max_output_bytes = 1024 * 1024,
+    });
 }
 
 fn runCliWithIsolatedHomeAndCodexHome(
@@ -220,28 +243,6 @@ fn runCliWithIsolatedHomeAndPath(
     path_override: []const u8,
     args: []const []const u8,
 ) !std.process.Child.RunResult {
-    const codex_home = try codexHomeAlloc(allocator, home_root);
-    defer allocator.free(codex_home);
-    return try runCliWithIsolatedHomeAndCodexHomeAndPath(
-        allocator,
-        project_root,
-        home_root,
-        codex_home,
-        path_override,
-        args,
-    );
-}
-
-fn runCliWithIsolatedHomeAndStdin(
-    allocator: std.mem.Allocator,
-    project_root: []const u8,
-    home_root: []const u8,
-    args: []const []const u8,
-    stdin_data: []const u8,
-) !std.process.Child.RunResult {
-    const codex_home = try codexHomeAlloc(allocator, home_root);
-    defer allocator.free(codex_home);
-
     const exe_path = try builtCliPathAlloc(allocator, project_root);
     defer allocator.free(exe_path);
 
@@ -254,7 +255,40 @@ fn runCliWithIsolatedHomeAndStdin(
     defer env_map.deinit();
     try env_map.put("HOME", home_root);
     try env_map.put("USERPROFILE", home_root);
-    try env_map.put("CODEX_HOME", codex_home);
+    env_map.remove("CODEX_HOME");
+    try env_map.put("PATH", path_override);
+    try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
+    try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
+
+    return try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv.items,
+        .cwd = project_root,
+        .env_map = &env_map,
+        .max_output_bytes = 1024 * 1024,
+    });
+}
+
+fn runCliWithIsolatedHomeAndStdin(
+    allocator: std.mem.Allocator,
+    project_root: []const u8,
+    home_root: []const u8,
+    args: []const []const u8,
+    stdin_data: []const u8,
+) !std.process.Child.RunResult {
+    const exe_path = try builtCliPathAlloc(allocator, project_root);
+    defer allocator.free(exe_path);
+
+    var argv = std.ArrayList([]const u8).empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, exe_path);
+    try argv.appendSlice(allocator, args);
+
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("HOME", home_root);
+    try env_map.put("USERPROFILE", home_root);
+    env_map.remove("CODEX_HOME");
     try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
     try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
 

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -3,38 +3,58 @@ const builtin = @import("builtin");
 const registry = @import("../registry.zig");
 const bdd = @import("bdd_helpers.zig");
 
+const e2e_install_prefix_env = "CODEX_AUTH_E2E_INSTALL_PREFIX";
+const e2e_project_root_env = "CODEX_AUTH_E2E_PROJECT_ROOT";
+
 const SeedAccount = struct {
     email: []const u8,
     alias: []const u8,
 };
 
 fn projectRootAlloc(allocator: std.mem.Allocator) ![]u8 {
+    const project_root = std.process.getEnvVarOwned(allocator, e2e_project_root_env) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    if (project_root) |path| return path;
     return std.fs.cwd().realpathAlloc(allocator, ".");
 }
 
 fn buildCliBinary(allocator: std.mem.Allocator, project_root: []const u8) !void {
-    const global_cache_dir = try std.fs.path.join(allocator, &[_][]const u8{
-        project_root,
-        ".zig-cache",
-        "e2e-global",
-    });
-    defer allocator.free(global_cache_dir);
-
-    const local_cache_dir = try std.fs.path.join(allocator, &[_][]const u8{
-        project_root,
-        ".zig-cache",
-        "e2e-local",
-    });
-    defer allocator.free(local_cache_dir);
-
     var env_map = try std.process.getEnvMap(allocator);
     defer env_map.deinit();
+    const global_cache_dir = if (env_map.get("ZIG_GLOBAL_CACHE_DIR")) |dir|
+        try allocator.dupe(u8, dir)
+    else
+        try std.fs.path.join(allocator, &[_][]const u8{
+            project_root,
+            ".zig-cache",
+            "e2e-global",
+        });
+    defer allocator.free(global_cache_dir);
+
+    const local_cache_dir = if (env_map.get("ZIG_LOCAL_CACHE_DIR")) |dir|
+        try allocator.dupe(u8, dir)
+    else
+        try std.fs.path.join(allocator, &[_][]const u8{
+            project_root,
+            ".zig-cache",
+            "e2e-local",
+        });
+    defer allocator.free(local_cache_dir);
+    const install_prefix = if (env_map.get(e2e_install_prefix_env)) |dir|
+        try allocator.dupe(u8, dir)
+    else
+        try std.fs.path.join(allocator, &[_][]const u8{ project_root, "zig-out" });
+    defer allocator.free(install_prefix);
+
     try env_map.put("ZIG_GLOBAL_CACHE_DIR", global_cache_dir);
     try env_map.put("ZIG_LOCAL_CACHE_DIR", local_cache_dir);
+    try env_map.put(e2e_install_prefix_env, install_prefix);
 
     const result = try std.process.Child.run(.{
         .allocator = allocator,
-        .argv = &[_][]const u8{ "zig", "build" },
+        .argv = &[_][]const u8{ "zig", "build", "-p", install_prefix },
         .cwd = project_root,
         .env_map = &env_map,
         .max_output_bytes = 1024 * 1024,
@@ -54,7 +74,14 @@ fn buildCliBinary(allocator: std.mem.Allocator, project_root: []const u8) !void 
 
 fn builtCliPathAlloc(allocator: std.mem.Allocator, project_root: []const u8) ![]u8 {
     const exe_name = if (builtin.os.tag == .windows) "codex-auth.exe" else "codex-auth";
-    return std.fs.path.join(allocator, &[_][]const u8{ project_root, "zig-out", "bin", exe_name });
+    const install_prefix = std.process.getEnvVarOwned(allocator, e2e_install_prefix_env) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    defer if (install_prefix) |dir| allocator.free(dir);
+
+    const prefix = install_prefix orelse return std.fs.path.join(allocator, &[_][]const u8{ project_root, "zig-out", "bin", exe_name });
+    return std.fs.path.join(allocator, &[_][]const u8{ prefix, "bin", exe_name });
 }
 
 fn fakeCodexCommandPath() []const u8 {
@@ -117,7 +144,16 @@ fn runCliWithIsolatedHome(
 ) !std.process.Child.RunResult {
     const codex_home = try codexHomeAlloc(allocator, home_root);
     defer allocator.free(codex_home);
+    return try runCliWithIsolatedHomeAndCodexHome(allocator, project_root, home_root, codex_home, args);
+}
 
+fn runCliWithIsolatedHomeAndCodexHome(
+    allocator: std.mem.Allocator,
+    project_root: []const u8,
+    home_root: []const u8,
+    codex_home: []const u8,
+    args: []const []const u8,
+) !std.process.Child.RunResult {
     const exe_path = try builtCliPathAlloc(allocator, project_root);
     defer allocator.free(exe_path);
 
@@ -143,16 +179,14 @@ fn runCliWithIsolatedHome(
     });
 }
 
-fn runCliWithIsolatedHomeAndPath(
+fn runCliWithIsolatedHomeAndCodexHomeAndPath(
     allocator: std.mem.Allocator,
     project_root: []const u8,
     home_root: []const u8,
+    codex_home: []const u8,
     path_override: []const u8,
     args: []const []const u8,
 ) !std.process.Child.RunResult {
-    const codex_home = try codexHomeAlloc(allocator, home_root);
-    defer allocator.free(codex_home);
-
     const exe_path = try builtCliPathAlloc(allocator, project_root);
     defer allocator.free(exe_path);
 
@@ -177,6 +211,25 @@ fn runCliWithIsolatedHomeAndPath(
         .env_map = &env_map,
         .max_output_bytes = 1024 * 1024,
     });
+}
+
+fn runCliWithIsolatedHomeAndPath(
+    allocator: std.mem.Allocator,
+    project_root: []const u8,
+    home_root: []const u8,
+    path_override: []const u8,
+    args: []const []const u8,
+) !std.process.Child.RunResult {
+    const codex_home = try codexHomeAlloc(allocator, home_root);
+    defer allocator.free(codex_home);
+    return try runCliWithIsolatedHomeAndCodexHomeAndPath(
+        allocator,
+        project_root,
+        home_root,
+        codex_home,
+        path_override,
+        args,
+    );
 }
 
 fn runCliWithIsolatedHomeAndStdin(
@@ -396,6 +449,61 @@ test "Scenario: Given device auth login when running login then it forwards the 
     const active_auth = try bdd.readFileAlloc(gpa, active_auth_path);
     defer gpa.free(active_auth);
     try std.testing.expectEqualStrings(fake_auth, active_auth);
+}
+
+test "Scenario: Given CODEX_HOME override when running login then it stores auth state under the override root" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+    try tmp.dir.makePath("custom-codex");
+    try tmp.dir.makePath("fake-bin");
+
+    const custom_codex_home = try tmp.dir.realpathAlloc(gpa, "custom-codex");
+    defer gpa.free(custom_codex_home);
+
+    const expected_email = "override@example.com";
+    const fake_auth = try bdd.authJsonWithEmailPlan(gpa, expected_email, "plus");
+    defer gpa.free(fake_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "fake-auth.json", .data = fake_auth });
+    try writeSuccessfulFakeCodex(tmp.dir);
+
+    const fake_bin_path = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "fake-bin" });
+    defer gpa.free(fake_bin_path);
+    const path_override = try prependPathEntryAlloc(gpa, fake_bin_path);
+    defer gpa.free(path_override);
+
+    const result = try runCliWithIsolatedHomeAndCodexHomeAndPath(
+        gpa,
+        project_root,
+        home_root,
+        custom_codex_home,
+        path_override,
+        &[_][]const u8{ "login", "--device-auth" },
+    );
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectSuccess(result);
+
+    const custom_auth_path = try registry.activeAuthPath(gpa, custom_codex_home);
+    defer gpa.free(custom_auth_path);
+    try std.fs.cwd().access(custom_auth_path, .{});
+
+    const default_auth_path = try authJsonPathAlloc(gpa, home_root);
+    defer gpa.free(default_auth_path);
+    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(default_auth_path, .{}));
+
+    var loaded = try registry.loadRegistry(gpa, custom_codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expectEqual(@as(usize, 1), loaded.accounts.items.len);
+    try std.testing.expect(std.mem.eql(u8, loaded.accounts.items[0].email, expected_email));
 }
 
 test "Scenario: Given failed device auth login with existing auth json when running login then it forwards the flag and does not mutate the registry" {

--- a/src/tests/registry_test.zig
+++ b/src/tests/registry_test.zig
@@ -119,16 +119,52 @@ fn makeAccountRecord(
 
 test "resolveCodexHomeFromEnv prefers CODEX_HOME over HOME" {
     const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
 
+    try tmp.dir.makePath("custom-codex");
+    const custom_codex_home = try tmp.dir.realpathAlloc(gpa, "custom-codex");
+    defer gpa.free(custom_codex_home);
     const resolved = try registry.resolveCodexHomeFromEnv(
         gpa,
-        "/tmp/custom-codex",
+        custom_codex_home,
         "/tmp/home-root",
         null,
     );
     defer gpa.free(resolved);
 
-    try std.testing.expectEqualStrings("/tmp/custom-codex", resolved);
+    try std.testing.expectEqualStrings(custom_codex_home, resolved);
+}
+
+test "resolveCodexHomeFromEnv rejects a missing CODEX_HOME override" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const missing = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(missing);
+    const missing_path = try std.fs.path.join(gpa, &[_][]const u8{ missing, "missing-codex-home" });
+    defer gpa.free(missing_path);
+
+    try std.testing.expectError(
+        error.FileNotFound,
+        registry.resolveCodexHomeFromEnv(gpa, missing_path, "/tmp/home-root", null),
+    );
+}
+
+test "resolveCodexHomeFromEnv rejects a file CODEX_HOME override" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "codex-home.txt", .data = "not a directory" });
+    const file_path = try tmp.dir.realpathAlloc(gpa, "codex-home.txt");
+    defer gpa.free(file_path);
+
+    try std.testing.expectError(
+        error.NotDir,
+        registry.resolveCodexHomeFromEnv(gpa, file_path, "/tmp/home-root", null),
+    );
 }
 
 test "resolveCodexHomeFromEnv falls back to HOME when CODEX_HOME is empty" {

--- a/src/tests/registry_test.zig
+++ b/src/tests/registry_test.zig
@@ -117,6 +117,51 @@ fn makeAccountRecord(
     };
 }
 
+test "resolveCodexHomeFromEnv prefers CODEX_HOME over HOME" {
+    const gpa = std.testing.allocator;
+
+    const resolved = try registry.resolveCodexHomeFromEnv(
+        gpa,
+        "/tmp/custom-codex",
+        "/tmp/home-root",
+        null,
+    );
+    defer gpa.free(resolved);
+
+    try std.testing.expectEqualStrings("/tmp/custom-codex", resolved);
+}
+
+test "resolveCodexHomeFromEnv falls back to HOME when CODEX_HOME is empty" {
+    const gpa = std.testing.allocator;
+
+    const resolved = try registry.resolveCodexHomeFromEnv(
+        gpa,
+        "",
+        "/tmp/home-root",
+        null,
+    );
+    defer gpa.free(resolved);
+
+    try std.testing.expectEqualStrings("/tmp/home-root/.codex", resolved);
+}
+
+test "resolveCodexHomeFromEnv falls back to USERPROFILE when HOME is unset" {
+    const gpa = std.testing.allocator;
+
+    const resolved = try registry.resolveCodexHomeFromEnv(
+        gpa,
+        null,
+        null,
+        "C:\\Users\\demo",
+    );
+    defer gpa.free(resolved);
+
+    const expected = try std.fs.path.join(gpa, &[_][]const u8{ "C:\\Users\\demo", ".codex" });
+    defer gpa.free(expected);
+
+    try std.testing.expectEqualStrings(expected, resolved);
+}
+
 fn setRecordIds(
     allocator: std.mem.Allocator,
     rec: *registry.AccountRecord,

--- a/src/tests/registry_test.zig
+++ b/src/tests/registry_test.zig
@@ -142,7 +142,10 @@ test "resolveCodexHomeFromEnv falls back to HOME when CODEX_HOME is empty" {
     );
     defer gpa.free(resolved);
 
-    try std.testing.expectEqualStrings("/tmp/home-root/.codex", resolved);
+    const expected = try std.fs.path.join(gpa, &[_][]const u8{ "/tmp/home-root", ".codex" });
+    defer gpa.free(expected);
+
+    try std.testing.expectEqualStrings(expected, resolved);
 }
 
 test "resolveCodexHomeFromEnv falls back to USERPROFILE when HOME is unset" {

--- a/src/windows_auto_main.zig
+++ b/src/windows_auto_main.zig
@@ -2,12 +2,43 @@ const std = @import("std");
 const auto = @import("auto.zig");
 const registry = @import("registry.zig");
 
+fn resolveDaemonCodexHome(allocator: std.mem.Allocator) ![]u8 {
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    var codex_home_override: ?[]u8 = null;
+    defer if (codex_home_override) |path| allocator.free(path);
+
+    var i: usize = 1;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (std.mem.eql(u8, arg, "--service-version")) {
+            if (i + 1 >= args.len) return error.InvalidCliUsage;
+            i += 1;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--codex-home")) {
+            if (i + 1 >= args.len) return error.InvalidCliUsage;
+            if (codex_home_override != null) return error.InvalidCliUsage;
+            codex_home_override = try allocator.dupe(u8, args[i + 1]);
+            i += 1;
+            continue;
+        }
+        return error.InvalidCliUsage;
+    }
+
+    if (codex_home_override) |path| {
+        return try registry.resolveCodexHomeFromEnv(allocator, path, null, null);
+    }
+    return try registry.resolveCodexHome(allocator);
+}
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const codex_home = try registry.resolveCodexHome(allocator);
+    const codex_home = try resolveDaemonCodexHome(allocator);
     defer allocator.free(codex_home);
 
     try auto.runDaemon(allocator, codex_home);


### PR DESCRIPTION
## Summary

- Align `codex-auth` with Codex's `CODEX_HOME` behavior.
- When `CODEX_HOME` is set, use it as the active Codex state root; otherwise fall back to `HOME/.codex`, then `USERPROFILE/.codex` on Windows.
- Match Codex semantics by requiring an explicit `CODEX_HOME` to point to an existing directory.

## Notes

- Managed service definition files do not move into `CODEX_HOME`.
- Linux `systemd --user` units, macOS `LaunchAgent` plists, and the Windows scheduled task still live in the platform-standard per-user locations.
- The managed watcher process now keeps using the same `codex_home` that was active when `config auto enable` ran.

## What Changed

- add `CODEX_HOME` validation and canonicalization in the Codex home resolver
- forward the active `codex_home` into managed watcher startup on Linux and macOS
- pass an explicit `--codex-home` argument to the Windows helper task
- add resolver coverage for explicit `CODEX_HOME`
- add e2e coverage for `HOME != CODEX_HOME`
- update docs to reflect the actual service-definition and watcher behavior

## Validation

- `zig build run -- list`
- `zig test src/main.zig -lc --test-filter "resolveCodexHomeFromEnv"`
- `zig test src/main.zig -lc --test-filter "persistent daemon watcher"`
- `zig test src/main.zig -lc --test-filter "mac plist"`
- `zig test src/main.zig -lc --test-filter "windows task"`
- `zig test src/main.zig -lc --test-filter "CODEX_HOME override when running login"`
