### PR TITLE
feat: support prolite plan

### DIFF
--- a/docs/api-refresh.md
+++ b/docs/api-refresh.md
@@ -92,8 +92,8 @@ After a successful `accounts/check` response:
 
 Example 1:
 
-- active record: `user@example.com / team #1 / account_name = null`
-- same grouped scope: `user@example.com / team #2 / account_name = null`
+- active record: `user@example.com / Team #1 / account_name = null`
+- same grouped scope: `user@example.com / Team #2 / account_name = null`
 
 Running `codex-auth list` should issue `accounts/check`. If the API returns:
 
@@ -104,9 +104,9 @@ Then both grouped Team records are updated.
 
 Example 2:
 
-- active record: `user@example.com / pro / account_name = null`
-- same grouped scope: `user@example.com / team #1 / account_name = null`
-- same grouped scope: `user@example.com / team #2 / account_name = "Old Workspace"`
+- active record: `user@example.com / Pro / account_name = null`
+- same grouped scope: `user@example.com / Team #1 / account_name = null`
+- same grouped scope: `user@example.com / Team #2 / account_name = "Old Workspace"`
 
 Running `codex-auth list` should still issue `accounts/check`, because the grouped scope still has missing Team names. If the API returns:
 
@@ -115,7 +115,7 @@ Running `codex-auth list` should still issue `accounts/check`, because the group
 
 Then:
 
