### PR TITLE
fix(v0.2): batch foreground API refreshes

### DIFF
--- a/src/chatgpt_http.zig
+++ b/src/chatgpt_http.zig
@@ -18,6 +18,38 @@ pub const HttpResult = struct {
     status_code: ?u16,
 };
 
+pub const BatchRequest = struct {
+    access_token: []const u8,
+    account_id: []const u8,
+};
+
+pub const BatchItemOutcome = enum {
+    ok,
+    timeout,
+    failed,
+};
+
+pub const BatchItemResult = struct {
+    body: []u8,
+    status_code: ?u16,
+    outcome: BatchItemOutcome,
+
+    fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+        allocator.free(self.body);
+        self.* = undefined;
+    }
+};
+
+pub const BatchHttpResult = struct {
+    items: []BatchItemResult,
+
+    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+        for (self.items) |*item| item.deinit(allocator);
+        allocator.free(self.items);
+        self.* = undefined;
+    }
+};
+
 const NodeOutcome = enum {
     ok,
     timeout,
@@ -49,7 +81,20 @@ const ChildProcessWatchdog = struct {
     timed_out: bool = false,
 
     fn run(self: *ChildProcessWatchdog, child_id: std.process.Child.Id, timeout_ms: u64) void {
-        std.Thread.sleep(timeout_ms * std.time.ns_per_ms);
+        const poll_interval_ms: u64 = 50;
+        var waited_ms: u64 = 0;
+        while (waited_ms < timeout_ms) {
+            const sleep_ms = @min(poll_interval_ms, timeout_ms - waited_ms);
+            std.Thread.sleep(@as(u64, sleep_ms) * std.time.ns_per_ms);
+            waited_ms += sleep_ms;
+
+            self.mutex.lock();
+            if (self.completed) {
+                self.mutex.unlock();
+                return;
+            }
+            self.mutex.unlock();
+        }
 
         self.mutex.lock();
         if (self.completed) {
@@ -120,6 +165,89 @@ const node_request_script =
     \\}
 ;
 
+const node_batch_request_script =
+    \\const readStdin = () => new Promise((resolve, reject) => {
+    \\  let data = "";
+    \\  process.stdin.setEncoding("utf8");
+    \\  process.stdin.on("data", (chunk) => {
+    \\    data += chunk;
+    \\  });
+    \\  process.stdin.on("end", () => resolve(data));
+    \\  process.stdin.on("error", reject);
+    \\});
+    \\const encode = (value) => Buffer.from(value ?? "", "utf8").toString("base64");
+    \\const emit = (body, status, outcome) => {
+    \\  process.stdout.write(encode(body));
+    \\  process.stdout.write("\n");
+    \\  process.stdout.write(String(status));
+    \\  process.stdout.write("\n");
+    \\  process.stdout.write(outcome);
+    \\};
+    \\const emitAndExit = (body, status, outcome) => {
+    \\  process.stdout.write(encode(body));
+    \\  process.stdout.write("\n");
+    \\  process.stdout.write(String(status));
+    \\  process.stdout.write("\n");
+    \\  process.stdout.write(outcome, () => process.exit(0));
+    \\};
+    \\const nodeMajor = Number(process.versions?.node?.split(".")[0] ?? 0);
+    \\if (!Number.isInteger(nodeMajor) || nodeMajor < 22 || typeof fetch !== "function" || typeof AbortSignal?.timeout !== "function") {
+    \\  emitAndExit("Node.js 22+ is required.", 0, "node-too-old");
+    \\} else {
+    \\  void (async () => {
+    \\    try {
+    \\      const payload = JSON.parse(await readStdin());
+    \\      const requests = Array.isArray(payload?.requests) ? payload.requests : [];
+    \\      const endpoint = String(payload?.endpoint ?? "");
+    \\      const timeoutMs = Number(payload?.timeout_ms ?? 0);
+    \\      const userAgent = String(payload?.user_agent ?? "");
+    \\      const requestedConcurrency = Math.max(1, Number(payload?.concurrency ?? 1) || 1);
+    \\      const workerCount = Math.max(1, Math.min(requestedConcurrency, Math.max(1, requests.length)));
+    \\      const results = new Array(requests.length);
+    \\      let nextIndex = 0;
+    \\      const runOne = async (index) => {
+    \\        const req = requests[index] ?? {};
+    \\        try {
+    \\          const response = await fetch(endpoint, {
+    \\            method: "GET",
+    \\            headers: {
+    \\              "Authorization": "Bearer " + String(req.access_token ?? ""),
+    \\              "ChatGPT-Account-Id": String(req.account_id ?? ""),
+    \\              "User-Agent": userAgent,
+    \\            },
+    \\            signal: AbortSignal.timeout(timeoutMs),
+    \\          });
+    \\          results[index] = {
+    \\            body: encode(await response.text()),
+    \\            status: response.status,
+    \\            outcome: "ok",
+    \\          };
+    \\        } catch (error) {
+    \\          const isTimeout = error?.name === "TimeoutError" || error?.name === "AbortError";
+    \\          results[index] = {
+    \\            body: encode(error?.message ?? ""),
+    \\            status: 0,
+    \\            outcome: isTimeout ? "timeout" : "error",
+    \\          };
+    \\        }
+    \\      };
+    \\      await Promise.all(Array.from({ length: workerCount }, async () => {
+    \\        while (true) {
+    \\          const index = nextIndex++;
+    \\          if (index >= requests.length) return;
+    \\          await runOne(index);
+    \\        }
+    \\      }));
+    \\      emit(JSON.stringify(results), 200, "ok");
+    \\    } catch (error) {
+    \\      emitAndExit(error?.message ?? "", 0, "error");
+    \\    }
+    \\  })().catch((error) => {
+    \\    emitAndExit(error?.message ?? "", 0, "error");
+    \\  });
+    \\}
+;
+
 pub fn runGetJsonCommand(
     allocator: std.mem.Allocator,
     endpoint: []const u8,
@@ -127,6 +255,15 @@ pub fn runGetJsonCommand(
     account_id: []const u8,
 ) !HttpResult {
     return runNodeGetJsonCommand(allocator, endpoint, access_token, account_id);
+}
+
+pub fn runGetJsonBatchCommand(
+    allocator: std.mem.Allocator,
+    endpoint: []const u8,
+    requests: []const BatchRequest,
+    max_concurrency: usize,
+) !BatchHttpResult {
+    return runNodeGetJsonBatchCommand(allocator, endpoint, requests, max_concurrency);
 }
 
 pub fn ensureNodeExecutableAvailable(allocator: std.mem.Allocator) !void {
@@ -210,15 +347,108 @@ fn runNodeGetJsonCommand(
     }
 }
 
+fn runNodeGetJsonBatchCommand(
+    allocator: std.mem.Allocator,
+    endpoint: []const u8,
+    requests: []const BatchRequest,
+    max_concurrency: usize,
+) !BatchHttpResult {
+    if (requests.len == 0) {
+        return .{ .items = try allocator.alloc(BatchItemResult, 0) };
+    }
+
+    const node_executable = try resolveNodeExecutableForLaunchAlloc(allocator);
+    defer allocator.free(node_executable);
+
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+
+    const node_env_proxy_supported = if (needsNodeEnvProxySupportCheck(&env_map))
+        detectNodeEnvProxySupport(allocator, node_executable)
+    else
+        false;
+    try maybeEnableNodeEnvProxy(allocator, &env_map, node_env_proxy_supported);
+
+    const Payload = struct {
+        endpoint: []const u8,
+        timeout_ms: u64,
+        concurrency: usize,
+        user_agent: []const u8,
+        requests: []const BatchRequest,
+    };
+
+    var payload_writer: std.Io.Writer.Allocating = .init(allocator);
+    defer payload_writer.deinit();
+    try std.json.Stringify.value(Payload{
+        .endpoint = endpoint,
+        .timeout_ms = request_timeout_ms_value,
+        .concurrency = @max(@as(usize, 1), max_concurrency),
+        .user_agent = browser_user_agent,
+        .requests = requests,
+    }, .{}, &payload_writer.writer);
+
+    const result = runChildCaptureWithInputAndOutputLimit(
+        allocator,
+        &.{
+            node_executable,
+            "-e",
+            node_batch_request_script,
+        },
+        payload_writer.written(),
+        computeBatchChildTimeoutMs(requests.len, @max(@as(usize, 1), max_concurrency)),
+        &env_map,
+        computeBatchChildOutputLimitBytes(requests.len),
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        error.FileNotFound => {
+            logNodeRequirement();
+            return error.NodeJsRequired;
+        },
+        else => return err,
+    };
+    defer result.deinit(allocator);
+
+    if (result.timed_out) return error.NodeProcessTimedOut;
+
+    switch (result.term) {
+        .Exited => |code| if (code != 0) return error.RequestFailed,
+        else => return error.RequestFailed,
+    }
+
+    const parsed = parseNodeHttpOutput(allocator, result.stdout) orelse return error.CommandFailed;
+    defer allocator.free(parsed.body);
+
+    switch (parsed.outcome) {
+        .ok => return try parseBatchNodeHttpOutput(allocator, parsed.body),
+        .timeout => return error.TimedOut,
+        .failed => return error.RequestFailed,
+        .node_too_old => {
+            logNodeRequirement();
+            return error.NodeJsRequired;
+        },
+    }
+}
+
 fn runChildCapture(
     allocator: std.mem.Allocator,
     argv: []const []const u8,
     timeout_ms: u64,
     env_map: ?*const std.process.EnvMap,
 ) !ChildCaptureResult {
+    return runChildCaptureWithInputAndOutputLimit(allocator, argv, null, timeout_ms, env_map, max_output_bytes);
+}
+
+fn runChildCaptureWithInputAndOutputLimit(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    stdin_bytes: ?[]const u8,
+    timeout_ms: u64,
+    env_map: ?*const std.process.EnvMap,
+    output_limit_bytes: usize,
+) !ChildCaptureResult {
     var child = std.process.Child.init(argv, allocator);
     child.env_map = env_map;
-    child.stdin_behavior = .Ignore;
+    child.stdin_behavior = if (stdin_bytes != null) .Pipe else .Ignore;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
 
@@ -230,6 +460,12 @@ fn runChildCapture(
     try child.spawn();
     errdefer reapChildAfterError(&child);
 
+    if (stdin_bytes) |bytes| {
+        try child.stdin.?.writeAll(bytes);
+        child.stdin.?.close();
+        child.stdin = null;
+    }
+
     var watchdog = ChildProcessWatchdog{};
     const watchdog_thread = std.Thread.spawn(.{}, ChildProcessWatchdog.run, .{
         &watchdog,
@@ -238,7 +474,7 @@ fn runChildCapture(
     }) catch null;
     defer if (watchdog_thread) |thread| thread.join();
 
-    try child.collectOutput(allocator, &stdout, &stderr, max_output_bytes);
+    try child.collectOutput(allocator, &stdout, &stderr, output_limit_bytes);
     const term = try child.wait();
     const timed_out = if (watchdog_thread != null) watchdog.finish() else false;
 
@@ -248,6 +484,16 @@ fn runChildCapture(
         .stderr = try stderr.toOwnedSlice(allocator),
         .timed_out = timed_out,
     };
+}
+
+fn computeBatchChildTimeoutMs(request_count: usize, max_concurrency: usize) u64 {
+    const safe_concurrency = @max(@as(usize, 1), max_concurrency);
+    const waves = @max(@as(usize, 1), (request_count + safe_concurrency - 1) / safe_concurrency);
+    return @as(u64, @intCast(waves)) * request_timeout_ms_value + 2000;
+}
+
+fn computeBatchChildOutputLimitBytes(request_count: usize) usize {
+    return std.math.mul(usize, max_output_bytes, @max(@as(usize, 1), request_count)) catch std.math.maxInt(usize);
 }
 
 fn terminateChildProcess(child_id: std.process.Child.Id) void {
@@ -749,6 +995,64 @@ fn parseNodeHttpOutput(allocator: std.mem.Allocator, output: []const u8) ?Parsed
     };
 }
 
+fn parseBatchNodeHttpOutput(allocator: std.mem.Allocator, output: []const u8) !BatchHttpResult {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, output, .{});
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .array => |array| array,
+        else => return error.InvalidBatchOutput,
+    };
+
+    const items = try allocator.alloc(BatchItemResult, root.items.len);
+    errdefer allocator.free(items);
+    for (items) |*item| item.* = .{
+        .body = &.{},
+        .status_code = null,
+        .outcome = .failed,
+    };
+    errdefer {
+        for (items) |*item| {
+            if (item.body.len != 0) allocator.free(item.body);
+        }
+    }
+
+    for (root.items, 0..) |entry, idx| {
+        const obj = switch (entry) {
+            .object => |object| object,
+            else => return error.InvalidBatchOutput,
+        };
+
+        const encoded_body = switch (obj.get("body") orelse return error.InvalidBatchOutput) {
+            .string => |value| value,
+            else => return error.InvalidBatchOutput,
+        };
+        const status = switch (obj.get("status") orelse return error.InvalidBatchOutput) {
+            .integer => |value| value,
+            else => return error.InvalidBatchOutput,
+        };
+        const outcome_text = switch (obj.get("outcome") orelse return error.InvalidBatchOutput) {
+            .string => |value| value,
+            else => return error.InvalidBatchOutput,
+        };
+
+        items[idx] = .{
+            .body = try decodeBase64Alloc(allocator, encoded_body),
+            .status_code = if (status == 0) null else std.math.cast(u16, status) orelse return error.InvalidBatchOutput,
+            .outcome = if (std.mem.eql(u8, outcome_text, "ok"))
+                .ok
+            else if (std.mem.eql(u8, outcome_text, "timeout"))
+                .timeout
+            else if (std.mem.eql(u8, outcome_text, "error"))
+                .failed
+            else
+                return error.InvalidBatchOutput,
+        };
+    }
+
+    return .{ .items = items };
+}
+
 fn parseNodeOutcome(input: []const u8) ?NodeOutcome {
     if (std.mem.eql(u8, input, "ok")) return .ok;
     if (std.mem.eql(u8, input, "timeout")) return .timeout;
@@ -784,6 +1088,29 @@ test "parse node http output keeps timeout marker" {
     try std.testing.expectEqual(NodeOutcome.timeout, parsed.outcome);
     try std.testing.expectEqual(@as(?u16, null), parsed.status_code);
     try std.testing.expectEqual(@as(usize, 0), parsed.body.len);
+}
+
+test "parse batch node http output decodes per-request bodies" {
+    const allocator = std.testing.allocator;
+    var parsed = try parseBatchNodeHttpOutput(
+        allocator,
+        "[{\"body\":\"aGVsbG8=\",\"status\":200,\"outcome\":\"ok\"},{\"body\":\"\",\"status\":0,\"outcome\":\"timeout\"}]",
+    );
+    defer parsed.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), parsed.items.len);
+    try std.testing.expectEqualStrings("hello", parsed.items[0].body);
+    try std.testing.expectEqual(@as(?u16, 200), parsed.items[0].status_code);
+    try std.testing.expectEqual(BatchItemOutcome.ok, parsed.items[0].outcome);
+    try std.testing.expectEqual(@as(usize, 0), parsed.items[1].body.len);
+    try std.testing.expectEqual(@as(?u16, null), parsed.items[1].status_code);
+    try std.testing.expectEqual(BatchItemOutcome.timeout, parsed.items[1].outcome);
+}
+
+test "batch child output limit scales with request count" {
+    try std.testing.expectEqual(max_output_bytes, computeBatchChildOutputLimitBytes(1));
+    try std.testing.expectEqual(max_output_bytes * 2, computeBatchChildOutputLimitBytes(2));
+    try std.testing.expectEqual(max_output_bytes * 8, computeBatchChildOutputLimitBytes(8));
 }
 
 test "run child capture times out stalled child process" {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -33,9 +33,15 @@ fn stderrColorEnabled() bool {
 
 pub const ListOptions = struct {
     debug: bool = false,
+    api_mode: ApiMode = .default,
 };
 pub const LoginOptions = struct {
     device_auth: bool = false,
+};
+pub const ApiMode = enum {
+    default,
+    force_api,
+    skip_api,
 };
 pub const ImportSource = enum { standard, cpa };
 pub const ImportOptions = struct {
@@ -44,10 +50,14 @@ pub const ImportOptions = struct {
     purge: bool,
     source: ImportSource,
 };
-pub const SwitchOptions = struct { query: ?[]u8 };
+pub const SwitchOptions = struct {
+    query: ?[]u8,
+    api_mode: ApiMode = .default,
+};
 pub const RemoveOptions = struct {
     query: ?[]u8,
     all: bool,
+    api_mode: ApiMode = .default,
 };
 pub const CleanOptions = struct {};
 pub const AutoAction = enum { enable, disable };
@@ -140,6 +150,22 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Pars
                     return usageErrorResult(allocator, .list, "duplicate `--debug` for `list`.", .{});
                 }
                 opts.debug = true;
+                continue;
+            }
+            if (std.mem.eql(u8, arg, "--api")) {
+                switch (opts.api_mode) {
+                    .default => opts.api_mode = .force_api,
+                    .force_api => return usageErrorResult(allocator, .list, "duplicate `--api` for `list`.", .{}),
+                    .skip_api => return usageErrorResult(allocator, .list, "`--api` cannot be combined with `--skip-api` for `list`.", .{}),
+                }
+                continue;
+            }
+            if (std.mem.eql(u8, arg, "--skip-api")) {
+                switch (opts.api_mode) {
+                    .default => opts.api_mode = .skip_api,
+                    .skip_api => return usageErrorResult(allocator, .list, "duplicate `--skip-api` for `list`.", .{}),
+                    .force_api => return usageErrorResult(allocator, .list, "`--skip-api` cannot be combined with `--api` for `list`.", .{}),
+                }
                 continue;
             }
             if (isHelpFlag(arg)) {
@@ -250,21 +276,53 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Pars
             return .{ .command = .{ .help = .switch_account } };
         }
 
-        var query: ?[]u8 = null;
+        var opts: SwitchOptions = .{ .query = null };
         var i: usize = 2;
         while (i < args.len) : (i += 1) {
             const arg = std.mem.sliceTo(args[i], 0);
+            if (std.mem.eql(u8, arg, "--api")) {
+                switch (opts.api_mode) {
+                    .default => opts.api_mode = .force_api,
+                    .force_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .switch_account, "duplicate `--api` for `switch`.", .{});
+                    },
+                    .skip_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .switch_account, "`--api` cannot be combined with `--skip-api` for `switch`.", .{});
+                    },
+                }
+                continue;
+            }
+            if (std.mem.eql(u8, arg, "--skip-api")) {
+                switch (opts.api_mode) {
+                    .default => opts.api_mode = .skip_api,
+                    .skip_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .switch_account, "duplicate `--skip-api` for `switch`.", .{});
+                    },
+                    .force_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .switch_account, "`--skip-api` cannot be combined with `--api` for `switch`.", .{});
+                    },
+                }
+                continue;
+            }
             if (std.mem.startsWith(u8, arg, "-")) {
-                if (query) |e| allocator.free(e);
+                if (opts.query) |query| allocator.free(query);
                 return usageErrorResult(allocator, .switch_account, "unknown flag `{s}` for `switch`.", .{arg});
             }
