### PR TITLE
fix: nodejs fetch proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npx @loongphy/codex-auth list
 > If you previously used those legacy installers, remove the leftover binaries and profile changes during migration.
 > API-backed usage refresh and team-name refresh use Node.js `fetch`.
 > npm installs already satisfy that requirement.
-> Legacy standalone binary installs need Node.js 18+ on `PATH` when `codex-auth config api enable` is used.
+> Legacy standalone binary installs need Node.js 22+ on `PATH` when `codex-auth config api enable` is used.
 
 ## Storage Root
 

--- a/bin/codex-auth.js
+++ b/bin/codex-auth.js
@@ -4,6 +4,21 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const rootPackageJsonPath = path.join(__dirname, "..", "package.json");
+const requiredNodeMajor = 22;
+
+function ensureSupportedNodeVersion() {
+  const major = Number(process.versions?.node?.split(".")[0] ?? 0);
+  if (Number.isInteger(major) && major >= requiredNodeMajor) {
+    return;
+  }
+
+  console.error(
+    `Node.js ${requiredNodeMajor}+ is required to run @loongphy/codex-auth. Current version: ${process.version}.`
+  );
+  process.exit(1);
+}
+
+ensureSupportedNodeVersion();
 
 const packageMap = {
   "linux:x64": "@loongphy/codex-auth-linux-x64",

--- a/docs/api-refresh.md
+++ b/docs/api-refresh.md
@@ -4,7 +4,8 @@ This document is the single source of truth for outbound ChatGPT API refresh beh
 
 All API refresh requests are issued through `Node.js fetch`.
 When `codex-auth` is launched from the npm package, the wrapper passes its current Node executable to the Zig binary.
-Legacy standalone binary installs must have Node.js 18+ available on `PATH` for API-backed refresh to work.
+Legacy standalone binary installs must have Node.js 22+ available on `PATH` for API-backed refresh to work.
+When `HTTP_PROXY` / `HTTPS_PROXY` are present, `codex-auth` enables Node environment-proxy support for the fetch child process automatically.
 
 ## Endpoints
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/src/chatgpt_http.zig
+++ b/src/chatgpt_http.zig
@@ -1,10 +1,15 @@
+const builtin = @import("builtin");
 const std = @import("std");
 
 pub const request_timeout_secs: []const u8 = "5";
 pub const request_timeout_ms: []const u8 = "5000";
+pub const request_timeout_ms_value: u64 = 5000;
+pub const child_process_timeout_ms: []const u8 = "7000";
+pub const child_process_timeout_ms_value: u64 = 7000;
 pub const browser_user_agent: []const u8 = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
 pub const node_executable_env = "CODEX_AUTH_NODE_EXECUTABLE";
-pub const node_requirement_hint = "Node.js 18+ is required for ChatGPT API refresh. Install Node.js 18+ or use the npm package.";
+pub const node_use_env_proxy_env = "NODE_USE_ENV_PROXY";
+pub const node_requirement_hint = "Node.js 22+ is required for ChatGPT API refresh. Install Node.js 22+ or use the npm package.";
 
 const max_output_bytes = 1024 * 1024;
 
@@ -30,10 +35,41 @@ const ChildCaptureResult = struct {
     term: std.process.Child.Term,
     stdout: []u8,
     stderr: []u8,
+    timed_out: bool = false,
 
     fn deinit(self: *const ChildCaptureResult, allocator: std.mem.Allocator) void {
         allocator.free(self.stdout);
         allocator.free(self.stderr);
+    }
+};
+
+const ChildProcessWatchdog = struct {
+    mutex: std.Thread.Mutex = .{},
+    completed: bool = false,
+    timed_out: bool = false,
+
+    fn run(self: *ChildProcessWatchdog, child_id: std.process.Child.Id, timeout_ms: u64) void {
+        std.Thread.sleep(timeout_ms * std.time.ns_per_ms);
+
+        self.mutex.lock();
+        if (self.completed) {
+            self.mutex.unlock();
+            return;
+        }
+        self.completed = true;
+        self.timed_out = true;
+        self.mutex.unlock();
+
+        terminateChildProcess(child_id);
+    }
+
+    fn finish(self: *ChildProcessWatchdog) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const timed_out = self.timed_out;
+        self.completed = true;
+        return timed_out;
     }
 };
 
@@ -51,8 +87,9 @@ const node_request_script =
     \\  process.stdout.write("\n");
     \\  process.stdout.write(outcome);
     \\};
