### PR TITLE
ci: use Node 24 setup-zig fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: Loongphy/setup-zig@node24-lts-runtime
         with:
           version: 0.16.0
 

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: Loongphy/setup-zig@node24-lts-runtime
         with:
           version: 0.16.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: Loongphy/setup-zig@node24-lts-runtime
         with:
           version: 0.16.0
 
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: Loongphy/setup-zig@node24-lts-runtime
         with:
           version: 0.16.0
 


### PR DESCRIPTION
## Summary
- use the Loongphy/setup-zig fork that declares the GitHub Actions Node 24 runtime
- update CI, release, and preview release workflows to use the forked action

## Validation
- node --check main.js and post.js in the setup-zig fork
- git diff --check