-            if (query != null) {
-                if (query) |e| allocator.free(e);
+            if (opts.query != null) {
+                if (opts.query) |query| allocator.free(query);
                 return usageErrorResult(allocator, .switch_account, "unexpected extra query `{s}` for `switch`.", .{arg});
             }
-            query = try allocator.dupe(u8, arg);
+            opts.query = try allocator.dupe(u8, arg);
         }
-        return .{ .command = .{ .switch_account = .{ .query = query } } };
+        if (opts.query != null and opts.api_mode != .default) {
+            if (opts.query) |query| allocator.free(query);
+            return usageErrorResult(allocator, .switch_account, "`switch <query>` does not support `--api` or `--skip-api`.", .{});
+        }
+        return .{ .command = .{ .switch_account = opts } };
     }
 
     if (std.mem.eql(u8, cmd, "remove")) {
@@ -272,33 +330,67 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Pars
             return .{ .command = .{ .help = .remove_account } };
         }
 
-        var query: ?[]u8 = null;
-        var all = false;
+        var opts: RemoveOptions = .{
+            .query = null,
+            .all = false,
+        };
         var i: usize = 2;
         while (i < args.len) : (i += 1) {
             const arg = std.mem.sliceTo(args[i], 0);
+            if (std.mem.eql(u8, arg, "--api")) {
+                switch (opts.api_mode) {
+                    .default => opts.api_mode = .force_api,
+                    .force_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .remove_account, "duplicate `--api` for `remove`.", .{});
+                    },
+                    .skip_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .remove_account, "`--api` cannot be combined with `--skip-api` for `remove`.", .{});
+                    },
+                }
+                continue;
+            }
+            if (std.mem.eql(u8, arg, "--skip-api")) {
+                switch (opts.api_mode) {
+                    .default => opts.api_mode = .skip_api,
+                    .skip_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .remove_account, "duplicate `--skip-api` for `remove`.", .{});
+                    },
+                    .force_api => {
+                        if (opts.query) |query| allocator.free(query);
+                        return usageErrorResult(allocator, .remove_account, "`--skip-api` cannot be combined with `--api` for `remove`.", .{});
+                    },
+                }
+                continue;
+            }
             if (std.mem.eql(u8, arg, "--all")) {
-                if (all or query != null) {
-                    if (query) |q| allocator.free(q);
+                if (opts.all or opts.query != null) {
+                    if (opts.query) |query| allocator.free(query);
                     return usageErrorResult(allocator, .remove_account, "`remove` cannot combine `--all` with another selector.", .{});
                 }
-                all = true;
+                opts.all = true;
                 continue;
             }
             if (std.mem.startsWith(u8, arg, "-")) {
-                if (query) |q| allocator.free(q);
+                if (opts.query) |query| allocator.free(query);
                 return usageErrorResult(allocator, .remove_account, "unknown flag `{s}` for `remove`.", .{arg});
             }
-            if (query != null or all) {
-                if (query) |q| allocator.free(q);
-                if (all) {
+            if (opts.query != null or opts.all) {
+                if (opts.query) |query| allocator.free(query);
+                if (opts.all) {
                     return usageErrorResult(allocator, .remove_account, "`remove` cannot combine `--all` with another selector.", .{});
                 }
                 return usageErrorResult(allocator, .remove_account, "unexpected extra selector `{s}` for `remove`.", .{arg});
             }
-            query = try allocator.dupe(u8, arg);
+            opts.query = try allocator.dupe(u8, arg);
         }
-        return .{ .command = .{ .remove_account = .{ .query = query, .all = all } } };
+        if ((opts.all or opts.query != null) and opts.api_mode != .default) {
+            if (opts.query) |query| allocator.free(query);
+            return usageErrorResult(allocator, .remove_account, "`remove <query>` and `remove --all` do not support `--api` or `--skip-api`.", .{});
+        }
+        return .{ .command = .{ .remove_account = opts } };
     }
 
     if (std.mem.eql(u8, cmd, "clean")) {
@@ -665,7 +757,7 @@ fn writeUsageSection(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  codex-auth --help\n");
             try out.writeAll("  codex-auth help <command>\n");
         },
-        .list => try out.writeAll("  codex-auth list [--debug]\n"),
+        .list => try out.writeAll("  codex-auth list [--debug] [--api|--skip-api]\n"),
         .status => try out.writeAll("  codex-auth status\n"),
         .login => {
             try out.writeAll("  codex-auth login\n");
@@ -677,11 +769,11 @@ fn writeUsageSection(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  codex-auth import --purge [<path>]\n");
         },
         .switch_account => {
-            try out.writeAll("  codex-auth switch\n");
+            try out.writeAll("  codex-auth switch [--api|--skip-api]\n");
             try out.writeAll("  codex-auth switch <query>\n");
         },
         .remove_account => {
-            try out.writeAll("  codex-auth remove\n");
+            try out.writeAll("  codex-auth remove [--api|--skip-api]\n");
             try out.writeAll("  codex-auth remove <query>\n");
             try out.writeAll("  codex-auth remove --all\n");
         },
@@ -710,6 +802,8 @@ fn writeExamplesSection(out: *std.Io.Writer, topic: HelpTopic) !void {
         .list => {
             try out.writeAll("  codex-auth list\n");
             try out.writeAll("  codex-auth list --debug\n");
+            try out.writeAll("  codex-auth list --api\n");
+            try out.writeAll("  codex-auth list --skip-api\n");
         },
         .status => try out.writeAll("  codex-auth status\n"),
         .login => {
@@ -723,10 +817,12 @@ fn writeExamplesSection(out: *std.Io.Writer, topic: HelpTopic) !void {
         },
         .switch_account => {
             try out.writeAll("  codex-auth switch\n");
+            try out.writeAll("  codex-auth switch --api\n");
             try out.writeAll("  codex-auth switch john@example.com\n");
         },
         .remove_account => {
             try out.writeAll("  codex-auth remove\n");
+            try out.writeAll("  codex-auth remove --skip-api\n");
             try out.writeAll("  codex-auth remove john@example.com\n");
             try out.writeAll("  codex-auth remove --all\n");
         },

--- a/src/main.zig
+++ b/src/main.zig
@@ -225,6 +225,14 @@ pub fn shouldRefreshForegroundUsage(target: ForegroundUsageRefreshTarget) bool {
     return target == .list or target == .switch_account or target == .remove_account;
 }
 
+fn apiModeUsesApi(default_enabled: bool, api_mode: cli.ApiMode) bool {
+    return switch (api_mode) {
+        .default => default_enabled,
+        .force_api => true,
+        .skip_api => false,
+    };
+}
+
 fn isAccountNameRefreshOnlyMode() bool {
     return std.process.hasNonEmptyEnvVarConstant(account_name_refresh_only_env);
 }
@@ -314,6 +322,18 @@ fn initForegroundUsageRefreshState(
     };
 }
 
+fn refreshActiveUsageWithApiOverride(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    usage_api_enabled: bool,
+) !bool {
+    const saved_usage_api = reg.api.usage;
+    reg.api.usage = usage_api_enabled;
+    defer reg.api.usage = saved_usage_api;
+    return try auto.refreshActiveUsage(allocator, codex_home, reg);
+}
+
 pub fn refreshForegroundUsageForDisplayWithApiFetcher(
     allocator: std.mem.Allocator,
     codex_home: []const u8,
@@ -336,12 +356,28 @@ pub fn refreshForegroundUsageForDisplayWithBatchApiFetcher(
     reg: *registry.Registry,
     batch_fetcher: UsageBatchFetchDetailedFn,
 ) !ForegroundUsageRefreshState {
+    return refreshForegroundUsageForDisplayWithBatchApiFetcherUsingApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        batch_fetcher,
+        reg.api.usage,
+    );
+}
+
+fn refreshForegroundUsageForDisplayWithBatchApiFetcherUsingApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    batch_fetcher: UsageBatchFetchDetailedFn,
+    usage_api_enabled: bool,
+) !ForegroundUsageRefreshState {
     var state = try initForegroundUsageRefreshState(allocator, reg.accounts.items.len);
     errdefer state.deinit(allocator);
 
-    if (!reg.api.usage) {
+    if (!usage_api_enabled) {
         state.local_only_mode = true;
-        if (try auto.refreshActiveUsage(allocator, codex_home, reg)) {
+        if (try refreshActiveUsageWithApiOverride(allocator, codex_home, reg, usage_api_enabled)) {
             try registry.saveRegistry(allocator, codex_home, reg);
         }
         return state;
@@ -424,6 +460,26 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
     pool_init: ForegroundUsagePoolInitFn,
     debug_logger: ?*ForegroundUsageDebugLogger,
 ) !ForegroundUsageRefreshState {
+    return refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebugUsingApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        usage_fetcher,
+        pool_init,
+        debug_logger,
+        reg.api.usage,
+    );
+}
+
+fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebugUsingApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    usage_fetcher: UsageFetchDetailedFn,
+    pool_init: ForegroundUsagePoolInitFn,
+    debug_logger: ?*ForegroundUsageDebugLogger,
+    usage_api_enabled: bool,
+) !ForegroundUsageRefreshState {
     var state = try initForegroundUsageRefreshState(allocator, reg.accounts.items.len);
     errdefer state.deinit(allocator);
 
@@ -432,9 +488,9 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
 
     var debug_context: ?ForegroundUsageDebugContext = null;
 
-    if (!reg.api.usage) {
+    if (!usage_api_enabled) {
         state.local_only_mode = true;
-        if (try auto.refreshActiveUsage(allocator, codex_home, reg)) {
+        if (try refreshActiveUsageWithApiOverride(allocator, codex_home, reg, usage_api_enabled)) {
             try registry.saveRegistry(allocator, codex_home, reg);
         }
         if (debug_logger) |logger| {
@@ -873,9 +929,39 @@ pub fn maybeRefreshForegroundAccountNames(
     target: ForegroundUsageRefreshTarget,
     fetcher: AccountFetchFn,
 ) !void {
+    return try maybeRefreshForegroundAccountNamesWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        target,
+        fetcher,
+        reg.api.account,
+    );
+}
+
+fn maybeRefreshForegroundAccountNamesWithAccountApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+    fetcher: AccountFetchFn,
+    account_api_enabled: bool,
+) !void {
     const changed = switch (target) {
-        .list => try refreshAccountNamesForList(allocator, codex_home, reg, fetcher),
-        .switch_account => try refreshAccountNamesAfterSwitch(allocator, codex_home, reg, fetcher),
+        .list => try refreshAccountNamesForListWithAccountApiEnabled(
+            allocator,
+            codex_home,
+            reg,
+            fetcher,
+            account_api_enabled,
+        ),
+        .switch_account => try refreshAccountNamesAfterSwitchWithAccountApiEnabled(
+            allocator,
+            codex_home,
+            reg,
+            fetcher,
+            account_api_enabled,
+        ),
         .remove_account => false,
     };
     if (!changed) return;
@@ -901,8 +987,24 @@ fn maybeRefreshAccountNamesForAuthInfo(
     info: *const auth.AuthInfo,
     fetcher: AccountFetchFn,
 ) !bool {
+    return try maybeRefreshAccountNamesForAuthInfoWithAccountApiEnabled(
+        allocator,
+        reg,
+        info,
+        fetcher,
+        reg.api.account,
+    );
+}
+
+fn maybeRefreshAccountNamesForAuthInfoWithAccountApiEnabled(
+    allocator: std.mem.Allocator,
+    reg: *registry.Registry,
+    info: *const auth.AuthInfo,
+    fetcher: AccountFetchFn,
+    account_api_enabled: bool,
+) !bool {
     const chatgpt_user_id = info.chatgpt_user_id orelse return false;
-    if (!shouldRefreshTeamAccountNamesForUserScope(reg, chatgpt_user_id)) return false;
+    if (!shouldRefreshTeamAccountNamesForUserScopeWithAccountApiEnabled(reg, chatgpt_user_id, account_api_enabled)) return false;
     const access_token = info.access_token orelse return false;
     const chatgpt_account_id = info.chatgpt_account_id orelse return false;
 
@@ -936,12 +1038,34 @@ fn refreshAccountNamesForActiveAuth(
     reg: *registry.Registry,
     fetcher: AccountFetchFn,
 ) !bool {
+    return try refreshAccountNamesForActiveAuthWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        fetcher,
+        reg.api.account,
+    );
+}
+
+fn refreshAccountNamesForActiveAuthWithAccountApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    fetcher: AccountFetchFn,
+    account_api_enabled: bool,
+) !bool {
     const active_user_id = registry.activeChatgptUserId(reg) orelse return false;
-    if (!shouldRefreshTeamAccountNamesForUserScope(reg, active_user_id)) return false;
+    if (!shouldRefreshTeamAccountNamesForUserScopeWithAccountApiEnabled(reg, active_user_id, account_api_enabled)) return false;
 
     var info = (try loadActiveAuthInfoForAccountRefresh(allocator, codex_home)) orelse return false;
     defer info.deinit(allocator);
-    return try maybeRefreshAccountNamesForAuthInfo(allocator, reg, &info, fetcher);
+    return try maybeRefreshAccountNamesForAuthInfoWithAccountApiEnabled(
+        allocator,
+        reg,
+        &info,
+        fetcher,
+        account_api_enabled,
+    );
 }
 
 pub fn refreshAccountNamesAfterLogin(
@@ -959,7 +1083,29 @@ pub fn refreshAccountNamesAfterSwitch(
     reg: *registry.Registry,
     fetcher: AccountFetchFn,
 ) !bool {
-    return try refreshAccountNamesForActiveAuth(allocator, codex_home, reg, fetcher);
+    return try refreshAccountNamesAfterSwitchWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        fetcher,
+        reg.api.account,
+    );
+}
+
+fn refreshAccountNamesAfterSwitchWithAccountApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    fetcher: AccountFetchFn,
+    account_api_enabled: bool,
+) !bool {
+    return try refreshAccountNamesForActiveAuthWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        fetcher,
+        account_api_enabled,
+    );
 }
 
 pub fn refreshAccountNamesForList(
@@ -968,19 +1114,50 @@ pub fn refreshAccountNamesForList(
     reg: *registry.Registry,
     fetcher: AccountFetchFn,
 ) !bool {
-    return try refreshAccountNamesForActiveAuth(allocator, codex_home, reg, fetcher);
+    return try refreshAccountNamesForListWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        fetcher,
+        reg.api.account,
+    );
+}
+
+fn refreshAccountNamesForListWithAccountApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    fetcher: AccountFetchFn,
+    account_api_enabled: bool,
+) !bool {
+    return try refreshAccountNamesForActiveAuthWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        fetcher,
+        account_api_enabled,
+    );
 }
 
 fn shouldRefreshTeamAccountNamesForUserScope(reg: *registry.Registry, chatgpt_user_id: []const u8) bool {
-    if (!reg.api.account) return false;
+    return shouldRefreshTeamAccountNamesForUserScopeWithAccountApiEnabled(reg, chatgpt_user_id, reg.api.account);
+}
+
+fn shouldRefreshTeamAccountNamesForUserScopeWithAccountApiEnabled(
+    reg: *registry.Registry,
+    chatgpt_user_id: []const u8,
+    account_api_enabled: bool,
+) bool {
+    if (!account_api_enabled) return false;
     return registry.shouldFetchTeamAccountNamesForUser(reg, chatgpt_user_id);
 }
 
-fn shouldPreflightNodeForAccountNameRefresh(
+fn shouldPreflightNodeForAccountNameRefreshWithAccountApiEnabled(
     allocator: std.mem.Allocator,
     codex_home: []const u8,
     reg: *registry.Registry,
     target: ForegroundUsageRefreshTarget,
+    account_api_enabled: bool,
 ) !bool {
     switch (target) {
         .list, .switch_account => {},
@@ -988,7 +1165,7 @@ fn shouldPreflightNodeForAccountNameRefresh(
     }
 
     const active_user_id = registry.activeChatgptUserId(reg) orelse return false;
-    if (!shouldRefreshTeamAccountNamesForUserScope(reg, active_user_id)) return false;
+    if (!shouldRefreshTeamAccountNamesForUserScopeWithAccountApiEnabled(reg, active_user_id, account_api_enabled)) return false;
 
     var info = (try loadActiveAuthInfoForAccountRefresh(allocator, codex_home)) orelse return false;
     defer info.deinit(allocator);
@@ -1002,8 +1179,32 @@ fn shouldPreflightNodeForForegroundTarget(
     reg: *registry.Registry,
     target: ForegroundUsageRefreshTarget,
 ) !bool {
-    if (shouldRefreshForegroundUsage(target) and reg.api.usage and reg.accounts.items.len > 0) return true;
-    return try shouldPreflightNodeForAccountNameRefresh(allocator, codex_home, reg, target);
+    return try shouldPreflightNodeForForegroundTargetWithApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        target,
+        reg.api.usage,
+        reg.api.account,
+    );
+}
+
+fn shouldPreflightNodeForForegroundTargetWithApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+    usage_api_enabled: bool,
+    account_api_enabled: bool,
+) !bool {
+    if (shouldRefreshForegroundUsage(target) and usage_api_enabled and reg.accounts.items.len > 0) return true;
+    return try shouldPreflightNodeForAccountNameRefreshWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        target,
+        account_api_enabled,
+    );
 }
 
 fn ensureForegroundNodeAvailable(
@@ -1012,13 +1213,54 @@ fn ensureForegroundNodeAvailable(
     reg: *registry.Registry,
     target: ForegroundUsageRefreshTarget,
 ) !void {
-    try ensureForegroundNodeAvailableWithChecker(
+    try ensureForegroundNodeAvailableWithCheckerAndApiEnabled(
         allocator,
         codex_home,
         reg,
         target,
         chatgpt_http.ensureNodeExecutableAvailable,
+        reg.api.usage,
+        reg.api.account,
     );
+}
+
+fn ensureForegroundNodeAvailableWithApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+    usage_api_enabled: bool,
+    account_api_enabled: bool,
+) !void {
+    try ensureForegroundNodeAvailableWithCheckerAndApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        target,
+        chatgpt_http.ensureNodeExecutableAvailable,
+        usage_api_enabled,
+        account_api_enabled,
+    );
+}
+
+fn ensureForegroundNodeAvailableWithCheckerAndApiEnabled(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    target: ForegroundUsageRefreshTarget,
+    checker: NodeAvailabilityFn,
+    usage_api_enabled: bool,
+    account_api_enabled: bool,
+) !void {
+    if (!try shouldPreflightNodeForForegroundTargetWithApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        target,
+        usage_api_enabled,
+        account_api_enabled,
+    )) return;
+    try checker(allocator);
 }
 
 fn ensureForegroundNodeAvailableWithChecker(
@@ -1028,8 +1270,15 @@ fn ensureForegroundNodeAvailableWithChecker(
     target: ForegroundUsageRefreshTarget,
     checker: NodeAvailabilityFn,
 ) !void {
-    if (!try shouldPreflightNodeForForegroundTarget(allocator, codex_home, reg, target)) return;
-    try checker(allocator);
+    try ensureForegroundNodeAvailableWithCheckerAndApiEnabled(
+        allocator,
+        codex_home,
+        reg,
+        target,
+        checker,
+        reg.api.usage,
+        reg.api.account,
+    );
 }
 
 pub fn shouldScheduleBackgroundAccountNameRefresh(reg: *registry.Registry) bool {
@@ -1221,16 +1470,33 @@ fn handleList(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.Li
     if (try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg)) {
         try registry.saveRegistry(allocator, codex_home, &reg);
     }
-    try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .list);
+    const usage_api_enabled = apiModeUsesApi(reg.api.usage, opts.api_mode);
+    const account_api_enabled = apiModeUsesApi(reg.api.account, opts.api_mode);
+    try ensureForegroundNodeAvailableWithApiEnabled(
+        allocator,
+        codex_home,
+        &reg,
+        .list,
+        usage_api_enabled,
+        account_api_enabled,
+    );
     if (!opts.debug) {
-        var usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcher(
+        var usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcherUsingApiEnabled(
             allocator,
             codex_home,
             &reg,
             usage_api.fetchUsageForAuthPathsDetailedBatch,
+            usage_api_enabled,
         );
         defer usage_state.deinit(allocator);
-        try maybeRefreshForegroundAccountNames(allocator, codex_home, &reg, .list, defaultAccountFetcher);
+        try maybeRefreshForegroundAccountNamesWithAccountApiEnabled(
+            allocator,
+            codex_home,
+            &reg,
+            .list,
+            defaultAccountFetcher,
+            account_api_enabled,
+        );
         try format.printAccountsWithUsageOverrides(&reg, usage_state.usage_overrides);
         return;
     }
@@ -1242,16 +1508,24 @@ fn handleList(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.Li
         debug_logger = ForegroundUsageDebugLogger.init(debug_stdout.out());
     }
 
-    var usage_state = try refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
+    var usage_state = try refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebugUsingApiEnabled(
         allocator,
         codex_home,
         &reg,
         usage_api.fetchUsageForAuthPathDetailed,
         initForegroundUsagePool,
         if (debug_logger) |*logger| logger else null,
+        usage_api_enabled,
     );
     defer usage_state.deinit(allocator);
-    try maybeRefreshForegroundAccountNames(allocator, codex_home, &reg, .list, defaultAccountFetcher);
+    try maybeRefreshForegroundAccountNamesWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        &reg,
+        .list,
+        defaultAccountFetcher,
+        account_api_enabled,
+    );
     try format.printAccountsWithUsageOverrides(&reg, usage_state.usage_overrides);
 }
 
@@ -1347,15 +1621,32 @@ fn handleSwitch(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
         try registry.saveRegistry(allocator, codex_home, &reg);
         return;
     }
-    try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .switch_account);
-    var usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcher(
+    const usage_api_enabled = apiModeUsesApi(reg.api.usage, opts.api_mode);
+    const account_api_enabled = apiModeUsesApi(reg.api.account, opts.api_mode);
+    try ensureForegroundNodeAvailableWithApiEnabled(
+        allocator,
+        codex_home,
+        &reg,
+        .switch_account,
+        usage_api_enabled,
+        account_api_enabled,
+    );
+    var usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcherUsingApiEnabled(
         allocator,
         codex_home,
         &reg,
         usage_api.fetchUsageForAuthPathsDetailedBatch,
+        usage_api_enabled,
     );
     defer usage_state.deinit(allocator);
-    try maybeRefreshForegroundAccountNames(allocator, codex_home, &reg, .switch_account, defaultAccountFetcher);
+    try maybeRefreshForegroundAccountNamesWithAccountApiEnabled(
+        allocator,
+        codex_home,
+        &reg,
+        .switch_account,
+        defaultAccountFetcher,
+        account_api_enabled,
+    );
 
     const selected_account_key = try cli.selectAccountWithUsageOverrides(allocator, &reg, usage_state.usage_overrides);
     if (selected_account_key == null) return;
@@ -1507,16 +1798,26 @@ fn handleRemove(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
     }
 
     const needs_selector = !opts.all and opts.query == null;
+    const usage_api_enabled = apiModeUsesApi(reg.api.usage, opts.api_mode);
+    const account_api_enabled = apiModeUsesApi(reg.api.account, opts.api_mode);
     var usage_state: ?ForegroundUsageRefreshState = null;
     defer if (usage_state) |*state| state.deinit(allocator);
 
     if (needs_selector) {
-        try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .remove_account);
-        usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcher(
+        try ensureForegroundNodeAvailableWithApiEnabled(
+            allocator,
+            codex_home,
+            &reg,
+            .remove_account,
+            usage_api_enabled,
+            account_api_enabled,
+        );
+        usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcherUsingApiEnabled(
             allocator,
             codex_home,
             &reg,
             usage_api.fetchUsageForAuthPathsDetailedBatch,
+            usage_api_enabled,
         );
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,7 +14,7 @@ const usage_api = @import("usage_api.zig");
 const skip_service_reconcile_env = "CODEX_AUTH_SKIP_SERVICE_RECONCILE";
 const account_name_refresh_only_env = "CODEX_AUTH_REFRESH_ACCOUNT_NAMES_ONLY";
 const disable_background_account_name_refresh_env = "CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH";
-const foreground_usage_refresh_concurrency: usize = 3;
+const foreground_usage_refresh_concurrency: usize = 5;
 
 const AccountFetchFn = *const fn (
     allocator: std.mem.Allocator,
@@ -25,6 +25,11 @@ const UsageFetchDetailedFn = *const fn (
     allocator: std.mem.Allocator,
     auth_path: []const u8,
 ) anyerror!usage_api.UsageFetchResult;
+const UsageBatchFetchDetailedFn = *const fn (
+    allocator: std.mem.Allocator,
+    auth_paths: []const []const u8,
+    max_concurrency: usize,
+) anyerror![]usage_api.BatchUsageFetchResult;
 const ForegroundUsagePoolInitFn = *const fn (
     pool: *std.Thread.Pool,
     allocator: std.mem.Allocator,
@@ -325,6 +330,75 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcher(
     );
 }
 
+pub fn refreshForegroundUsageForDisplayWithBatchApiFetcher(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    batch_fetcher: UsageBatchFetchDetailedFn,
+) !ForegroundUsageRefreshState {
+    var state = try initForegroundUsageRefreshState(allocator, reg.accounts.items.len);
+    errdefer state.deinit(allocator);
+
+    if (!reg.api.usage) {
+        state.local_only_mode = true;
+        if (try auto.refreshActiveUsage(allocator, codex_home, reg)) {
+            try registry.saveRegistry(allocator, codex_home, reg);
+        }
+        return state;
+    }
+
+    if (reg.accounts.items.len == 0) return state;
+
+    const worker_results = try allocator.alloc(ForegroundUsageWorkerResult, reg.accounts.items.len);
+    defer {
+        for (worker_results) |*worker_result| worker_result.deinit(allocator);
+        allocator.free(worker_results);
+    }
+    for (worker_results) |*worker_result| worker_result.* = .{};
+
+    var auth_path_arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer auth_path_arena_state.deinit();
+    const auth_path_arena = auth_path_arena_state.allocator();
+
+    const auth_paths = try auth_path_arena.alloc([]const u8, reg.accounts.items.len);
+    for (reg.accounts.items, 0..) |account, idx| {
+        auth_paths[idx] = try registry.accountAuthPath(auth_path_arena, codex_home, account.account_key);
+    }
+
+    const batch_results = batch_fetcher(
+        allocator,
+        auth_paths,
+        @min(reg.accounts.items.len, foreground_usage_refresh_concurrency),
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            const error_name = @errorName(err);
+            for (worker_results) |*worker_result| {
+                worker_result.* = .{ .error_name = error_name };
+            }
+            try applyForegroundUsageWorkerResults(allocator, codex_home, reg, &state, worker_results);
+            return state;
+        },
+    };
+    defer {
+        for (batch_results) |*batch_result| batch_result.deinit(allocator);
+        allocator.free(batch_results);
+    }
+
+    for (batch_results, 0..) |*batch_result, idx| {
+        worker_results[idx] = .{
+            .status_code = batch_result.status_code,
+            .missing_auth = batch_result.missing_auth,
+            .error_name = batch_result.error_name,
+            .snapshot = batch_result.snapshot,
+        };
+        batch_result.snapshot = null;
+    }
+
+    try applyForegroundUsageWorkerResults(allocator, codex_home, reg, &state, worker_results);
+    return state;
+}
+
 pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInit(
     allocator: std.mem.Allocator,
     codex_home: []const u8,
@@ -437,6 +511,22 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
         }
     }
 
+    try applyForegroundUsageWorkerResults(allocator, codex_home, reg, &state, worker_results);
+
+    if (debug_logger) |logger| {
+        try printForegroundUsageDebugDone(logger, &state);
+    }
+
+    return state;
+}
+
+fn applyForegroundUsageWorkerResults(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *registry.Registry,
+    state: *ForegroundUsageRefreshState,
+    worker_results: []ForegroundUsageWorkerResult,
+) !void {
     var registry_changed = false;
     for (worker_results, 0..) |*worker_result, idx| {
         const outcome = &state.outcomes[idx];
@@ -472,12 +562,6 @@ pub fn refreshForegroundUsageForDisplayWithApiFetcherWithPoolInitAndDebug(
     if (registry_changed) {
         try registry.saveRegistry(allocator, codex_home, reg);
     }
-
-    if (debug_logger) |logger| {
-        try printForegroundUsageDebugDone(logger, &state);
-    }
-
-    return state;
 }
 
 fn initForegroundUsagePool(
@@ -1138,6 +1222,19 @@ fn handleList(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.Li
         try registry.saveRegistry(allocator, codex_home, &reg);
     }
     try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .list);
+    if (!opts.debug) {
+        var usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcher(
+            allocator,
+            codex_home,
+            &reg,
+            usage_api.fetchUsageForAuthPathsDetailedBatch,
+        );
+        defer usage_state.deinit(allocator);
+        try maybeRefreshForegroundAccountNames(allocator, codex_home, &reg, .list, defaultAccountFetcher);
+        try format.printAccountsWithUsageOverrides(&reg, usage_state.usage_overrides);
+        return;
+    }
+
     var debug_stdout: io_util.Stdout = undefined;
     var debug_logger: ?ForegroundUsageDebugLogger = null;
     if (opts.debug) {
@@ -1251,11 +1348,11 @@ fn handleSwitch(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
         return;
     }
     try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .switch_account);
-    var usage_state = try refreshForegroundUsageForDisplayWithApiFetcher(
+    var usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcher(
         allocator,
         codex_home,
         &reg,
-        usage_api.fetchUsageForAuthPathDetailed,
+        usage_api.fetchUsageForAuthPathsDetailedBatch,
     );
     defer usage_state.deinit(allocator);
     try maybeRefreshForegroundAccountNames(allocator, codex_home, &reg, .switch_account, defaultAccountFetcher);
@@ -1415,11 +1512,11 @@ fn handleRemove(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.
 
     if (needs_selector) {
         try ensureForegroundNodeAvailable(allocator, codex_home, &reg, .remove_account);
-        usage_state = try refreshForegroundUsageForDisplayWithApiFetcher(
+        usage_state = try refreshForegroundUsageForDisplayWithBatchApiFetcher(
             allocator,
             codex_home,
             &reg,
-            usage_api.fetchUsageForAuthPathDetailed,
+            usage_api.fetchUsageForAuthPathsDetailedBatch,
         );
     }
 

--- a/src/tests/cli_bdd_test.zig
+++ b/src/tests/cli_bdd_test.zig
@@ -181,6 +181,47 @@ test "Scenario: Given list with debug flag when parsing then debug mode is prese
     }
 }
 
+test "Scenario: Given list with api override flags when parsing then api mode is preserved" {
+    const gpa = std.testing.allocator;
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "list", "--api" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        switch (result) {
+            .command => |cmd| switch (cmd) {
+                .list => |opts| try std.testing.expectEqual(cli.ApiMode.force_api, opts.api_mode),
+                else => return error.TestExpectedEqual,
+            },
+            else => return error.TestExpectedEqual,
+        }
+    }
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "list", "--skip-api" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        switch (result) {
+            .command => |cmd| switch (cmd) {
+                .list => |opts| try std.testing.expectEqual(cli.ApiMode.skip_api, opts.api_mode),
+                else => return error.TestExpectedEqual,
+            },
+            else => return error.TestExpectedEqual,
+        }
+    }
+}
+
+test "Scenario: Given conflicting list api override flags when parsing then usage error is returned" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "list", "--api", "--skip-api" };
+    var result = try cli.parseArgs(gpa, &args);
+    defer cli.freeParseResult(gpa, &result);
+
+    try expectUsageError(result, .list, "cannot be combined");
+}
+
 test "Scenario: Given login with removed no-login flag when parsing then usage error is returned" {
     const gpa = std.testing.allocator;
     const args = [_][:0]const u8{ "codex-auth", "login", "--no-login" };
@@ -276,7 +317,7 @@ test "Scenario: Given simple command help when rendering then examples are omitt
     const help = aw.written();
     try std.testing.expect(std.mem.indexOf(u8, help, "codex-auth list") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "List available accounts.") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help, "Usage:\n  codex-auth list [--debug]\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "Usage:\n  codex-auth list [--debug] [--api|--skip-api]\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "Examples:") == null);
 }
 