-    \\if (typeof fetch !== "function" || typeof AbortSignal?.timeout !== "function") {
-    \\  emit("Node.js 18+ is required.", 0, "node-too-old");
+    \\const nodeMajor = Number(process.versions?.node?.split(".")[0] ?? 0);
+    \\if (!Number.isInteger(nodeMajor) || nodeMajor < 22 || typeof fetch !== "function" || typeof AbortSignal?.timeout !== "function") {
+    \\  emit("Node.js 22+ is required.", 0, "node-too-old");
     \\} else {
     \\  void (async () => {
     \\    try {
@@ -85,13 +122,26 @@ pub fn runGetJsonCommand(
     return runNodeGetJsonCommand(allocator, endpoint, access_token, account_id);
 }
 
+pub fn ensureNodeExecutableAvailable(allocator: std.mem.Allocator) !void {
+    const node_executable = try resolveNodeExecutableForLaunchAlloc(allocator);
+    defer allocator.free(node_executable);
+}
+
+pub fn resolveNodeExecutableAlloc(allocator: std.mem.Allocator) ![]u8 {
+    return resolveNodeExecutable(allocator);
+}
+
+pub fn resolveNodeExecutableForDebugAlloc(allocator: std.mem.Allocator) ![]u8 {
+    return resolveNodeExecutableForLaunchAlloc(allocator);
+}
+
 fn runNodeGetJsonCommand(
     allocator: std.mem.Allocator,
     endpoint: []const u8,
     access_token: []const u8,
     account_id: []const u8,
 ) !HttpResult {
-    const node_executable = try resolveNodeExecutable(allocator);
+    const node_executable = try resolveNodeExecutableForLaunchAlloc(allocator);
     defer allocator.free(node_executable);
 
     // Use an explicit wait path so failed output collection cannot strand zombies.
@@ -104,15 +154,17 @@ fn runNodeGetJsonCommand(
         account_id,
         request_timeout_ms,
         browser_user_agent,
-    }) catch |err| switch (err) {
+    }, child_process_timeout_ms_value) catch |err| switch (err) {
         error.OutOfMemory => return err,
         error.FileNotFound => {
             logNodeRequirement();
             return error.NodeJsRequired;
         },
-        else => return error.RequestFailed,
+        else => return err,
     };
     defer result.deinit(allocator);
+
+    if (result.timed_out) return error.NodeProcessTimedOut;
 
     switch (result.term) {
         .Exited => |code| if (code != 0) return error.RequestFailed,
@@ -142,8 +194,16 @@ fn runNodeGetJsonCommand(
     }
 }
 
-fn runChildCapture(allocator: std.mem.Allocator, argv: []const []const u8) !ChildCaptureResult {
+fn runChildCapture(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    timeout_ms: u64,
+) !ChildCaptureResult {
     var child = std.process.Child.init(argv, allocator);
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try maybeEnableNodeEnvProxy(&env_map);
+    child.env_map = &env_map;
     child.stdin_behavior = .Ignore;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
@@ -156,14 +216,36 @@ fn runChildCapture(allocator: std.mem.Allocator, argv: []const []const u8) !Chil
     try child.spawn();
     errdefer reapChildAfterError(&child);
 
+    var watchdog = ChildProcessWatchdog{};
+    const watchdog_thread = std.Thread.spawn(.{}, ChildProcessWatchdog.run, .{
+        &watchdog,
+        child.id,
+        timeout_ms,
+    }) catch null;
+    defer if (watchdog_thread) |thread| thread.join();
+
     try child.collectOutput(allocator, &stdout, &stderr, max_output_bytes);
     const term = try child.wait();
+    const timed_out = if (watchdog_thread != null) watchdog.finish() else false;
 
     return .{
         .term = term,
         .stdout = try stdout.toOwnedSlice(allocator),
         .stderr = try stderr.toOwnedSlice(allocator),
+        .timed_out = timed_out,
     };
+}
+
+fn terminateChildProcess(child_id: std.process.Child.Id) void {
+    switch (builtin.os.tag) {
+        .windows => {
+            std.os.windows.TerminateProcess(child_id, 1) catch {};
+        },
+        .wasi => {},
+        else => {
+            std.posix.kill(child_id, std.posix.SIG.KILL) catch {};
+        },
+    }
 }
 
 fn reapChildAfterError(child: *std.process.Child) void {
@@ -180,6 +262,107 @@ fn resolveNodeExecutable(allocator: std.mem.Allocator) ![]u8 {
         error.EnvironmentVariableNotFound => try allocator.dupe(u8, "node"),
         else => return err,
     };
+}
+
+fn maybeEnableNodeEnvProxy(env_map: *std.process.EnvMap) !void {
+    if (env_map.get(node_use_env_proxy_env) == null) {
+        const all_proxy = env_map.get("ALL_PROXY") orelse env_map.get("all_proxy");
+        if (all_proxy) |proxy| {
+            if (env_map.get("HTTP_PROXY") == null and env_map.get("http_proxy") == null) {
+                try env_map.put("HTTP_PROXY", proxy);
+            }
+            if (env_map.get("HTTPS_PROXY") == null and env_map.get("https_proxy") == null) {
+                try env_map.put("HTTPS_PROXY", proxy);
+            }
+        }
+
+        if (env_map.get("HTTP_PROXY") != null or
+            env_map.get("http_proxy") != null or
+            env_map.get("HTTPS_PROXY") != null or
+            env_map.get("https_proxy") != null)
+        {
+            try env_map.put(node_use_env_proxy_env, "1");
+        }
+    }
+}
+
+fn resolveNodeExecutableForLaunchAlloc(allocator: std.mem.Allocator) ![]u8 {
+    const node_executable = try resolveNodeExecutable(allocator);
+    defer allocator.free(node_executable);
+    return ensureExecutableAvailableAlloc(allocator, node_executable);
+}
+
+fn ensureExecutableAvailableAlloc(allocator: std.mem.Allocator, executable: []const u8) ![]u8 {
+    if (try resolveExecutableForLaunchAlloc(allocator, executable)) |resolved| return resolved;
+    logNodeRequirement();
+    return error.NodeJsRequired;
+}
+
+fn resolveExecutableForLaunchAlloc(allocator: std.mem.Allocator, executable: []const u8) !?[]u8 {
+    if (std.fs.path.isAbsolute(executable) or std.mem.indexOfAny(u8, executable, "/\\") != null) {
+        if (!accessPath(executable)) return null;
+        return try allocator.dupe(u8, executable);
+    }
+
+    const path_value = std.process.getEnvVarOwned(allocator, "PATH") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => return null,
+        else => return err,
+    };
+    defer allocator.free(path_value);
+
+    var path_it = std.mem.splitScalar(u8, path_value, std.fs.path.delimiter);
+    while (path_it.next()) |entry| {
+        if (entry.len == 0) continue;
+        if (try resolveExecutablePathEntryForLaunchAlloc(allocator, entry, executable)) |resolved| return resolved;
+    }
+
+    return null;
+}
+
+fn resolveExecutablePathEntryForLaunchAlloc(
+    allocator: std.mem.Allocator,
+    entry: []const u8,
+    executable: []const u8,
+) !?[]u8 {
+    const candidate = try std.fs.path.join(allocator, &[_][]const u8{ entry, executable });
+    defer allocator.free(candidate);
+
+    if (accessPath(candidate)) {
+        return try allocator.dupe(u8, candidate);
+    }
+
+    if (builtin.os.tag == .windows and std.fs.path.extension(executable).len == 0) {
+        const path_ext = std.process.getEnvVarOwned(allocator, "PATHEXT") catch |err| switch (err) {
+            error.EnvironmentVariableNotFound => try allocator.dupe(u8, ".COM;.EXE;.BAT;.CMD"),
+            else => return err,
+        };
+        defer allocator.free(path_ext);
+
+        var ext_it = std.mem.splitScalar(u8, path_ext, ';');
+        while (ext_it.next()) |raw_ext| {
+            if (raw_ext.len == 0) continue;
+            const ext = std.mem.trim(u8, raw_ext, " \t");
+            if (ext.len == 0) continue;
+
+            const ext_candidate = try std.fmt.allocPrint(allocator, "{s}{s}", .{ candidate, ext });
+            defer allocator.free(ext_candidate);
+
+            if (accessPath(ext_candidate)) {
+                return try allocator.dupe(u8, ext_candidate);
+            }
+        }
+    }
+
+    return null;
+}
+fn accessPath(path: []const u8) bool {
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.accessAbsolute(path, .{}) catch return false;
+        return true;
+    }
+
+    std.fs.cwd().access(path, .{}) catch return false;
+    return true;
 }
 
 fn logNodeRequirement() void {
@@ -242,3 +425,102 @@ test "parse node http output keeps timeout marker" {
     try std.testing.expectEqual(@as(usize, 0), parsed.body.len);
 }
 
+test "run child capture times out stalled child process" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const script_name = switch (builtin.os.tag) {
+        .windows => "stall.ps1",
+        else => "stall.sh",
+    };
+    const script_data = switch (builtin.os.tag) {
+        .windows =>
+        \\Start-Sleep -Seconds 30
+        ,
+        else =>
+        \\#!/bin/sh
+        \\sleep 30
+        ,
+    };
+
+    try tmp.dir.writeFile(.{
+        .sub_path = script_name,
+        .data = script_data,
+    });
+
+    if (builtin.os.tag != .windows) {
+        var script_file = try tmp.dir.openFile(script_name, .{ .mode = .read_write });
+        defer script_file.close();
+        try script_file.chmod(0o755);
+    }
+
+    const script_path = try tmp.dir.realpathAlloc(allocator, script_name);
+    defer allocator.free(script_path);
+
+    const argv: []const []const u8 = switch (builtin.os.tag) {
+        .windows => &[_][]const u8{ "pwsh.exe", "-NoLogo", "-NoProfile", "-File", script_path },
+        else => &[_][]const u8{script_path},
+    };
+
+    const result = try runChildCapture(allocator, argv, 100);
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.timed_out);
+}
+
+test "ensure executable available returns NodeJsRequired for missing path" {
+    try std.testing.expectError(
+        error.NodeJsRequired,
+        ensureExecutableAvailableAlloc(std.testing.allocator, "/definitely/missing/node"),
+    );
+}
+
+test "maybe enable node env proxy sets NODE_USE_ENV_PROXY when HTTP proxy is present" {
+    var env_map = std.process.EnvMap.init(std.testing.allocator);
+    defer env_map.deinit();
+
+    try env_map.put("HTTPS_PROXY", "http://127.0.0.1:7890");
+    try maybeEnableNodeEnvProxy(&env_map);
+
+    try std.testing.expectEqualStrings("1", env_map.get(node_use_env_proxy_env).?);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", env_map.get("HTTPS_PROXY").?);
+}
+
+test "maybe enable node env proxy maps ALL_PROXY when direct proxy vars are missing" {
+    var env_map = std.process.EnvMap.init(std.testing.allocator);
+    defer env_map.deinit();
+
+    try env_map.put("ALL_PROXY", "http://127.0.0.1:7890");
+    try maybeEnableNodeEnvProxy(&env_map);
+
+    try std.testing.expectEqualStrings("1", env_map.get(node_use_env_proxy_env).?);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", env_map.get("HTTP_PROXY").?);
+    try std.testing.expectEqualStrings("http://127.0.0.1:7890", env_map.get("HTTPS_PROXY").?);
+}
+
+test "launch path resolution preserves node symlink path" {
+    const allocator = std.testing.allocator;
+    const tmp_dir = std.testing.tmpDir(.{});
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const entry = try tmp_dir.dir.realpathAlloc(arena, ".");
+    const node_path = try std.fs.path.join(arena, &[_][]const u8{ entry, "node" });
+
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "node-real",
+        .data = "#!/bin/sh\nexit 0\n",
+    });
+    var real_file = try tmp_dir.dir.openFile("node-real", .{ .mode = .read_write });
+    defer real_file.close();
+    try real_file.chmod(0o755);
+    try tmp_dir.dir.symLink("node-real", "node", .{});
+
+    const resolved = (try resolveExecutablePathEntryForLaunchAlloc(allocator, entry, "node")) orelse return error.TestUnexpectedResult;
+    defer allocator.free(resolved);
+
+    try std.testing.expectEqualStrings(node_path, resolved);
+}

