### PR TITLE
fix: align remove usage refresh with switch

### DIFF
--- a/docs/api-refresh.md
+++ b/docs/api-refresh.md
@@ -33,11 +33,12 @@ The `accounts/check` response is parsed by `chatgpt_account_id`. `name: null` an
 
 - `api.usage = true`: foreground refresh uses the usage API.
 - `api.usage = false`: foreground refresh reads only the newest local `~/.codex/sessions/**/rollout-*.jsonl`.
-- when `api.usage = true`, `list` and interactive `switch` refresh all stored accounts before rendering, using stored auth snapshots under `accounts/` with a maximum concurrency of `3`
-- when one of those per-account foreground usage requests returns a non-`200` HTTP status, the corresponding `list` / `switch` row shows that response status in both usage columns until a later successful refresh replaces it
-- when a stored account snapshot cannot make a ChatGPT usage request because it is missing the required ChatGPT auth fields, the corresponding `list` / `switch` row shows `MissingAuth` in both usage columns until a later successful refresh replaces it
+- when `api.usage = true`, `list`, interactive `switch`, and `remove` without a query or `--all` refresh all stored accounts before rendering, using stored auth snapshots under `accounts/` with a maximum concurrency of `3`
+- when one of those per-account foreground usage requests returns a non-`200` HTTP status, the corresponding `list` / `switch` / `remove` row shows that response status in both usage columns until a later successful refresh replaces it
+- when a stored account snapshot cannot make a ChatGPT usage request because it is missing the required ChatGPT auth fields, the corresponding `list` / `switch` / `remove` row shows `MissingAuth` in both usage columns until a later successful refresh replaces it
 - when `api.usage = false`, foreground refresh still uses only the active local rollout data because local session files do not identify the other stored accounts
 - `switch <query>` does not perform a foreground usage refresh before activation or before showing a local multi-match picker
+- `remove <query>` and `remove --all` do not perform a foreground usage refresh before deletion
 - `switch` does not refresh usage again after the new account is activated
 - the auto-switch daemon refreshes the current active account usage during each cycle when `auto_switch.enabled = true`
 - the auto-switch daemon may also refresh a small number of non-active candidate accounts from stored snapshots so it can score switch candidates

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -193,6 +193,12 @@ If exactly one account matches, it is removed immediately.
 If multiple accounts match in a TTY session, the command prints the matched account labels using the same display grouping as `list` and asks for confirmation with `Confirm delete? [y/N]:`; only `y` or `Y` proceeds.
 If multiple accounts match and stdin is not a TTY, the command exits non-zero instead of reading the pipe as confirmation input; the user must refine the query or rerun it interactively.
 
+When `api.usage = true`, `codex-auth remove` without a query or `--all` refreshes usage for all stored accounts before rendering account choices, using a maximum concurrency of `3`. The remove picker shows the same per-row usage overlays as `list` / interactive `switch`, including non-`200` HTTP statuses and `MissingAuth` in both usage columns when applicable.
+
+When `api.usage = false`, `codex-auth remove` without a query or `--all` keeps the existing local-only behavior and can refresh only the active account from the newest local rollout data.
+
+In the interactive remove picker, `q` quits without deleting accounts.
+
 When an account is removed, `codex-auth` deletes both:
 
 - the account snapshot `accounts/<account file key>.auth.json`

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1114,13 +1114,21 @@ pub fn selectAccountFromIndicesWithUsageOverrides(
 }
 
 pub fn selectAccountsToRemove(allocator: std.mem.Allocator, reg: *registry.Registry) !?[]usize {
+    return selectAccountsToRemoveWithUsageOverrides(allocator, reg, null);
+}
+
+pub fn selectAccountsToRemoveWithUsageOverrides(
+    allocator: std.mem.Allocator,
+    reg: *registry.Registry,
+    usage_overrides: ?[]const ?[]const u8,
+) !?[]usize {
     if (comptime builtin.os.tag == .windows) {
-        return selectRemoveWithNumbers(allocator, reg);
+        return selectRemoveWithNumbers(allocator, reg, usage_overrides);
     }
     if (shouldUseNumberedRemoveSelector(false, std.fs.File.stdin().isTty())) {
-        return selectRemoveWithNumbers(allocator, reg);
+        return selectRemoveWithNumbers(allocator, reg, usage_overrides);
     }
-    return selectRemoveInteractive(allocator, reg) catch selectRemoveWithNumbers(allocator, reg);
+    return selectRemoveInteractive(allocator, reg, usage_overrides) catch selectRemoveWithNumbers(allocator, reg, usage_overrides);
 }
 
 pub fn shouldUseNumberedRemoveSelector(is_windows: bool, stdin_is_tty: bool) bool {
@@ -1334,12 +1342,16 @@ fn selectInteractiveFromIndices(
     }
 }
 