@@ -574,6 +615,53 @@ test "Scenario: Given switch with positional query when parsing then non-interac
     }
 }
 
+test "Scenario: Given interactive switch with api override flags when parsing then api mode is preserved" {
+    const gpa = std.testing.allocator;
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "switch", "--api" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        switch (result) {
+            .command => |cmd| switch (cmd) {
+                .switch_account => |opts| {
+                    try std.testing.expect(opts.query == null);
+                    try std.testing.expectEqual(cli.ApiMode.force_api, opts.api_mode);
+                },
+                else => return error.TestExpectedEqual,
+            },
+            else => return error.TestExpectedEqual,
+        }
+    }
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "switch", "--skip-api" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        switch (result) {
+            .command => |cmd| switch (cmd) {
+                .switch_account => |opts| {
+                    try std.testing.expect(opts.query == null);
+                    try std.testing.expectEqual(cli.ApiMode.skip_api, opts.api_mode);
+                },
+                else => return error.TestExpectedEqual,
+            },
+            else => return error.TestExpectedEqual,
+        }
+    }
+}
+
+test "Scenario: Given query switch with api override flags when parsing then usage error is returned" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "switch", "--api", "user@example.com" };
+    var result = try cli.parseArgs(gpa, &args);
+    defer cli.freeParseResult(gpa, &result);
+
+    try expectUsageError(result, .switch_account, "does not support `--api` or `--skip-api`");
+}
+
 test "Scenario: Given switch with duplicate target when parsing then usage error is returned" {
     const gpa = std.testing.allocator;
     const args = [_][:0]const u8{ "codex-auth", "switch", "a@example.com", "b@example.com" };
@@ -608,6 +696,46 @@ test "Scenario: Given remove with positional query when parsing then query mode 
             else => return error.TestExpectedEqual,
         },
         else => return error.TestExpectedEqual,