-- `team #1` is filled with `Prod Workspace`
-- `team #2` is overwritten from `Old Workspace` to `Sandbox Workspace`
+- `Team #1` is filled with `Prod Workspace`
+- `Team #2` is overwritten from `Old Workspace` to `Sandbox Workspace`
 
 The same grouped-scope rule also applies to synchronous `list` / pre-selection `switch` refreshes and to the auto-switch daemon.

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -294,7 +294,8 @@ Latest rollout `.jsonl` rate limit record shape (from an `event_msg` + `token_co
   - child rows are the selectable accounts
   - alias takes precedence for the child label
   - otherwise the child label is the human-readable plan name (`Team`, `Plus`, `Pro Lite`, etc.)
-  - repeated plans under the same email are rendered as stable numbered labels like `Team #1`, `Team #2`
+  - workspace-style duplicate plans may use stable numbered labels like `Team #1`, `Team #2`
+  - non-workspace duplicate plans (`Free`, `Plus`, `Pro`, `Pro Lite`) do not use `#1` / `#2`; they should use another disambiguator such as an account or user suffix
 - Single-account emails still render as one flat row; when an alias is set, that row shows `(alias)email`.
 - The switch/remove UI shows `ACCOUNT`, `PLAN`, `5H`, `WEEKLY`, `LAST`, and preserves grouped child indentation.
 - Usage limit cells show remaining percent plus reset time: `NN% (HH:MM)` for same-day resets, or `NN% (HH:MM on D Mon)` when the reset is on a different day.

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -293,10 +293,10 @@ Latest rollout `.jsonl` rate limit record shape (from an `event_msg` + `token_co
   - the top-level email line is a header only
   - child rows are the selectable accounts
   - alias takes precedence for the child label
-  - otherwise the child label is the plan name (`team`, `plus`, etc.)
-  - repeated plans under the same email are rendered as stable numbered labels like `team #1`, `team #2`
+  - otherwise the child label is the human-readable plan name (`Team`, `Plus`, `Pro Lite`, etc.)
+  - repeated plans under the same email are rendered as stable numbered labels like `Team #1`, `Team #2`
 - Single-account emails still render as one flat row; when an alias is set, that row shows `(alias)email`.
 - The switch/remove UI shows `ACCOUNT`, `PLAN`, `5H`, `WEEKLY`, `LAST`, and preserves grouped child indentation.
 - Usage limit cells show remaining percent plus reset time: `NN% (HH:MM)` for same-day resets, or `NN% (HH:MM on D Mon)` when the reset is on a different day.
 - `LAST ACTIVITY` is derived from `last_usage_at` and rendered as a relative time like `Now` or `2m ago`.
-- `PLAN` comes from the auth claim when available, and falls back to the last usage snapshot's `plan_type` (e.g. `free`, `plus`, `team`).
+- `PLAN` comes from the auth claim when available, and falls back to the last usage snapshot's `plan_type` (for example raw values like `free`, `plus`, `prolite`, `team` are shown as `Free`, `Plus`, `Pro Lite`, `Team`).

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -275,6 +275,7 @@ fn base64UrlNoPadDecode(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
 fn parsePlanType(s: []const u8) registry.PlanType {
     if (std.ascii.eqlIgnoreCase(s, "free")) return .free;
     if (std.ascii.eqlIgnoreCase(s, "plus")) return .plus;
+    if (std.ascii.eqlIgnoreCase(s, "prolite")) return .prolite;
     if (std.ascii.eqlIgnoreCase(s, "pro")) return .pro;
     if (std.ascii.eqlIgnoreCase(s, "team")) return .team;
     if (std.ascii.eqlIgnoreCase(s, "business")) return .business;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1821,7 +1821,7 @@ fn buildSwitchRows(allocator: std.mem.Allocator, reg: *registry.Registry) !Switc
     for (display.rows, 0..) |display_row, i| {
         if (display_row.account_index) |account_idx| {
             const rec = reg.accounts.items[account_idx];
-            const plan = if (registry.resolvePlan(&rec)) |p| @tagName(p) else "-";
+            const plan = if (registry.resolvePlan(&rec)) |p| registry.planLabel(p) else "-";
             const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
             const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
             const rate_5h_str = try formatRateLimitSwitchAlloc(allocator, rate_5h);
@@ -1885,7 +1885,7 @@ fn buildSwitchRowsFromIndices(
     for (display.rows, 0..) |display_row, i| {
         if (display_row.account_index) |account_idx| {
             const rec = reg.accounts.items[account_idx];
-            const plan = if (registry.resolvePlan(&rec)) |p| @tagName(p) else "-";
+            const plan = if (registry.resolvePlan(&rec)) |p| registry.planLabel(p) else "-";
             const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
             const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
             const rate_5h_str = try formatRateLimitSwitchAlloc(allocator, rate_5h);

--- a/src/display_rows.zig
+++ b/src/display_rows.zig
@@ -139,13 +139,13 @@ fn lessThanByDisplayOrder(ctx: SortContext, lhs: usize, rhs: usize) bool {
 fn planSortRank(plan: ?registry.PlanType) u8 {
     return switch (plan orelse .unknown) {
         .team, .business, .enterprise, .edu => 0,
-        .free, .plus, .pro => 1,
+        .free, .plus, .prolite, .pro => 1,
         else => 2,
     };
 }
 
 fn displayPlan(rec: *const registry.AccountRecord) []const u8 {
-    return if (registry.resolvePlan(rec)) |plan| @tagName(plan) else "-";
+    return if (registry.resolvePlan(rec)) |plan| registry.planLabel(plan) else "-";
 }
 
 fn isActive(reg: *const registry.Registry, account_idx: usize) bool {

--- a/src/format.zig
+++ b/src/format.zig
@@ -19,7 +19,7 @@ fn colorEnabled() bool {
 }
 
 fn planDisplay(rec: *const registry.AccountRecord, missing: []const u8) []const u8 {
-    if (registry.resolvePlan(rec)) |p| return @tagName(p);
+    if (registry.resolvePlan(rec)) |p| return registry.planLabel(p);
     return missing;
 }
 

--- a/src/format.zig
+++ b/src/format.zig
@@ -683,5 +683,5 @@ test "writeAccountsTable shows zero-padded row numbers for selectable accounts" 
 
     const output = writer.buffered();
     try std.testing.expect(std.mem.indexOf(u8, output, "01   Als's Workspace") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "02   free") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "02   Free") != null);
 }

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -5,7 +5,7 @@ const c_time = @cImport({
     @cInclude("time.h");
 });
 
-pub const PlanType = enum { free, plus, pro, team, business, enterprise, edu, unknown };
+pub const PlanType = enum { free, plus, prolite, pro, team, business, enterprise, edu, unknown };
 pub const AuthMode = enum { chatgpt, apikey };
 pub const current_schema_version: u32 = 3;
 pub const min_supported_schema_version: u32 = 2;
@@ -82,6 +82,13 @@ pub fn resolvePlan(rec: *const AccountRecord) ?PlanType {
     if (rec.plan) |p| return p;
     if (rec.last_usage) |u| return u.plan_type;
     return null;
+}
+
+pub fn planLabel(plan: PlanType) []const u8 {
+    return switch (plan) {
+        .prolite => "pro lite",
+        else => @tagName(plan),
+    };
 }
 
 pub const Registry = struct {
@@ -2512,6 +2519,7 @@ const RegistryOut = struct {
 fn parsePlanType(s: []const u8) ?PlanType {
     if (std.mem.eql(u8, s, "free")) return .free;
     if (std.mem.eql(u8, s, "plus")) return .plus;
+    if (std.mem.eql(u8, s, "prolite")) return .prolite;
     if (std.mem.eql(u8, s, "pro")) return .pro;
     if (std.mem.eql(u8, s, "team")) return .team;
     if (std.mem.eql(u8, s, "business")) return .business;

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -86,8 +86,15 @@ pub fn resolvePlan(rec: *const AccountRecord) ?PlanType {
 
 pub fn planLabel(plan: PlanType) []const u8 {
     return switch (plan) {
-        .prolite => "pro lite",
-        else => @tagName(plan),
+        .free => "Free",
+        .plus => "Plus",
+        .prolite => "Pro Lite",
+        .pro => "Pro",
+        .team => "Team",
+        .business => "Business",
+        .enterprise => "Enterprise",
+        .edu => "Edu",
+        .unknown => "Unknown",
     };
 }
 

--- a/src/sessions.zig
+++ b/src/sessions.zig
@@ -450,6 +450,7 @@ fn parseCredits(allocator: std.mem.Allocator, parsed: UsageCreditsJson) registry
 fn parsePlanType(s: []const u8) registry.PlanType {
     if (std.ascii.eqlIgnoreCase(s, "free")) return .free;
     if (std.ascii.eqlIgnoreCase(s, "plus")) return .plus;
+    if (std.ascii.eqlIgnoreCase(s, "prolite")) return .prolite;
     if (std.ascii.eqlIgnoreCase(s, "pro")) return .pro;
     if (std.ascii.eqlIgnoreCase(s, "team")) return .team;
     if (std.ascii.eqlIgnoreCase(s, "business")) return .business;

--- a/src/tests/display_rows_test.zig
+++ b/src/tests/display_rows_test.zig
@@ -80,20 +80,21 @@ test "Scenario: Given grouped accounts with aliases when building display rows t
     try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "backup") or std.mem.eql(u8, rows.rows[2].account_cell, "work"));
 }
 
-test "Scenario: Given prolite accounts when building display rows then labels use Pro Lite wording" {
+test "Scenario: Given grouped accounts with a prolite record when building display rows then labels use Pro Lite wording" {
     const gpa = std.testing.allocator;
     var reg = makeRegistry();
     defer reg.deinit(gpa);
 
     try appendAccount(gpa, &reg, "user-ESYgcy2QkOGZc0NoxSlFCeVT::67fe2bbb-0de6-49a4-b2b3-d1df366d1faf", "user@example.com", "", .prolite);
-    try appendAccount(gpa, &reg, "user-ESYgcy2QkOGZc0NoxSlFCeVT::518a44d9-ba75-4bad-87e5-ae9377042960", "user@example.com", "", .prolite);
+    try appendAccount(gpa, &reg, "user-ESYgcy2QkOGZc0NoxSlFCeVT::518a44d9-ba75-4bad-87e5-ae9377042960", "user@example.com", "", .team);
 
     var rows = try display_rows.buildDisplayRows(gpa, &reg, null);
     defer rows.deinit(gpa);
 
     try std.testing.expectEqual(@as(usize, 3), rows.rows.len);
-    try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "Pro Lite #1"));
-    try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "Pro Lite #2"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[0].account_cell, "user@example.com"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "Team"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "Pro Lite"));
 }
 
 test "Scenario: Given same-email accounts filtered down to one row when building display rows then singleton is decided from the rendered subset" {

--- a/src/tests/display_rows_test.zig
+++ b/src/tests/display_rows_test.zig
@@ -80,6 +80,22 @@ test "Scenario: Given grouped accounts with aliases when building display rows t
     try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "backup") or std.mem.eql(u8, rows.rows[2].account_cell, "work"));
 }
 
+test "Scenario: Given prolite accounts when building display rows then labels use pro lite wording" {
+    const gpa = std.testing.allocator;
+    var reg = makeRegistry();
+    defer reg.deinit(gpa);
+
+    try appendAccount(gpa, &reg, "user-ESYgcy2QkOGZc0NoxSlFCeVT::67fe2bbb-0de6-49a4-b2b3-d1df366d1faf", "user@example.com", "", .prolite);
+    try appendAccount(gpa, &reg, "user-ESYgcy2QkOGZc0NoxSlFCeVT::518a44d9-ba75-4bad-87e5-ae9377042960", "user@example.com", "", .prolite);
+
+    var rows = try display_rows.buildDisplayRows(gpa, &reg, null);
+    defer rows.deinit(gpa);
+
+    try std.testing.expectEqual(@as(usize, 3), rows.rows.len);
+    try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "pro lite #1"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "pro lite #2"));
+}
+
 test "Scenario: Given same-email accounts filtered down to one row when building display rows then singleton is decided from the rendered subset" {
     const gpa = std.testing.allocator;
     var reg = makeRegistry();

--- a/src/tests/display_rows_test.zig
+++ b/src/tests/display_rows_test.zig
@@ -57,10 +57,10 @@ test "Scenario: Given same email with two team accounts and one plus account whe
     try std.testing.expect(rows.rows.len == 4);
     try std.testing.expect(rows.rows[0].account_index == null);
     try std.testing.expect(std.mem.eql(u8, rows.rows[0].account_cell, "user@example.com"));
-    try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "team #1"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "Team #1"));
     try std.testing.expect(rows.rows[1].is_active);
-    try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "team #2"));
-    try std.testing.expect(std.mem.eql(u8, rows.rows[3].account_cell, "plus"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "Team #2"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[3].account_cell, "Plus"));
     try std.testing.expect(rows.selectable_row_indices.len == 3);
 }
 
