### PR TITLE
fix(tui): improve mouse wheel scrolling

### DIFF
--- a/USER.md
+++ b/USER.md
@@ -10,14 +10,37 @@ supporting responsive mouse-wheel scrolling.
 This applies to live TUI screens such as `list --live`, `switch --live`, and
 `remove --live`.
 
+When the terminal supports Kitty keyboard enhancement, real keyboard Up/Down
+input is kept distinct from alternate-scroll mouse-wheel input:
+
+- keyboard Up/Down moves the cursor in `switch --live` and `remove --live`
+- mouse-wheel movement scrolls the viewport in `list --live`, `switch --live`,
+  and `remove --live`
+- translated wheel scrolling uses the shared live-list wheel step
+
+When the terminal does not confirm keyboard enhancement support, the TUI keeps
+the legacy copy-friendly fallback. In that fallback, terminals may translate
+mouse-wheel movement into the same Up/Down bytes as real keyboard arrows, so
+`switch --live` and `remove --live` preserve the existing cursor movement and
+edge-scroll compensation behavior.
+
 ### Technical Implementation
 
 - The TUI enters the alternate screen with `?1049h`.
 - The cursor is hidden while the TUI is active with `?25l`.
 - XTerm alternate scroll is enabled with `?1007h`.
 - Mouse reporting is not enabled with `?1000h` or `?1006h`.
+- Kitty keyboard enhancement support is queried with `?u`.
+- Keyboard enhancement flags `7` are pushed with `>7u` and popped with `<1u`
+  on exit.
 - Terminals that support alternate scroll translate mouse-wheel movement in the
   alternate screen into Up/Down-style input.
+- The TUI only treats traditional `Esc [ A` and `Esc [ B` as mouse-wheel
+  viewport scrolling after it has received a keyboard-enhancement response.
+- Enhanced keyboard Up/Down sequences are parsed as keyboard-only cursor
+  movement and do not trigger viewport edge-scroll compensation.
+- Without a keyboard-enhancement response, traditional Up/Down input keeps the
+  legacy behavior so unsupported terminals do not lose keyboard navigation.
 - `list --live` treats that Up/Down-style input as viewport scrolling so the
   translated wheel input remains responsive.
 
@@ -25,6 +48,9 @@ This applies to live TUI screens such as `list --live`, `switch --live`, and
 
 - Users can drag-select and copy text normally without holding `Shift`.
 - Mouse-wheel scrolling remains usable in live TUI screens.
+- On terminals with keyboard enhancement support, mouse-wheel scrolling and
+  keyboard Up/Down navigation no longer conflict in `switch --live` and
+  `remove --live`.
 - The TUI avoids taking ownership of mouse clicks, drags, and coordinates when
   those interactions are not needed.
 - Long live lists can scroll without sacrificing native terminal selection.

--- a/src/cli/live_remove.zig
+++ b/src/cli/live_remove.zig
@@ -165,6 +165,16 @@ pub fn runRemoveLiveActions(
                                 }
                                 needs_render = true;
                             },
+                            .keyboard_up => {
+                                if (try live_tui.moveSelectedIndex(allocator, &cursor_account_key, rows, borrowed.reg, .up)) number_len = 0;
+                                follow_selection = true;
+                                needs_render = true;
+                            },
+                            .keyboard_down => {
+                                if (try live_tui.moveSelectedIndex(allocator, &cursor_account_key, rows, borrowed.reg, .down)) number_len = 0;
+                                follow_selection = true;
+                                needs_render = true;
+                            },
                             .scroll_up => {
                                 live_tui.scrollListViewportBy(rows.items.len, page_rows, &viewport_start, .up, wheel_rows);
                                 follow_selection = false;

--- a/src/cli/live_switch.zig
+++ b/src/cli/live_switch.zig
@@ -187,6 +187,16 @@ pub fn runSwitchLiveActions(
                                 }
                                 needs_render = true;
                             },