+    }
+}
+
+test "Scenario: Given interactive remove with api override flags when parsing then api mode is preserved" {
+    const gpa = std.testing.allocator;
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "remove", "--api" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        switch (result) {
+            .command => |cmd| switch (cmd) {
+                .remove_account => |opts| {
+                    try std.testing.expect(opts.query == null);
+                    try std.testing.expect(!opts.all);
+                    try std.testing.expectEqual(cli.ApiMode.force_api, opts.api_mode);
+                },
+                else => return error.TestExpectedEqual,
+            },
+            else => return error.TestExpectedEqual,
+        }
+    }
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "remove", "--skip-api" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        switch (result) {
+            .command => |cmd| switch (cmd) {
+                .remove_account => |opts| {
+                    try std.testing.expect(opts.query == null);
+                    try std.testing.expect(!opts.all);
+                    try std.testing.expectEqual(cli.ApiMode.skip_api, opts.api_mode);
+                },
+                else => return error.TestExpectedEqual,
+            },
+            else => return error.TestExpectedEqual,
+        }
     }
 }
 
@@ -654,6 +782,26 @@ test "Scenario: Given remove with all and query when parsing then usage error is
     defer cli.freeParseResult(gpa, &result);
 
     try expectUsageError(result, .remove_account, "cannot combine `--all`");