@@ -80,7 +80,7 @@ test "Scenario: Given grouped accounts with aliases when building display rows t
     try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "backup") or std.mem.eql(u8, rows.rows[2].account_cell, "work"));
 }
 
-test "Scenario: Given prolite accounts when building display rows then labels use pro lite wording" {
+test "Scenario: Given prolite accounts when building display rows then labels use Pro Lite wording" {
     const gpa = std.testing.allocator;
     var reg = makeRegistry();
     defer reg.deinit(gpa);
@@ -92,8 +92,8 @@ test "Scenario: Given prolite accounts when building display rows then labels us
     defer rows.deinit(gpa);
 
     try std.testing.expectEqual(@as(usize, 3), rows.rows.len);
-    try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "pro lite #1"));
-    try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "pro lite #2"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "Pro Lite #1"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "Pro Lite #2"));
 }
 
 test "Scenario: Given same-email accounts filtered down to one row when building display rows then singleton is decided from the rendered subset" {
@@ -160,7 +160,7 @@ test "Scenario: Given mixed singleton and grouped accounts when building display
     try std.testing.expect(rows.rows[1].account_index == null);
     try std.testing.expect(std.mem.eql(u8, rows.rows[1].account_cell, "user@example.com"));
     try std.testing.expect(std.mem.eql(u8, rows.rows[2].account_cell, "work (Primary Workspace)"));
-    try std.testing.expect(std.mem.eql(u8, rows.rows[3].account_cell, "plus"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[3].account_cell, "Plus"));
 }
 
 test "Scenario: Given grouped accounts with account names when building display rows then child labels use the same precedence" {
@@ -184,5 +184,5 @@ test "Scenario: Given grouped accounts with account names when building display 
             (std.mem.eql(u8, rows.rows[1].account_cell, "Backup Workspace") and
                 std.mem.eql(u8, rows.rows[2].account_cell, "work (Primary Workspace)")),
     );