+                            .keyboard_up => {
+                                if (try live_tui.moveSelectedIndex(allocator, &selected_account_key, rows, borrowed.reg, .up)) number_len = 0;
+                                follow_selection = true;
+                                needs_render = true;
+                            },
+                            .keyboard_down => {
+                                if (try live_tui.moveSelectedIndex(allocator, &selected_account_key, rows, borrowed.reg, .down)) number_len = 0;
+                                follow_selection = true;
+                                needs_render = true;
+                            },
                             .scroll_up => {
                                 live_tui.scrollListViewportBy(rows.items.len, page_rows, &viewport_start, .up, wheel_rows);
                                 follow_selection = false;

--- a/src/cli/live_tui.zig
+++ b/src/cli/live_tui.zig
@@ -180,11 +180,11 @@ pub fn applyListViewportKey(
     key: tui_mod.TuiInputKey,
 ) bool {
     switch (key) {
-        .move_up => {
+        .move_up, .keyboard_up => {
             scrollListViewportBy(row_count, max_rows, viewport_start, .up, wheel_rows);
             return true;
         },
-        .move_down => {
+        .move_down, .keyboard_down => {
             scrollListViewportBy(row_count, max_rows, viewport_start, .down, wheel_rows);
             return true;
         },
@@ -321,8 +321,8 @@ pub fn moveSelectedIndexForKey(
     key: tui_mod.TuiInputKey,
 ) !bool {
     const direction: ScrollDirection = switch (key) {
-        .move_up => .up,
-        .move_down => .down,
+        .move_up, .keyboard_up => .up,
+        .move_down, .keyboard_down => .down,
         .byte => |ch| switch (ch) {
             'k' => .up,
             'j' => .down,

--- a/src/cli/live_view.zig
+++ b/src/cli/live_view.zig
@@ -147,11 +147,11 @@ pub fn selectAccountWithLiveUpdates(
                     for (key_buf[0..key_count]) |key| {
                         const selected_idx = try live_tui.resolveSelectedIndex(allocator, &selected_account_key, rows, borrowed.reg);
                         switch (key) {
-                            .move_up => {
+                            .move_up, .keyboard_up => {
                                 if (try live_tui.moveSelectedIndex(allocator, &selected_account_key, rows, borrowed.reg, .up)) number_len = 0;
                                 needs_render = true;
                             },
-                            .move_down => {
+                            .move_down, .keyboard_down => {
                                 if (try live_tui.moveSelectedIndex(allocator, &selected_account_key, rows, borrowed.reg, .down)) number_len = 0;
                                 needs_render = true;
                             },

--- a/src/cli/picker_remove.zig
+++ b/src/cli/picker_remove.zig
@@ -160,7 +160,7 @@ fn selectRemoveInteractive(
 
         if (comptime builtin.os.tag == .windows) {
             switch (try tui.readWindowsKey()) {
-                .move_up, .scroll_up, .page_up => {
+                .move_up, .keyboard_up, .scroll_up, .page_up => {
                     if (idx > 0) {
                         idx -= 1;
                         number_len = 0;
@@ -170,7 +170,7 @@ fn selectRemoveInteractive(
                     idx = 0;
                     number_len = 0;
                 },
-                .move_down, .scroll_down, .page_down => {
+                .move_down, .keyboard_down, .scroll_down, .page_down => {
                     if (idx + 1 < rows.selectable_row_indices.len) {
                         idx += 1;
                         number_len = 0;
@@ -252,20 +252,20 @@ fn selectRemoveInteractive(
                     tui_escape_sequence_timeout_ms,
                 );
                 switch (escape.action) {
-                    .move_up, .scroll_up, .page_up, .home => {
+                    .move_up, .keyboard_up, .scroll_up, .page_up, .home => {
                         if (idx > 0) {
                             idx = if (escape.action == .home) 0 else idx - 1;
                             number_len = 0;
                         }
                     },
-                    .move_down, .scroll_down, .page_down, .end => {
+                    .move_down, .keyboard_down, .scroll_down, .page_down, .end => {
                         if (idx + 1 < rows.selectable_row_indices.len) {
                             idx = if (escape.action == .end) rows.selectable_row_indices.len - 1 else idx + 1;
                             number_len = 0;
                         }
                     },
                     .quit => return null,
-                    .ignore => {},
+                    .keyboard_enhancement_supported, .ignore => {},
                 }
                 i += escape.buffered_bytes_consumed;
                 continue;

--- a/src/cli/picker_switch.zig
+++ b/src/cli/picker_switch.zig
@@ -210,7 +210,7 @@ fn selectInteractiveFromIndices(
 
         if (comptime builtin.os.tag == .windows) {
             switch (try tui.readWindowsKey()) {
-                .move_up, .scroll_up, .page_up => {
+                .move_up, .keyboard_up, .scroll_up, .page_up => {
                     if (rows.selectable_row_indices.len != 0 and idx > 0) {
                         idx -= 1;
                         number_len = 0;
@@ -222,7 +222,7 @@ fn selectInteractiveFromIndices(
                         number_len = 0;
                     }
                 },
-                .move_down, .scroll_down, .page_down => {
+                .move_down, .keyboard_down, .scroll_down, .page_down => {
                     if (rows.selectable_row_indices.len != 0 and idx + 1 < rows.selectable_row_indices.len) {
                         idx += 1;
                         number_len = 0;
@@ -291,7 +291,7 @@ fn selectInteractiveFromIndices(
                     tui_escape_sequence_timeout_ms,
                 );
                 switch (escape.action) {
-                    .move_up, .scroll_up, .page_up => {
+                    .move_up, .keyboard_up, .scroll_up, .page_up => {
                         if (rows.selectable_row_indices.len != 0 and idx > 0) {
                             idx -= 1;
                             number_len = 0;
@@ -303,7 +303,7 @@ fn selectInteractiveFromIndices(
                             number_len = 0;
                         }
                     },
-                    .move_down, .scroll_down, .page_down => {
+                    .move_down, .keyboard_down, .scroll_down, .page_down => {
                         if (rows.selectable_row_indices.len != 0 and idx + 1 < rows.selectable_row_indices.len) {
                             idx += 1;
                             number_len = 0;
@@ -316,7 +316,7 @@ fn selectInteractiveFromIndices(
                         }
                     },
                     .quit => return null,
-                    .ignore => {},
+                    .keyboard_enhancement_supported, .ignore => {},
                 }
                 i += escape.buffered_bytes_consumed;
                 continue;
@@ -415,7 +415,7 @@ fn selectInteractive(
 
         if (comptime builtin.os.tag == .windows) {
             switch (try tui.readWindowsKey()) {
-                .move_up, .scroll_up, .page_up => {
+                .move_up, .keyboard_up, .scroll_up, .page_up => {
                     if (rows.selectable_row_indices.len != 0 and idx > 0) {
                         idx -= 1;
                         number_len = 0;
@@ -427,7 +427,7 @@ fn selectInteractive(
                         number_len = 0;
                     }
                 },
-                .move_down, .scroll_down, .page_down => {
+                .move_down, .keyboard_down, .scroll_down, .page_down => {
                     if (rows.selectable_row_indices.len != 0 and idx + 1 < rows.selectable_row_indices.len) {
                         idx += 1;
                         number_len = 0;
@@ -496,7 +496,7 @@ fn selectInteractive(
                     tui_escape_sequence_timeout_ms,
                 );
                 switch (escape.action) {
-                    .move_up, .scroll_up, .page_up => {
+                    .move_up, .keyboard_up, .scroll_up, .page_up => {
                         if (rows.selectable_row_indices.len != 0 and idx > 0) {
                             idx -= 1;
                             number_len = 0;
@@ -508,7 +508,7 @@ fn selectInteractive(
                             number_len = 0;
                         }
                     },
-                    .move_down, .scroll_down, .page_down => {
+                    .move_down, .keyboard_down, .scroll_down, .page_down => {
                         if (rows.selectable_row_indices.len != 0 and idx + 1 < rows.selectable_row_indices.len) {
                             idx += 1;
                             number_len = 0;
@@ -521,7 +521,7 @@ fn selectInteractive(
                         }
                     },
                     .quit => return null,
-                    .ignore => {},
+                    .keyboard_enhancement_supported, .ignore => {},
                 }
                 i += escape.buffered_bytes_consumed;
                 continue;

--- a/src/cli/tui.zig
+++ b/src/cli/tui.zig
@@ -104,6 +104,8 @@ pub const live_ui_tick_ms: i32 = 100;
 pub const TuiNavigation = enum {
     up,
     down,
+    keyboard_up,
+    keyboard_down,
     page_up,
     page_down,
     home,
@@ -115,6 +117,7 @@ pub const TuiNavigation = enum {
 pub const TuiEscapeClassification = union(enum) {
     incomplete,
     ignore,
+    keyboard_enhancement_supported,
     navigation: TuiNavigation,
 };
 
@@ -123,12 +126,15 @@ pub const TuiEscapeAction = enum {
     ignore,
     move_up,
     move_down,
+    keyboard_up,
+    keyboard_down,
     page_up,
     page_down,
     home,
     end,
     scroll_up,
     scroll_down,
+    keyboard_enhancement_supported,
 };
 
 pub const TuiEscapeReadResult = struct {
@@ -151,6 +157,8 @@ pub const TuiInputRead = union(enum) {
 pub const TuiInputKey = union(enum) {
     move_up,
     move_down,
+    keyboard_up,
+    keyboard_down,
     page_up,
     page_down,
     home,
@@ -221,11 +229,12 @@ else
 
 pub fn writeTuiEnterTo(out: *std.Io.Writer) !void {
     try out.writeAll("\x1b[?1049h\x1b[?25l\x1b[?1007h");
+    try out.writeAll("\x1b[?u\x1b[>7u");
     try out.writeAll("\x1b[H\x1b[J");
 }
 
 pub fn writeTuiExitTo(out: *std.Io.Writer) !void {
-    try out.writeAll("\x1b[?1007l\x1b[?25h\x1b[?1049l");
+    try out.writeAll("\x1b[<1u\x1b[?1007l\x1b[?25h\x1b[?1049l");
 }
 
 pub fn writeTuiResetFrameTo(out: *std.Io.Writer) !void {
@@ -361,6 +370,7 @@ pub const TuiSession = struct {
     saved_output_state: TuiSavedOutputState = if (builtin.os.tag == .windows) 0 else {},
     pending_windows_key: ?TuiInputKey = null,
     pending_windows_repeat_count: u16 = 0,
+    keyboard_enhancement_supported: bool = false,
     last_frame_hash: u64 = 0,
     last_frame_line_count: usize = 0,
     has_last_frame: bool = false,
@@ -474,8 +484,10 @@ pub const TuiSession = struct {
                     tui_escape_sequence_timeout_ms,
                 );
                 switch (escape.action) {
-                    .move_up => appendTuiInputKey(keys, &key_count, .move_up),
-                    .move_down => appendTuiInputKey(keys, &key_count, .move_down),
+                    .move_up => appendTuiInputKey(keys, &key_count, if (self.keyboard_enhancement_supported) .scroll_up else .move_up),
+                    .move_down => appendTuiInputKey(keys, &key_count, if (self.keyboard_enhancement_supported) .scroll_down else .move_down),
+                    .keyboard_up => appendTuiInputKey(keys, &key_count, .keyboard_up),
+                    .keyboard_down => appendTuiInputKey(keys, &key_count, .keyboard_down),
                     .page_up => appendTuiInputKey(keys, &key_count, .page_up),
                     .page_down => appendTuiInputKey(keys, &key_count, .page_down),
                     .home => appendTuiInputKey(keys, &key_count, .home),
@@ -483,6 +495,7 @@ pub const TuiSession = struct {
                     .scroll_up => appendTuiInputKey(keys, &key_count, .scroll_up),
                     .scroll_down => appendTuiInputKey(keys, &key_count, .scroll_down),
                     .quit => appendTuiInputKey(keys, &key_count, .quit),
+                    .keyboard_enhancement_supported => self.keyboard_enhancement_supported = true,
                     .ignore => {},
                 }
                 i += escape.buffered_bytes_consumed;
@@ -629,6 +642,45 @@ pub fn terminalSize(file: std.Io.File) ?TuiSize {
     }
 }
 
+fn isKeyboardEnhancementFlagsResponse(seq: []const u8) bool {
+    if (seq.len < 4 or seq[0] != '[' or seq[1] != '?' or seq[seq.len - 1] != 'u') return false;
+    for (seq[2 .. seq.len - 1]) |ch| {
+        if (!std.ascii.isDigit(ch)) return false;
+    }
+    return true;
+}
+
+fn isEnhancedArrowSuffix(seq: []const u8) bool {
+    if (seq.len < 4) return false;
+    const final = seq[seq.len - 1];
+    if (final != 'A' and final != 'B') return false;
+    if (seq[0] != '[') return false;
+
+    var has_separator = false;
+    for (seq[1 .. seq.len - 1]) |ch| {
+        switch (ch) {
+            ';', ':' => has_separator = true,
+            '0'...'9' => {},
+            else => return false,
+        }
+    }
+    return has_separator;
+}
+
+fn isCsiUKeyboardArrow(seq: []const u8) ?TuiNavigation {
+    if (seq.len < 4 or seq[0] != '[' or seq[seq.len - 1] != 'u') return null;
+    const params = seq[1 .. seq.len - 1];
+    var code_end: usize = 0;
+    while (code_end < params.len and params[code_end] != ':' and params[code_end] != ';') : (code_end += 1) {}
+    if (code_end == 0) return null;
+    const code = std.fmt.parseInt(usize, params[0..code_end], 10) catch return null;
+    return switch (code) {
+        57419 => .keyboard_up,
+        57420 => .keyboard_down,
+        else => null,
+    };
+}
+
 pub fn classifyTuiEscapeSuffix(seq: []const u8) TuiEscapeClassification {
     if (seq.len == 0) return .incomplete;
 
@@ -636,6 +688,8 @@ pub fn classifyTuiEscapeSuffix(seq: []const u8) TuiEscapeClassification {
         '[' => blk: {
             if (seq.len == 1) break :blk .incomplete;
             const final = seq[seq.len - 1];
+            if (isKeyboardEnhancementFlagsResponse(seq)) break :blk .keyboard_enhancement_supported;
+            if (isCsiUKeyboardArrow(seq)) |direction| break :blk .{ .navigation = direction };
             if (seq[1] == '<') {
                 if (final != 'M' and final != 'm') {
                     if (final >= '@' and final <= '~') break :blk .ignore;
@@ -650,6 +704,9 @@ pub fn classifyTuiEscapeSuffix(seq: []const u8) TuiEscapeClassification {
                 };
             }
             if (final == 'A' or final == 'B') {
+                if (isEnhancedArrowSuffix(seq)) {
+                    break :blk .{ .navigation = if (final == 'A') .keyboard_up else .keyboard_down };
+                }
                 for (seq[1 .. seq.len - 1]) |ch| {
                     if (!std.ascii.isDigit(ch) and ch != ';') break :blk .ignore;
                 }
@@ -709,6 +766,8 @@ pub fn readTuiEscapeAction(
                     .action = switch (direction) {
                         .up => .move_up,
                         .down => .move_down,
+                        .keyboard_up => .keyboard_up,
+                        .keyboard_down => .keyboard_down,
                         .page_up => .page_up,
                         .page_down => .page_down,
                         .home => .home,
@@ -718,6 +777,10 @@ pub fn readTuiEscapeAction(
                     },
                     .buffered_bytes_consumed = buffered_bytes_consumed,
                 };
+            },
+            .keyboard_enhancement_supported => return .{
+                .action = .keyboard_enhancement_supported,
+                .buffered_bytes_consumed = buffered_bytes_consumed,
             },
             .ignore => return .{
                 .action = .ignore,

--- a/tests/tui_session_test.zig
+++ b/tests/tui_session_test.zig
@@ -21,13 +21,28 @@ test "Scenario: Given tty arrow escape suffixes when classifying them then both 
         else => return error.TestUnexpectedResult,
     }
     switch (classifyTuiEscapeSuffix("[1;2B")) {
-        .navigation => |direction| try std.testing.expectEqual(TuiNavigation.down, direction),
+        .navigation => |direction| try std.testing.expectEqual(TuiNavigation.keyboard_down, direction),
         else => return error.TestUnexpectedResult,
     }
     switch (classifyTuiEscapeSuffix("OA")) {
         .navigation => |direction| try std.testing.expectEqual(TuiNavigation.up, direction),
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "Scenario: Given keyboard enhancement responses and keys when classifying them then enhanced arrows stay distinct from alternate scroll arrows" {
+    try std.testing.expectEqual(TuiEscapeClassification.keyboard_enhancement_supported, classifyTuiEscapeSuffix("[?7u"));
+    switch (classifyTuiEscapeSuffix("[1;1:1A")) {
+        .navigation => |direction| try std.testing.expectEqual(TuiNavigation.keyboard_up, direction),
+        else => return error.TestUnexpectedResult,
+    }
+    switch (classifyTuiEscapeSuffix("[57420;1u")) {
+        .navigation => |direction| try std.testing.expectEqual(TuiNavigation.keyboard_down, direction),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const result = try readTuiEscapeAction(std.Io.File.stdin(), "[1;1:1A", 0, 0);
+    try std.testing.expectEqual(TuiEscapeAction.keyboard_up, result.action);
 }
 
 test "Scenario: Given tty paging and mouse wheel escape suffixes when classifying them then scrolling actions are recognized" {
@@ -78,9 +93,9 @@ test "Scenario: Given shared TUI screen lifecycle when writing it then switch an
     try writeTuiExitTo(&aw.writer);
 
     try std.testing.expectEqualStrings(
-        "\x1b[?1049h\x1b[?25l\x1b[?1007h" ++
+        "\x1b[?1049h\x1b[?25l\x1b[?1007h\x1b[?u\x1b[>7u" ++
             "\x1b[H\x1b[J" ++
-            "\x1b[?1007l\x1b[?25h\x1b[?1049l",
+            "\x1b[<1u\x1b[?1007l\x1b[?25h\x1b[?1049l",
         aw.written(),
     );
     try std.testing.expect(std.mem.indexOf(u8, aw.written(), "\x1b[?1007h") != null);


### PR DESCRIPTION
Improves live TUI mouse-wheel scrolling while preserving terminal text selection behavior.

## Changes

- Keep `?1007h` alternate scroll enabled.
- Keep mouse reporting disabled (`?1000h` / `?1006h` are not enabled).
- Query and enable Kitty keyboard enhancement (`?u`, `>7u`) when supported.
- Treat traditional `Esc [ A` / `Esc [ B` as viewport scrolling only after keyboard enhancement support is confirmed.
- Parse enhanced keyboard Up/Down separately so keyboard navigation continues to move the cursor in `switch --live` and `remove --live`.
- Preserve the legacy fallback behavior for terminals that do not support keyboard enhancement.

## Terminal Support

This best-effort path is supported by common terminals that implement Kitty keyboard enhancement, such as Kitty, WezTerm, Ghostty, Alacritty, foot, iTerm2, and Windows Terminal 1.25+.

For terminals that do not confirm keyboard enhancement support, the TUI falls back to the previous behavior, where alternate-scroll wheel input and keyboard Up/Down may be indistinguishable.