+}
+
+test "Scenario: Given selector remove with api override flags when parsing then usage error is returned" {
+    const gpa = std.testing.allocator;
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "remove", "--api", "user@example.com" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        try expectUsageError(result, .remove_account, "does not support `--api` or `--skip-api`");
+    }
+
+    {
+        const args = [_][:0]const u8{ "codex-auth", "remove", "--skip-api", "--all" };
+        var result = try cli.parseArgs(gpa, &args);
+        defer cli.freeParseResult(gpa, &result);
+
+        try expectUsageError(result, .remove_account, "does not support `--api` or `--skip-api`");
+    }
 }
 
 test "Scenario: Given multiple removed accounts when rendering summary then emails are joined on one line" {

--- a/src/tests/cli_bdd_test.zig
+++ b/src/tests/cli_bdd_test.zig
@@ -792,7 +792,7 @@ test "Scenario: Given selector remove with api override flags when parsing then 
         var result = try cli.parseArgs(gpa, &args);
         defer cli.freeParseResult(gpa, &result);
 
-        try expectUsageError(result, .remove_account, "does not support `--api` or `--skip-api`");
+        try expectUsageError(result, .remove_account, "do not support `--api` or `--skip-api`");
     }
 
     {
@@ -800,7 +800,7 @@ test "Scenario: Given selector remove with api override flags when parsing then 
         var result = try cli.parseArgs(gpa, &args);
         defer cli.freeParseResult(gpa, &result);
 
-        try expectUsageError(result, .remove_account, "does not support `--api` or `--skip-api`");
+        try expectUsageError(result, .remove_account, "do not support `--api` or `--skip-api`");
     }
 }
 

