### PR TITLE
chore: esm only

### DIFF
--- a/bin/codex-auth.js
+++ b/bin/codex-auth.js
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
-const path = require("node:path");
-const { spawnSync } = require("node:child_process");
-const fs = require("node:fs");
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
 const rootPackageJsonPath = path.join(__dirname, "..", "package.json");
 const requiredNodeMajor = 22;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@loongphy/codex-auth",
   "version": "0.2.6-alpha.1",
+  "type": "module",
   "description": "CLI for switching Codex accounts",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- switch the root npm package to ESM-only by adding `"type": "module"`
- migrate `bin/codex-auth.js` from CommonJS to ESM imports while preserving current CLI behavior
- keep package resolution working under ESM by using `createRequire(import.meta.url)` for optional platform package lookup