-fn selectRemoveWithNumbers(allocator: std.mem.Allocator, reg: *registry.Registry) !?[]usize {
+fn selectRemoveWithNumbers(
+    allocator: std.mem.Allocator,
+    reg: *registry.Registry,
+    usage_overrides: ?[]const ?[]const u8,
+) !?[]usize {
     var stdout: io_util.Stdout = undefined;
     stdout.init();
     const out = stdout.out();
     if (reg.accounts.items.len == 0) return null;
-    var rows = try buildSwitchRows(allocator, reg);
+    var rows = try buildSwitchRowsWithUsageOverrides(allocator, reg, usage_overrides);
     defer rows.deinit(allocator);
     const use_color = colorEnabled();
     const idx_width = @max(@as(usize, 2), indexWidth(rows.selectable_row_indices.len));
@@ -1512,9 +1524,13 @@ fn selectInteractive(
     }
 }
 
-fn selectRemoveInteractive(allocator: std.mem.Allocator, reg: *registry.Registry) !?[]usize {
+fn selectRemoveInteractive(
+    allocator: std.mem.Allocator,
+    reg: *registry.Registry,
+    usage_overrides: ?[]const ?[]const u8,
+) !?[]usize {
     if (reg.accounts.items.len == 0) return null;
-    var rows = try buildSwitchRows(allocator, reg);
+    var rows = try buildSwitchRowsWithUsageOverrides(allocator, reg, usage_overrides);
     defer rows.deinit(allocator);
 
     var tty = try std.fs.cwd().openFile("/dev/tty", .{});
@@ -1549,7 +1565,7 @@ fn selectRemoveInteractive(allocator: std.mem.Allocator, reg: *registry.Registry
         try renderRemoveList(out, reg, rows.items, idx_width, widths, idx, checked, use_color);
         try out.writeAll("\n");
         if (use_color) try out.writeAll(ansi.dim);
-        try out.writeAll("Keys: ↑/↓ or j/k move, Space toggle, Enter delete, 1-9 type, Backspace edit, Esc exit\n");
+        try out.writeAll("Keys: ↑/↓ or j/k move, Space toggle, Enter delete, 1-9 type, Backspace edit, Esc or q quit\n");
         if (use_color) try out.writeAll(ansi.reset);
         try out.flush();
 
@@ -1588,6 +1604,7 @@ fn selectRemoveInteractive(allocator: std.mem.Allocator, reg: *registry.Registry
                 }
                 return selected;
             }
+            if (isQuitKey(b[i])) return null;
             if (b[i] == 'k' and idx > 0) {
                 idx -= 1;
                 number_len = 0;
@@ -2247,6 +2264,28 @@ test "Scenario: Given usage overrides when rendering switch list then failed row
     try std.testing.expect(std.mem.count(u8, output, "401") >= 2);
 }
 
+test "Scenario: Given usage overrides when rendering remove list then failed rows show response status in both usage columns" {
+    const gpa = std.testing.allocator;
+    var reg = makeTestRegistry();
+    defer reg.deinit(gpa);
+
+    try appendTestAccount(gpa, &reg, "user-1::acc-1", "user@example.com", "", .team);
+    try appendTestAccount(gpa, &reg, "user-1::acc-2", "user@example.com", "", .free);
+
+    const usage_overrides = [_]?[]const u8{ null, "401" };
+    var rows = try buildSwitchRowsWithUsageOverrides(gpa, &reg, &usage_overrides);
+    defer rows.deinit(gpa);
+
+    var checked = [_]bool{ false, false };
+    var buffer: [2048]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buffer);
+    const idx_width = @max(@as(usize, 2), indexWidth(rows.selectable_row_indices.len));
+    try renderRemoveList(&writer, &reg, rows.items, idx_width, rows.widths, null, &checked, false);
+
+    const output = writer.buffered();
+    try std.testing.expect(std.mem.count(u8, output, "401") >= 2);
+}
+
 test "Scenario: Given a usage snapshot plan when building switch rows then the displayed plan prefers it over the stored auth plan" {
     const gpa = std.testing.allocator;
     var reg = makeTestRegistry();
@@ -2265,4 +2304,3 @@ test "Scenario: Given a usage snapshot plan when building switch rows then the d
 
     try std.testing.expectEqualStrings("Business", rows.items[0].plan);
 }
-

--- a/src/main.zig
+++ b/src/main.zig
@@ -217,7 +217,7 @@ pub const ForegroundUsageRefreshTarget = enum {
 };
 
 pub fn shouldRefreshForegroundUsage(target: ForegroundUsageRefreshTarget) bool {
-    return target == .list or target == .switch_account;
+    return target == .list or target == .switch_account or target == .remove_account;
 }
 
 fn isAccountNameRefreshOnlyMode() bool {
@@ -307,18 +307,6 @@ fn initForegroundUsageRefreshState(
         .usage_overrides = usage_overrides,
         .outcomes = outcomes,
     };
-}
-
-fn maybeRefreshForegroundUsage(
-    allocator: std.mem.Allocator,
-    codex_home: []const u8,
-    reg: *registry.Registry,
-    target: ForegroundUsageRefreshTarget,
-) !void {
-    if (!shouldRefreshForegroundUsage(target)) return;
-    if (try auto.refreshActiveUsage(allocator, codex_home, reg)) {
-        try registry.saveRegistry(allocator, codex_home, reg);
-    }
 }
 
 pub fn refreshForegroundUsageForDisplayWithApiFetcher(
@@ -1420,7 +1408,20 @@ fn handleRemove(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
     if (try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg)) {
         try registry.saveRegistry(allocator, codex_home, &reg);
     }
-    try maybeRefreshForegroundUsage(allocator, codex_home, &reg, .remove_account);
+
+    const needs_selector = !opts.all and opts.query == null;
+    var usage_state: ?ForegroundUsageRefreshState = null;
+    defer if (usage_state) |*state| state.deinit(allocator);
+
+    if (needs_selector) {
+        try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .remove_account);
+        usage_state = try refreshForegroundUsageForDisplayWithApiFetcher(
+            allocator,
+            codex_home,
+            &reg,
+            usage_api.fetchUsageForAuthPathDetailed,
+        );
+    }
 
     var selected: ?[]usize = null;
     if (opts.all) {
@@ -1450,7 +1451,11 @@ fn handleRemove(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
 
         selected = try allocator.dupe(usize, matches.items);
     } else {
-        selected = cli.selectAccountsToRemove(allocator, &reg) catch |err| switch (err) {
+        selected = cli.selectAccountsToRemoveWithUsageOverrides(
+            allocator,
+            &reg,
+            if (usage_state) |*state| state.usage_overrides else null,
+        ) catch |err| switch (err) {
             error.InvalidRemoveSelectionInput => {
                 try cli.printInvalidRemoveSelectionError();
                 return error.InvalidRemoveSelectionInput;

--- a/src/tests/main_test.zig
+++ b/src/tests/main_test.zig
@@ -329,10 +329,10 @@ test "Scenario: Given foreground commands when checking reconcile policy then co
     try std.testing.expect(!main_mod.shouldReconcileManagedService(.{ .daemon = .{ .mode = .once } }));
 }
 
-test "Scenario: Given foreground usage refresh targets when checking refresh policy then list and switch refresh but remove does not" {
+test "Scenario: Given foreground usage refresh targets when checking refresh policy then list, switch, and remove all refresh" {
     try std.testing.expect(main_mod.shouldRefreshForegroundUsage(.list));
     try std.testing.expect(main_mod.shouldRefreshForegroundUsage(.switch_account));
-    try std.testing.expect(!main_mod.shouldRefreshForegroundUsage(.remove_account));
+    try std.testing.expect(main_mod.shouldRefreshForegroundUsage(.remove_account));
 }
 
 test "Scenario: Given switch query with one local match when resolving locally then it returns the target account directly" {


### PR DESCRIPTION
## Summary

- align the interactive `remove` flow with `switch` so the no-query picker refreshes latest API usage before rendering account choices
- pass per-account usage overrides through the remove selectors so HTTP status and `MissingAuth` overlays render in both usage columns just like `list` and `switch`
- add `q` quit handling to the remove TUI, and update docs/tests to describe and cover the new behavior

## Validation

- `zig test src/main.zig -lc`
- `zig build run -- list`
- `zig test src/main.zig -lc --test-filter "Given remove query with one match when running remove then it deletes immediately and prints a summary"`
- `zig test src/main.zig -lc --test-filter "Given non-tty stdin when running interactive remove then it falls back to the numbered selector"`

## Risks

- the main behavior change is that `remove` without a query now does the same foreground Node/API preflight as the interactive `switch` picker when `api.usage = true`
- query-driven `remove` and `remove --all` intentionally stay local-only before deletion, so reviewers should verify that scope split matches expectations
- the remove picker now shares more of the switch-row rendering path, so extra attention on selector UI behavior and status overlays is useful

## PR Loop Status

- latest push intent: send the remove/switch alignment changes for CI and review
- latest CI status: green across CI and preview-package checks
- review comments addressed in the latest push: none yet
- open comments intentionally left unresolved and why: none