--- a/src/chatgpt_http.zig
+++ b/src/chatgpt_http.zig
@@ -516,7 +516,9 @@ test "launch path resolution preserves node symlink path" {
     });
     var real_file = try tmp_dir.dir.openFile("node-real", .{ .mode = .read_write });
     defer real_file.close();
-    try real_file.chmod(0o755);
+    if (builtin.os.tag != .windows) {
+        try real_file.chmod(0o755);
+    }
     try tmp_dir.dir.symLink("node-real", "node", .{});
 
     const resolved = (try resolveExecutablePathEntryForLaunchAlloc(allocator, entry, "node")) orelse return error.TestUnexpectedResult;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const account_api = @import("account_api.zig");
 const account_name_refresh = @import("account_name_refresh.zig");
 const cli = @import("cli.zig");
+const chatgpt_http = @import("chatgpt_http.zig");
 const display_rows = @import("display_rows.zig");
 const registry = @import("registry.zig");
 const auth = @import("auth.zig");
@@ -29,6 +30,7 @@ const ForegroundUsagePoolInitFn = *const fn (
     allocator: std.mem.Allocator,
     n_jobs: usize,
 ) anyerror!void;
+const NodeAvailabilityFn = *const fn (allocator: std.mem.Allocator) anyerror!void;
 const BackgroundRefreshLockAcquirer = *const fn (
     allocator: std.mem.Allocator,
     codex_home: []const u8,
@@ -79,14 +81,36 @@ pub const ForegroundUsageRefreshState = struct {
 
 const DebugUsageLabelState = struct {
     labels: [][]const u8,
-    display_order: []usize,
 
     fn deinit(self: *DebugUsageLabelState, allocator: std.mem.Allocator) void {
         for (self.labels) |label| allocator.free(@constCast(label));
         allocator.free(self.labels);
-        allocator.free(self.display_order);
         self.* = undefined;
     }
+};
+
+pub const ForegroundUsageDebugLogger = struct {
+    writer: *std.Io.Writer,
+    mutex: std.Thread.Mutex = .{},
+
+    pub fn init(writer: *std.Io.Writer) ForegroundUsageDebugLogger {
+        return .{
+            .writer = writer,
+        };
+    }
+
+    pub fn print(self: *ForegroundUsageDebugLogger, comptime fmt: []const u8, args: anytype) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        try self.writer.print(fmt, args);
+        try self.writer.flush();
+    }
+};
+
+const ForegroundUsageDebugContext = struct {
+    logger: *ForegroundUsageDebugLogger,
+    label_state: *const DebugUsageLabelState,
 };
 
 pub fn main() !void {
@@ -158,6 +182,7 @@ fn runMain() !void {
 fn isHandledCliError(err: anyerror) bool {
     return err == error.AccountNotFound or
         err == error.CodexLoginFailed or
+        err == error.NodeJsRequired or
         err == error.RemoveConfirmationUnavailable or
         err == error.RemoveSelectionRequiresTty or
         err == error.InvalidRemoveSelectionInput;
@@ -288,12 +313,13 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcher(
     reg: *registry.Registry,
     usage_fetcher: UsageFetchDetailedFn,
 ) !ForegroundUsageRefreshState {
-    return refreshForegroundUsageForDisplayWithApiFetcherWithPoolInit(
+    return refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
         allocator,
         codex_home,
         reg,
         usage_fetcher,
         initForegroundUsagePool,
+        null,
     );
 }
 
@@ -304,18 +330,61 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInit(
     usage_fetcher: UsageFetchDetailedFn,
     pool_init: ForegroundUsagePoolInitFn,
 ) !ForegroundUsageRefreshState {
+    return refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
+        allocator,
+        codex_home,
+        reg,
+        usage_fetcher,
+        pool_init,
+        null,
+    );
+}
+
+pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    usage_fetcher: UsageFetchDetailedFn,
+    pool_init: ForegroundUsagePoolInitFn,
+    debug_logger: ?*ForegroundUsageDebugLogger,
+) !ForegroundUsageRefreshState {
     var state = try initForegroundUsageRefreshState(allocator, reg.accounts.items.len);
     errdefer state.deinit(allocator);
+
+    var debug_label_state: ?DebugUsageLabelState = null;
+    defer if (debug_label_state) |*label_state| label_state.deinit(allocator);
+
+    var debug_context: ?ForegroundUsageDebugContext = null;
 
     if (!reg.api.usage) {
         state.local_only_mode = true;
         if (try auto.refreshActiveUsage(allocator, codex_home, reg)) {
             try registry.saveRegistry(allocator, codex_home, reg);
         }
+        if (debug_logger) |logger| {
+            try logger.print("[debug] usage refresh skipped: mode=local-only; only the active account can refresh from local rollout data\n", .{});
+            try printForegroundUsageDebugDone(logger, &state);
+        }
         return state;
     }
 
-    if (reg.accounts.items.len == 0) return state;
+    if (debug_logger) |logger| {
+        debug_label_state = try buildDebugUsageLabelState(allocator, reg);
+        debug_context = .{
+            .logger = logger,
+            .label_state = &debug_label_state.?,
+        };
+        const node_executable = try chatgpt_http.resolveNodeExecutableForDebugAlloc(allocator);
+        defer allocator.free(node_executable);
+        try printForegroundUsageDebugStart(logger, reg.accounts.items.len, node_executable);
+    }
+
+    if (reg.accounts.items.len == 0) {
+        if (debug_logger) |logger| {
+            try printForegroundUsageDebugDone(logger, &state);
+        }
+        return state;
+    }
 
     const worker_results = try allocator.alloc(ForegroundUsageWorkerResult, reg.accounts.items.len);
     defer {
@@ -325,7 +394,7 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInit(
     for (worker_results) |*worker_result| worker_result.* = .{};
 
     if (reg.accounts.items.len <= 1) {
-        runForegroundUsageRefreshWorkersSerially(allocator, codex_home, reg, usage_fetcher, worker_results);
+        runForegroundUsageRefreshWorkersSerially(allocator, codex_home, reg, usage_fetcher, worker_results, debug_context);
     } else {
         var thread_safe_allocator: std.heap.ThreadSafeAllocator = .{ .child_allocator = allocator };
         const thread_allocator = thread_safe_allocator.allocator();
@@ -347,6 +416,9 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInit(
 
             var wait_group: std.Thread.WaitGroup = .{};
             for (reg.accounts.items, 0..) |_, idx| {
+                if (debug_context) |debug| {
+                    try printForegroundUsageDebugRequest(debug.logger, reg, idx, debug.label_state.labels[idx]);
+                }
                 pool.spawnWg(&wait_group, foregroundUsageRefreshWorker, .{
                     thread_allocator,
                     codex_home,
@@ -354,11 +426,12 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInit(
                     idx,
                     usage_fetcher,
                     worker_results,
+                    debug_context,
                 });
             }
             wait_group.wait();
         } else {
-            runForegroundUsageRefreshWorkersSerially(allocator, codex_home, reg, usage_fetcher, worker_results);
+            runForegroundUsageRefreshWorkersSerially(allocator, codex_home, reg, usage_fetcher, worker_results, debug_context);
         }
     }
 
@@ -398,6 +471,10 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInit(
         try registry.saveRegistry(allocator, codex_home, reg);
     }
 
+    if (debug_logger) |logger| {
+        try printForegroundUsageDebugDone(logger, &state);
+    }
+
     return state;
 }
 
@@ -418,9 +495,13 @@ fn runForegroundUsageRefreshWorkersSerially(
     reg: *registry.Registry,
     usage_fetcher: UsageFetchDetailedFn,
     results: []ForegroundUsageWorkerResult,
+    debug_context: ?ForegroundUsageDebugContext,
 ) void {
     for (reg.accounts.items, 0..) |_, idx| {
-        foregroundUsageRefreshWorker(allocator, codex_home, reg, idx, usage_fetcher, results);
+        if (debug_context) |debug| {
+            printForegroundUsageDebugRequest(debug.logger, reg, idx, debug.label_state.labels[idx]) catch {};
+        }
+        foregroundUsageRefreshWorker(allocator, codex_home, reg, idx, usage_fetcher, results, debug_context);
     }
 }
 
@@ -431,6 +512,7 @@ fn foregroundUsageRefreshWorker(
     account_idx: usize,
     usage_fetcher: UsageFetchDetailedFn,
     results: []ForegroundUsageWorkerResult,
+    debug_context: ?ForegroundUsageDebugContext,
 ) void {
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
@@ -438,11 +520,29 @@ fn foregroundUsageRefreshWorker(
 
     const auth_path = registry.accountAuthPath(arena, codex_home, reg.accounts.items[account_idx].account_key) catch |err| {
         results[account_idx] = .{ .error_name = @errorName(err) };
+        if (debug_context) |debug| {
+            printForegroundUsageDebugWorkerResult(
+                arena,
+                debug.logger,
+                debug.label_state.labels[account_idx],
+                reg.accounts.items[account_idx].last_usage,
+                results[account_idx],
+            );
+        }
         return;
     };
 
     const fetch_result = usage_fetcher(arena, auth_path) catch |err| {
         results[account_idx] = .{ .error_name = @errorName(err) };
+        if (debug_context) |debug| {
+            printForegroundUsageDebugWorkerResult(
+                arena,
+                debug.logger,
+                debug.label_state.labels[account_idx],
+                reg.accounts.items[account_idx].last_usage,
+                results[account_idx],
+            );
+        }
         return;
     };
 
@@ -458,11 +558,29 @@ fn foregroundUsageRefreshWorker(
                 .missing_auth = fetch_result.missing_auth,
                 .error_name = @errorName(err),
             };
+            if (debug_context) |debug| {
+                printForegroundUsageDebugWorkerResult(
+                    arena,
+                    debug.logger,
+                    debug.label_state.labels[account_idx],
+                    reg.accounts.items[account_idx].last_usage,
+                    results[account_idx],
+                );
+            }
             return;
         };
     }
 
     results[account_idx] = result;
+    if (debug_context) |debug| {
+        printForegroundUsageDebugWorkerResult(
+            arena,
+            debug.logger,
+            debug.label_state.labels[account_idx],
+            reg.accounts.items[account_idx].last_usage,
+            result,
+        );
+    }
 }
 
 fn setForegroundUsageOverrideForOutcome(
@@ -502,9 +620,6 @@ fn buildDebugUsageLabelState(
 
     var display = try display_rows.buildDisplayRows(allocator, reg, null);
     defer display.deinit(allocator);
-    var display_order = std.ArrayList(usize).empty;
-    defer display_order.deinit(allocator);
-
     for (display.rows) |row| {
         const account_idx = row.account_index orelse continue;
         const next_label = if (row.depth == 0)
@@ -516,30 +631,28 @@ fn buildDebugUsageLabelState(
             });
         allocator.free(@constCast(labels[account_idx]));
         labels[account_idx] = next_label;
-        try display_order.append(allocator, account_idx);
     }
 
     return .{
         .labels = labels,
-        .display_order = try display_order.toOwnedSlice(allocator),
     };
 }
 
-fn debugStatusLabel(buf: *[32]u8, outcome: ForegroundUsageOutcome) []const u8 {
-    if (outcome.error_name) |error_name| return error_name;
-    if (outcome.missing_auth) return "MissingAuth";
-    if (outcome.status_code) |status_code| {
+fn debugWorkerStatusLabel(buf: *[32]u8, result: ForegroundUsageWorkerResult) []const u8 {
+    if (result.error_name) |error_name| return error_name;
+    if (result.missing_auth) return "MissingAuth";
+    if (result.status_code) |status_code| {
         return std.fmt.bufPrint(buf, "{d}", .{status_code}) catch "-";
     }
-    return if (outcome.has_usage_windows) "200" else "-";
+    return if (result.snapshot != null) "200" else "-";
 }
 
-fn outcomeHasNoUsageWindow(outcome: ForegroundUsageOutcome) bool {
-    return outcome.error_name == null and
-        !outcome.missing_auth and
-        !outcome.has_usage_windows and
-        outcome.status_code != null and
-        outcome.status_code.? == 200;
+fn workerResultHasNoUsageWindow(result: ForegroundUsageWorkerResult) bool {
+    return result.error_name == null and
+        !result.missing_auth and
+        result.snapshot == null and
+        result.status_code != null and
+        result.status_code.? == 200;
 }
 
 fn formatRemainingPercentAlloc(
@@ -550,77 +663,121 @@ fn formatRemainingPercentAlloc(
     return std.fmt.allocPrint(allocator, "{d}%", .{remaining});
 }
 
-fn printForegroundUsageDebug(
-    allocator: std.mem.Allocator,
-    reg: *const registry.Registry,
-    state: *const ForegroundUsageRefreshState,
+fn printForegroundUsageDebugStart(
+    logger: *ForegroundUsageDebugLogger,
+    account_count: usize,
+    node_executable: []const u8,
 ) !void {
-    var stdout: io_util.Stdout = undefined;
-    stdout.init();
-    const out = stdout.out();
-
-    if (state.local_only_mode) {
-        try out.writeAll("[debug] usage refresh skipped: mode=local-only; only the active account can refresh from local rollout data\n");
-        try out.flush();
-        return;
-    }
-
-    var label_state = try buildDebugUsageLabelState(allocator, reg);
-    defer label_state.deinit(allocator);
-
-    try out.print(
-        "[debug] usage refresh start: accounts={d} concurrency={d}\n",
+    try logger.print(
+        "[debug] usage refresh start: accounts={d} concurrency={d} timeout_ms={s} child_timeout_ms={s} endpoint={s} node={s}\n",
         .{
-            reg.accounts.items.len,
-            @min(reg.accounts.items.len, foreground_usage_refresh_concurrency),
+            account_count,
+            @min(account_count, foreground_usage_refresh_concurrency),
+            chatgpt_http.request_timeout_ms,
+            chatgpt_http.child_process_timeout_ms,
+            usage_api.default_usage_endpoint,
+            node_executable,
         },
     );
+}
 
-    for (label_state.display_order) |account_idx| {
-        if (!state.outcomes[account_idx].attempted) continue;
-        try out.print("[debug] request usage: {s}\n", .{label_state.labels[account_idx]});
-    }
-
-    for (label_state.display_order) |account_idx| {
-        const outcome = state.outcomes[account_idx];
-        if (!outcome.attempted) continue;
-
-        var status_buf: [32]u8 = undefined;
-        try out.print(
-            "[debug] response usage: {s} status={s}",
-            .{
-                label_state.labels[account_idx],
-                debugStatusLabel(&status_buf, outcome),
-            },
-        );
-        if (outcomeHasNoUsageWindow(outcome)) {
-            try out.writeAll(" result=no-usage-limits-window");
-        }
-        try out.writeAll("\n");
-
-        if (outcome.updated) {
-            const rate_5h = registry.resolveRateWindow(reg.accounts.items[account_idx].last_usage, 300, true);
-            const rate_weekly = registry.resolveRateWindow(reg.accounts.items[account_idx].last_usage, 10080, false);
-            const rate_5h_text = try formatRemainingPercentAlloc(allocator, rate_5h);
-            defer allocator.free(rate_5h_text);
-            const rate_weekly_text = try formatRemainingPercentAlloc(allocator, rate_weekly);
-            defer allocator.free(rate_weekly_text);
-            try out.print(
-                "[debug] updated usage: {s} 5h={s} weekly={s}\n",
-                .{
-                    label_state.labels[account_idx],
-                    rate_5h_text,
-                    rate_weekly_text,
-                },
-            );
-        }
-    }
-
-    try out.print(
+fn printForegroundUsageDebugDone(logger: *ForegroundUsageDebugLogger, state: *const ForegroundUsageRefreshState) !void {
+    try logger.print(
         "[debug] usage refresh done: attempted={d} updated={d} failed={d} unchanged={d}\n",
         .{ state.attempted, state.updated, state.failed, state.unchanged },
     );
-    try out.flush();
+}
+
+fn printForegroundUsageDebugRequest(
+    logger: *ForegroundUsageDebugLogger,
+    reg: *const registry.Registry,
+    account_idx: usize,
+    label: []const u8,
+) !void {
+    try logger.print(
+        "[debug] request usage: {s} account_id={s}\n",
+        .{
+            label,
+            reg.accounts.items[account_idx].chatgpt_account_id,
+        },
+    );
+}
+
+fn printForegroundUsageDebugWorkerResult(
+    allocator: std.mem.Allocator,
+    logger: *ForegroundUsageDebugLogger,
+    label: []const u8,
+    previous_snapshot: ?registry.RateLimitSnapshot,
+    result: ForegroundUsageWorkerResult,
+) void {
+    var status_buf: [32]u8 = undefined;
+    if (workerResultHasNoUsageWindow(result)) {
+        logger.print(
+            "[debug] response usage: {s} status={s} result=no-usage-limits-window\n",
+            .{
+                label,
+                debugWorkerStatusLabel(&status_buf, result),
+            },
+        ) catch return;
+    } else if (result.snapshot != null) {
+        logger.print(
+            "[debug] response usage: {s} status={s} result=usage-windows\n",
+            .{
+                label,
+                debugWorkerStatusLabel(&status_buf, result),
+            },
+        ) catch return;
+    } else if (result.missing_auth) {
+        logger.print(
+            "[debug] response usage: {s} status={s} result=missing-auth\n",
+            .{
+                label,
+                debugWorkerStatusLabel(&status_buf, result),
+            },
+        ) catch return;
+    } else if (result.error_name != null) {
+        const result_kind = if (std.mem.eql(u8, result.error_name.?, "NodeProcessTimedOut"))
+            "node-process-timeout"
+        else if (std.mem.eql(u8, result.error_name.?, "NodeJsRequired"))
+            "node-launch-failed"
+        else
+            "error";
+        logger.print(
+            "[debug] response usage: {s} status={s} result={s}\n",
+            .{
+                label,
+                debugWorkerStatusLabel(&status_buf, result),
+                result_kind,
+            },
+        ) catch return;
+    } else {
+        logger.print(
+            "[debug] response usage: {s} status={s} result=http-response\n",
+            .{
+                label,
+                debugWorkerStatusLabel(&status_buf, result),
+            },
+        ) catch return;
+    }
+
+    const snapshot = result.snapshot orelse return;
+    if (registry.rateLimitSnapshotsEqual(previous_snapshot, snapshot)) return;
+
+    const rate_5h = registry.resolveRateWindow(snapshot, 300, true);
+    const rate_weekly = registry.resolveRateWindow(snapshot, 10080, false);
+    const rate_5h_text = formatRemainingPercentAlloc(allocator, rate_5h) catch return;
+    defer allocator.free(rate_5h_text);
+    const rate_weekly_text = formatRemainingPercentAlloc(allocator, rate_weekly) catch return;
+    defer allocator.free(rate_weekly_text);
+
+    logger.print(
+        "[debug] updated usage: {s} 5h={s} weekly={s}\n",
+        .{
+            label,
+            rate_5h_text,
+            rate_weekly_text,
+        },
+    ) catch {};
 }
 
 pub fn maybeRefreshForegroundAccountNames(
@@ -731,6 +888,62 @@ pub fn refreshAccountNamesForList(
 fn shouldRefreshTeamAccountNamesForUserScope(reg: *registry.Registry, chatgpt_user_id: []const u8) bool {
     if (!reg.api.account) return false;
     return registry.shouldFetchTeamAccountNamesForUser(reg, chatgpt_user_id);
+}
+
+fn shouldPreflightNodeForAccountNameRefresh(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+) !bool {
+    switch (target) {
+        .list, .switch_account => {},
+        .remove_account => return false,
+    }
+
+    const active_user_id = registry.activeChatgptUserId(reg) orelse return false;
+    if (!shouldRefreshTeamAccountNamesForUserScope(reg, active_user_id)) return false;
+
+    var info = (try loadActiveAuthInfoForAccountRefresh(allocator, codex_home)) orelse return false;
+    defer info.deinit(allocator);
+
+    return info.access_token != null and info.chatgpt_account_id != null;
+}
+
+fn shouldPreflightNodeForForegroundTarget(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+) !bool {
+    if (shouldRefreshForegroundUsage(target) and reg.api.usage and reg.accounts.items.len > 0) return true;
+    return try shouldPreflightNodeForAccountNameRefresh(allocator, codex_home, reg, target);
+}
+
+fn ensureForegroundNodeAvailable(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+) !void {
+    try ensureForegroundNodeAvailableWithChecker(
+        allocator,
+        codex_home,
+        reg,
+        target,
+        chatgpt_http.ensureNodeExecutableAvailable,
+    );
+}
+
+fn ensureForegroundNodeAvailableWithChecker(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+    checker: NodeAvailabilityFn,
+) !void {
+    if (!try shouldPreflightNodeForForegroundTarget(allocator, codex_home, reg, target)) return;
+    try checker(allocator);
 }
 
 pub fn shouldScheduleBackgroundAccountNameRefresh(reg: *registry.Registry) bool {
@@ -922,17 +1135,24 @@ fn handleList(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.Li
     if (try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg)) {
         try registry.saveRegistry(allocator, codex_home, &reg);
     }
-    var usage_state = try refreshForegroundUsageForDisplayWithApiFetcher(
+    try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .list);
+    var debug_stdout: io_util.Stdout = undefined;
+    var debug_logger: ?ForegroundUsageDebugLogger = null;
+    if (opts.debug) {
+        debug_stdout.init();
+        debug_logger = ForegroundUsageDebugLogger.init(debug_stdout.out());
+    }
+
+    var usage_state = try refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
         allocator,
         codex_home,
         &reg,
         usage_api.fetchUsageForAuthPathDetailed,
+        initForegroundUsagePool,
+        if (debug_logger) |*logger| logger else null,
     );
     defer usage_state.deinit(allocator);
     try maybeRefreshForegroundAccountNames(allocator, codex_home, &reg, .list, defaultAccountFetcher);
-    if (opts.debug) {
-        try printForegroundUsageDebug(allocator, &reg, &usage_state);
-    }
     try format.printAccountsWithUsageOverrides(&reg, usage_state.usage_overrides);
 }
 
@@ -1004,6 +1224,7 @@ fn handleSwitch(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
     if (try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg)) {
         try registry.saveRegistry(allocator, codex_home, &reg);
     }
+    try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .switch_account);
     var usage_state = try refreshForegroundUsageForDisplayWithApiFetcher(
         allocator,
         codex_home,
@@ -1318,6 +1539,188 @@ test "background account-name refresh returns early when another refresh holds t
         TestState.lockUnavailable,
     );
     try std.testing.expectEqual(@as(usize, 0), TestState.fetch_count);
+}
+
+test "foreground node preflight fails fast when usage refresh needs node" {
+    const TestState = struct {
+        var check_count: usize = 0;
+
+        fn missingNode(allocator: std.mem.Allocator) !void {
+            _ = allocator;
+            check_count += 1;
+            return error.NodeJsRequired;
+        }
+    };
+
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+
+    var reg = registry.Registry{
+        .schema_version = registry.current_schema_version,
+        .active_account_key = null,
+        .active_account_activated_at_ms = null,
+        .auto_switch = registry.defaultAutoSwitchConfig(),
+        .api = registry.defaultApiConfig(),
+        .accounts = std.ArrayList(registry.AccountRecord).empty,
+    };
+    defer reg.deinit(gpa);
+
+    try reg.accounts.append(gpa, .{
+        .account_key = try gpa.dupe(u8, "user-1::acct-1"),
+        .chatgpt_account_id = try gpa.dupe(u8, "acct-1"),
+        .chatgpt_user_id = try gpa.dupe(u8, "user-1"),
+        .email = try gpa.dupe(u8, "alpha@example.com"),
+        .alias = try gpa.dupe(u8, ""),
+        .account_name = null,
+        .plan = .plus,
+        .auth_mode = .chatgpt,
+        .created_at = 1,
+        .last_used_at = null,
+        .last_usage = null,
+        .last_usage_at = null,
+        .last_local_rollout = null,
+    });
+
+    TestState.check_count = 0;
+    try std.testing.expectError(
+        error.NodeJsRequired,
+        ensureForegroundNodeAvailableWithChecker(gpa, codex_home, &reg, .list, TestState.missingNode),
+    );
+    try std.testing.expectEqual(@as(usize, 1), TestState.check_count);
+}
+
+test "foreground node preflight fails fast when account-name refresh needs node" {
+    const TestState = struct {
+        var check_count: usize = 0;
+
+        fn missingNode(allocator: std.mem.Allocator) !void {
+            _ = allocator;
+            check_count += 1;
+            return error.NodeJsRequired;
+        }
+
+        fn appendAccount(
+            allocator: std.mem.Allocator,
+            reg: *registry.Registry,
+            record_key: []const u8,
+            email: []const u8,
+            plan: registry.PlanType,
+        ) !void {
+            const sep = std.mem.lastIndexOf(u8, record_key, "::") orelse return error.InvalidRecordKey;
+            const user_id = record_key[0..sep];
+            const account_id = record_key[sep + 2 ..];
+            try reg.accounts.append(allocator, .{
+                .account_key = try allocator.dupe(u8, record_key),
+                .chatgpt_account_id = try allocator.dupe(u8, account_id),
+                .chatgpt_user_id = try allocator.dupe(u8, user_id),
+                .email = try allocator.dupe(u8, email),
+                .alias = try allocator.dupe(u8, ""),
+                .account_name = null,
+                .plan = plan,
+                .auth_mode = .chatgpt,
+                .created_at = 1,
+                .last_used_at = null,
+                .last_usage = null,
+                .last_usage_at = null,
+                .last_local_rollout = null,
+            });
+        }
+
+        fn authJsonWithIds(
+            allocator: std.mem.Allocator,
+            email: []const u8,
+            plan: []const u8,
+            chatgpt_user_id: []const u8,
+            chatgpt_account_id: []const u8,
+        ) ![]u8 {
+            const encoder = std.base64.url_safe_no_pad.Encoder;
+            const header = "{\"alg\":\"none\",\"typ\":\"JWT\"}";
+            const payload = try std.fmt.allocPrint(
+                allocator,
+                "{{\"email\":\"{s}\",\"https://api.openai.com/auth\":{{\"chatgpt_account_id\":\"{s}\",\"chatgpt_user_id\":\"{s}\",\"user_id\":\"{s}\",\"chatgpt_plan_type\":\"{s}\"}}}}",
+                .{ email, chatgpt_account_id, chatgpt_user_id, chatgpt_user_id, plan },
+            );
+            defer allocator.free(payload);
+
+            const header_b64 = try allocator.alloc(u8, encoder.calcSize(header.len));
+            defer allocator.free(header_b64);
+            _ = encoder.encode(header_b64, header);
+            const payload_b64 = try allocator.alloc(u8, encoder.calcSize(payload.len));
+            defer allocator.free(payload_b64);
+            _ = encoder.encode(payload_b64, payload);
+            const jwt = try std.mem.concat(allocator, u8, &[_][]const u8{ header_b64, ".", payload_b64, ".sig" });
+            defer allocator.free(jwt);
+
+            return try std.fmt.allocPrint(
+                allocator,
+                "{{\"tokens\":{{\"access_token\":\"access-{s}\",\"account_id\":\"{s}\",\"id_token\":\"{s}\"}}}}",
+                .{ email, chatgpt_account_id, jwt },
+            );
+        }
+
+        fn writeActiveAuth(
+            allocator: std.mem.Allocator,
+            codex_home: []const u8,
+            email: []const u8,
+            plan: []const u8,
+            chatgpt_user_id: []const u8,
+            chatgpt_account_id: []const u8,
+        ) !void {
+            const auth_path = try registry.activeAuthPath(allocator, codex_home);
+            defer allocator.free(auth_path);
+
+            const auth_json = try authJsonWithIds(
+                allocator,
+                email,
+                plan,
+                chatgpt_user_id,
+                chatgpt_account_id,
+            );
+            defer allocator.free(auth_json);
+            try std.fs.cwd().writeFile(.{ .sub_path = auth_path, .data = auth_json });
+        }
+    };
+
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+
+    var reg = registry.Registry{
+        .schema_version = registry.current_schema_version,
+        .active_account_key = null,
+        .active_account_activated_at_ms = null,
+        .auto_switch = registry.defaultAutoSwitchConfig(),
+        .api = registry.defaultApiConfig(),
+        .accounts = std.ArrayList(registry.AccountRecord).empty,
+    };
+    defer reg.deinit(gpa);
+    reg.api.usage = false;
+
+    const user_id = "user-shared";
+    const primary_record_key = "user-shared::acct-primary";
+    const secondary_record_key = "user-shared::acct-secondary";
+    try TestState.appendAccount(gpa, &reg, primary_record_key, "team@example.com", .team);
+    try TestState.appendAccount(gpa, &reg, secondary_record_key, "team@example.com", .team);
+    try registry.setActiveAccountKey(gpa, &reg, primary_record_key);
+    try TestState.writeActiveAuth(gpa, codex_home, "team@example.com", "team", user_id, "acct-primary");
+
+    TestState.check_count = 0;
+    try std.testing.expectError(
+        error.NodeJsRequired,
+        ensureForegroundNodeAvailableWithChecker(gpa, codex_home, &reg, .list, TestState.missingNode),
+    );
+    try std.testing.expectEqual(@as(usize, 1), TestState.check_count);
+}
+
+test "handled cli errors include missing node" {
+    try std.testing.expect(isHandledCliError(error.NodeJsRequired));
 }
 
 // Tests live in separate files but are pulled in by main.zig for zig test.

--- a/src/tests/main_test.zig
+++ b/src/tests/main_test.zig
@@ -522,6 +522,140 @@ test "Scenario: Given thread pool init failure when refreshing foreground usage 
     try std.testing.expectEqual(@as(f64, 22), reg.accounts.items[0].last_usage.?.primary.?.used_percent);
 }
 
+test "Scenario: Given debug usage refresh when listing then request and response details stream in refresh order" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+
+    const TestUsageFetcher = struct {
+        fn snapshot(plan: registry.PlanType, used_5h: f64, used_weekly: f64) registry.RateLimitSnapshot {
+            return .{
+                .primary = .{
+                    .used_percent = used_5h,
+                    .window_minutes = 300,
+                    .resets_at = 4773491460,
+                },
+                .secondary = .{
+                    .used_percent = used_weekly,
+                    .window_minutes = 10080,
+                    .resets_at = 4773749620,
+                },
+                .credits = null,
+                .plan_type = plan,
+            };
+        }
+
+        fn fetch(allocator: std.mem.Allocator, auth_path: []const u8) !usage_api.UsageFetchResult {
+            var info = try auth_mod.parseAuthInfo(allocator, auth_path);
+            defer info.deinit(allocator);
+
+            const account_id = info.chatgpt_account_id orelse return .{
+                .snapshot = null,
+                .status_code = null,
+                .missing_auth = true,
+            };
+
+            if (std.mem.eql(u8, account_id, primary_account_id)) {
+                return .{
+                    .snapshot = snapshot(.team, 18, 39),
+                    .status_code = 200,
+                };
+            }
+            if (std.mem.eql(u8, account_id, secondary_account_id)) {
+                return .{
+                    .snapshot = null,
+                    .status_code = 403,
+                };
+            }
+            return .{
+                .snapshot = null,
+                .status_code = 404,
+            };
+        }
+
+        fn failPoolInit(
+            pool: *std.Thread.Pool,
+            allocator: std.mem.Allocator,
+            n_jobs: usize,
+        ) !void {
+            _ = pool;
+            _ = allocator;
+            _ = n_jobs;
+            return error.ThreadQuotaExceeded;
+        }
+    };
+
+    var reg = makeRegistry();
+    defer reg.deinit(gpa);
+    try appendAccount(gpa, &reg, primary_record_key, "alpha@example.com", "", .team);
+    try appendAccount(gpa, &reg, secondary_record_key, "beta@example.com", "", .team);
+    try registry.setActiveAccountKey(gpa, &reg, primary_record_key);
+
+    try writeAccountSnapshotWithIds(gpa, codex_home, "alpha@example.com", "team", shared_user_id, primary_account_id);
+    try writeAccountSnapshotWithIds(gpa, codex_home, "beta@example.com", "team", shared_user_id, secondary_account_id);
+
+    var debug_output: std.Io.Writer.Allocating = .init(gpa);
+    defer debug_output.deinit();
+    var debug_logger = main_mod.ForegroundUsageDebugLogger.init(&debug_output.writer);
+
+    var state = try main_mod.refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
+        gpa,
+        codex_home,
+        &reg,
+        TestUsageFetcher.fetch,
+        TestUsageFetcher.failPoolInit,
+        &debug_logger,
+    );
+    defer state.deinit(gpa);
+
+    const debug_text = debug_output.written();
+    const start_idx = std.mem.indexOf(
+        u8,
+        debug_text,
+        "[debug] usage refresh start: accounts=2 concurrency=2 timeout_ms=5000 child_timeout_ms=7000 endpoint=https://chatgpt.com/backend-api/wham/usage node=",
+    ) orelse return error.TestExpectedEqual;
+    const request_primary_idx = std.mem.indexOf(
+        u8,
+        debug_text,
+        "[debug] request usage: alpha@example.com account_id=67fe2bbb-0de6-49a4-b2b3-d1df366d1faf\n",
+    ) orelse return error.TestExpectedEqual;
+    const response_primary_idx = std.mem.indexOf(
+        u8,
+        debug_text,
+        "[debug] response usage: alpha@example.com status=200 result=usage-windows\n",
+    ) orelse return error.TestExpectedEqual;
+    const updated_primary_idx = std.mem.indexOf(
+        u8,
+        debug_text,
+        "[debug] updated usage: alpha@example.com ",
+    ) orelse return error.TestExpectedEqual;
+    const request_secondary_idx = std.mem.indexOf(
+        u8,
+        debug_text,
+        "[debug] request usage: beta@example.com account_id=518a44d9-ba75-4bad-87e5-ae9377042960\n",
+    ) orelse return error.TestExpectedEqual;
+    const response_secondary_idx = std.mem.indexOf(
+        u8,
+        debug_text,
+        "[debug] response usage: beta@example.com status=403 result=http-response\n",
+    ) orelse return error.TestExpectedEqual;
+    const done_idx = std.mem.indexOf(
+        u8,
+        debug_text,
+        "[debug] usage refresh done: attempted=2 updated=1 failed=1 unchanged=0\n",
+    ) orelse return error.TestExpectedEqual;
+
+    try std.testing.expect(start_idx < request_primary_idx);
+    try std.testing.expect(request_primary_idx < response_primary_idx);
+    try std.testing.expect(response_primary_idx < updated_primary_idx);
+    try std.testing.expect(updated_primary_idx < request_secondary_idx);
+    try std.testing.expect(request_secondary_idx < response_secondary_idx);
+    try std.testing.expect(response_secondary_idx < done_idx);
+}
+
 test "Scenario: Given list with missing team names when running foreground account-name refresh then it waits and saves the updated names" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
## Summary
- add real-time `list --debug` request and response logging
- fail fast when the required Node runtime is unavailable
- add a Node child-process watchdog and enable proxy-aware API refreshes
- Nodejs 22+ required