--- a/src/tests/main_test.zig
+++ b/src/tests/main_test.zig
@@ -471,6 +471,111 @@ test "Scenario: Given api usage refresh for list and switch when refreshing fore
     try std.testing.expectEqual(@as(f64, 55), reg.accounts.items[2].last_usage.?.secondary.?.used_percent);
 }
 
+test "Scenario: Given batch api usage refresh for list when refreshing foreground usage then all accounts are updated with status overlays" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+
+    const TestUsageBatchFetcher = struct {
+        fn snapshot(plan: registry.PlanType, used_5h: f64, used_weekly: f64) registry.RateLimitSnapshot {
+            return .{
+                .primary = .{
+                    .used_percent = used_5h,
+                    .window_minutes = 300,
+                    .resets_at = 1773491460,
+                },
+                .secondary = .{
+                    .used_percent = used_weekly,
+                    .window_minutes = 10080,
+                    .resets_at = 1773749620,
+                },
+                .credits = null,
+                .plan_type = plan,
+            };
+        }
+
+        fn fetch(allocator: std.mem.Allocator, auth_paths: []const []const u8, max_concurrency: usize) ![]usage_api.BatchUsageFetchResult {
+            try std.testing.expectEqual(@as(usize, 3), auth_paths.len);
+            try std.testing.expectEqual(@as(usize, 3), max_concurrency);
+
+            const results = try allocator.alloc(usage_api.BatchUsageFetchResult, auth_paths.len);
+            errdefer allocator.free(results);
+            for (results) |*result| result.* = .{};
+
+            for (auth_paths, 0..) |auth_path, idx| {
+                var info = try auth_mod.parseAuthInfo(allocator, auth_path);
+                defer info.deinit(allocator);
+
+                const account_id = info.chatgpt_account_id orelse return error.MissingChatgptAccountId;
+                if (std.mem.eql(u8, account_id, primary_account_id)) {
+                    results[idx] = .{
+                        .snapshot = snapshot(.team, 17, 38),
+                        .status_code = 200,
+                    };
+                } else if (std.mem.eql(u8, account_id, secondary_account_id)) {
+                    results[idx] = .{
+                        .status_code = 401,
+                    };
+                } else if (std.mem.eql(u8, account_id, tertiary_account_id)) {
+                    results[idx] = .{
+                        .snapshot = snapshot(.plus, 30, 55),
+                        .status_code = 200,
+                    };
+                } else {
+                    results[idx] = .{
+                        .status_code = 404,
+                    };
+                }
+            }
+
+            return results;
+        }
+    };
+
+    var reg = makeRegistry();
+    defer reg.deinit(gpa);
+    try appendAccount(gpa, &reg, primary_record_key, "user@example.com", "", .team);
+    try appendAccount(gpa, &reg, secondary_record_key, "user@example.com", "", .team);
+    try appendAccount(gpa, &reg, tertiary_record_key, "user@example.com", "", .plus);
+    try registry.setActiveAccountKey(gpa, &reg, primary_record_key);
+
+    reg.accounts.items[2].last_usage = TestUsageBatchFetcher.snapshot(.plus, 30, 55);
+    reg.accounts.items[2].last_usage_at = 10;
+
+    try writeAccountSnapshotWithIds(gpa, codex_home, "user@example.com", "team", shared_user_id, primary_account_id);
+    try writeAccountSnapshotWithIds(gpa, codex_home, "user@example.com", "team", shared_user_id, secondary_account_id);
+    try writeAccountSnapshotWithIds(gpa, codex_home, "user@example.com", "plus", shared_user_id, tertiary_account_id);
+
+    var state = try main_mod.refreshForegroundUsageForDisplayWithBatchApiFetcher(
+        gpa,
+        codex_home,
+        &reg,
+        TestUsageBatchFetcher.fetch,
+    );
+    defer state.deinit(gpa);
+
+    try std.testing.expect(!state.local_only_mode);
+    try std.testing.expectEqual(@as(usize, 3), state.attempted);
+    try std.testing.expectEqual(@as(usize, 1), state.updated);
+    try std.testing.expectEqual(@as(usize, 1), state.failed);
+    try std.testing.expectEqual(@as(usize, 1), state.unchanged);
+
+    try std.testing.expect(state.usage_overrides[0] == null);
+    try std.testing.expectEqualStrings("401", state.usage_overrides[1].?);
+    try std.testing.expect(state.usage_overrides[2] == null);
+
+    try std.testing.expect(state.outcomes[0].updated);
+    try std.testing.expectEqual(@as(?u16, 401), state.outcomes[1].status_code);
+    try std.testing.expect(state.outcomes[2].unchanged);
+
+    try std.testing.expectEqual(@as(?registry.PlanType, .team), reg.accounts.items[0].last_usage.?.plan_type);
+    try std.testing.expectEqual(@as(f64, 17), reg.accounts.items[0].last_usage.?.primary.?.used_percent);
+    try std.testing.expectEqual(@as(f64, 55), reg.accounts.items[2].last_usage.?.secondary.?.used_percent);
+}
+
 test "Scenario: Given thread pool init failure when refreshing foreground usage then it falls back to serial refresh" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/usage_api.zig