-    try std.testing.expect(std.mem.eql(u8, rows.rows[3].account_cell, "plus"));
+    try std.testing.expect(std.mem.eql(u8, rows.rows[3].account_cell, "Plus"));
 }

--- a/src/tests/registry_test.zig
+++ b/src/tests/registry_test.zig
@@ -218,6 +218,34 @@ test "registry save/load" {
     try std.testing.expect(loaded.accounts.items[0].account_name == null);
 }
 
+test "plan labels are human-readable while registry stores raw plan values" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("accounts");
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "label@example.com", "", .prolite, .chatgpt, 1));
+    try registry.saveRegistry(gpa, codex_home, &reg);
+
+    const registry_path = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "accounts", "registry.json" });
+    defer gpa.free(registry_path);
+    const saved = try bdd.readFileAlloc(gpa, registry_path);
+    defer gpa.free(saved);
+
+    try std.testing.expect(std.mem.indexOf(u8, saved, "\"plan\": \"prolite\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "Pro Lite") == null);
+    try std.testing.expectEqualStrings("Free", registry.planLabel(.free));
+    try std.testing.expectEqualStrings("Plus", registry.planLabel(.plus));
+    try std.testing.expectEqualStrings("Pro Lite", registry.planLabel(.prolite));
+    try std.testing.expectEqualStrings("Team", registry.planLabel(.team));
+}
+
 test "registry load defaults missing account_name field to null" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/tests/usage_api_test.zig
+++ b/src/tests/usage_api_test.zig
@@ -80,6 +80,31 @@ test "parse usage api response without windows is ignored" {
     try std.testing.expect(snapshot == null);
 }
 
+test "parse usage api response maps prolite plan" {
+    const gpa = std.testing.allocator;
+    const body =
+        \\{
+        \\  "plan_type": "prolite",
+        \\  "rate_limit": {
+        \\    "allowed": true,
+        \\    "limit_reached": false,
+        \\    "primary_window": {
+        \\      "used_percent": 7,
+        \\      "limit_window_seconds": 18000,
+        \\      "reset_after_seconds": 1200,
+        \\      "reset_at": 1773491460
+        \\    },
+        \\    "secondary_window": null
+        \\  }
+        \\}
+    ;
+
+    const snapshot = (try usage_api.parseUsageResponse(gpa, body)) orelse return error.TestExpectedEqual;
+    defer registry.freeRateLimitSnapshot(gpa, &snapshot);
+
+    try std.testing.expectEqual(registry.PlanType.prolite, snapshot.plan_type.?);
+}
+
 test "fetch usage for auth path groups non-chatgpt or incomplete auth as missing auth" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/usage_api.zig
+++ b/src/usage_api.zig
@@ -185,6 +185,7 @@ fn parsePlanType(v: std.json.Value) ?registry.PlanType {
 
     if (std.ascii.eqlIgnoreCase(plan_name, "free")) return .free;
     if (std.ascii.eqlIgnoreCase(plan_name, "plus")) return .plus;
+    if (std.ascii.eqlIgnoreCase(plan_name, "prolite")) return .prolite;
     if (std.ascii.eqlIgnoreCase(plan_name, "pro")) return .pro;
     if (std.ascii.eqlIgnoreCase(plan_name, "team")) return .team;
     if (std.ascii.eqlIgnoreCase(plan_name, "business")) return .business;


### PR DESCRIPTION
## Summary
- add `prolite` plan
- align CLI plan labels with openai/codex human-readable display names such as `Free`, `Plus`, `Pro`, and `Pro Lite`

## Why
The new `prolite` plan (Pro x5) is not parsed yet, so `codex-auth` falls back to
`unknown` instead of showing the actual plan in CLI output.

Codex already added support for the same raw plan type and human-readable display name here:
- https://github.com/openai/codex/pull/17419

## Verification
- zig build run -- list
- zig build test