+++ b/src/usage_api.zig
@@ -11,6 +11,20 @@ pub const UsageFetchResult = struct {
     missing_auth: bool = false,
 };
 
+pub const BatchUsageFetchResult = struct {
+    snapshot: ?registry.RateLimitSnapshot = null,
+    status_code: ?u16 = null,
+    missing_auth: bool = false,
+    error_name: ?[]const u8 = null,
+
+    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+        if (self.snapshot) |*snapshot| {
+            registry.freeRateLimitSnapshot(allocator, snapshot);
+            self.snapshot = null;
+        }
+    }
+};
+
 const UsageHttpResult = struct {
     body: []u8,
     status_code: ?u16,
@@ -47,6 +61,99 @@ pub fn fetchUsageForAuthPathDetailed(allocator: std.mem.Allocator, auth_path: []
     const chatgpt_account_id = info.chatgpt_account_id orelse return .{ .snapshot = null, .status_code = null, .missing_auth = true };
 
     return try fetchUsageForTokenDetailed(allocator, default_usage_endpoint, access_token, chatgpt_account_id);
+}
+
+pub fn fetchUsageForAuthPathsDetailedBatch(
+    allocator: std.mem.Allocator,
+    auth_paths: []const []const u8,
+    max_concurrency: usize,
+) ![]BatchUsageFetchResult {
+    const results = try allocator.alloc(BatchUsageFetchResult, auth_paths.len);
+    errdefer allocator.free(results);
+    for (results) |*result| result.* = .{};
+
+    if (auth_paths.len == 0) return results;
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var requests = std.ArrayList(chatgpt_http.BatchRequest).empty;
+    defer requests.deinit(arena);
+
+    const request_indexes = try arena.alloc(?usize, auth_paths.len);
+    for (request_indexes) |*slot| slot.* = null;
+
+    for (auth_paths, 0..) |auth_path, idx| {
+        var info = auth.parseAuthInfo(arena, auth_path) catch |err| {
+            results[idx].error_name = @errorName(err);
+            continue;
+        };
+        defer info.deinit(arena);
+
+        if (info.auth_mode != .chatgpt) {
+            results[idx].missing_auth = true;
+            continue;
+        }
+        const access_token = info.access_token orelse {
+            results[idx].missing_auth = true;
+            continue;
+        };
+        const chatgpt_account_id = info.chatgpt_account_id orelse {
+            results[idx].missing_auth = true;
+            continue;
+        };
+
+        var existing_request_index: ?usize = null;
+        for (requests.items, 0..) |request, request_idx| {
+            if (std.mem.eql(u8, request.access_token, access_token) and
+                std.mem.eql(u8, request.account_id, chatgpt_account_id))
+            {
+                existing_request_index = request_idx;
+                break;
+            }
+        }
+
+        if (existing_request_index) |request_idx| {
+            request_indexes[idx] = request_idx;
+            continue;
+        }
+
+        try requests.append(arena, .{
+            .access_token = try arena.dupe(u8, access_token),
+            .account_id = try arena.dupe(u8, chatgpt_account_id),
+        });
+        request_indexes[idx] = requests.items.len - 1;
+    }
+
+    if (requests.items.len == 0) return results;
+
+    var http_results = try chatgpt_http.runGetJsonBatchCommand(
+        allocator,
+        default_usage_endpoint,
+        requests.items,
+        max_concurrency,
+    );
+    defer http_results.deinit(allocator);
+
+    for (request_indexes, 0..) |request_idx, result_idx| {
+        const unique_idx = request_idx orelse continue;
+        const http_result = http_results.items[unique_idx];
+        results[result_idx].status_code = http_result.status_code;
+        switch (http_result.outcome) {
+            .ok => {
+                if (http_result.body.len == 0) continue;
+                results[result_idx].snapshot = parseUsageResponse(allocator, http_result.body) catch |err| {
+                    results[result_idx].error_name = @errorName(err);
+                    continue;
+                };
+            },
+            .timeout => results[result_idx].error_name = @errorName(error.TimedOut),
+            .failed => results[result_idx].error_name = @errorName(error.RequestFailed),
+        }
+    }
+
+    return results;
 }
 
 pub fn fetchUsageForToken(


### PR DESCRIPTION
- fix the slow API request path used by foreground refreshes in list and interactive switch/remove by switching to batched requests
- add --api and --skip-api for list and interactive switch/remove