### PR TITLE
feat: add export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Detailed command documentation lives in [docs/commands/README.md](./docs/command
 | [`codex-auth import <path> [--alias <alias>]`](./docs/commands/import.md) | Import a single auth file or batch import a folder |
 | [`codex-auth import --cpa [<path>]`](./docs/commands/import.md) | Import CLIProxyAPI token JSON |
 | [`codex-auth import --purge [<path>]`](./docs/commands/import.md) | Rebuild `registry.json` from auth files |
+| [`codex-auth export [<dir>]`](./docs/commands/export.md) | Export stored account auth files |
+| [`codex-auth export --cpa [<dir>]`](./docs/commands/export.md) | Export CLIProxyAPI token JSON |
 | [`codex-auth clean`](./docs/commands/clean.md) | Delete managed backup and stale account files |
 
 ### Configuration

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -9,6 +9,7 @@ This directory documents command behavior by command. Use `codex-auth <command> 
 | `list` | [docs/commands/list.md](./list.md) |
 | `login` | [docs/commands/login.md](./login.md) |
 | `import` | [docs/commands/import.md](./import.md) |
+| `export` | [docs/commands/export.md](./export.md) |
 | `switch` | [docs/commands/switch.md](./switch.md) |
 | `remove` | [docs/commands/remove.md](./remove.md) |
 | `clean` | [docs/commands/clean.md](./clean.md) |

--- a/docs/commands/export.md
+++ b/docs/commands/export.md
@@ -1,0 +1,27 @@
+# `codex-auth export`
+
+## Usage
+
+```shell
+codex-auth export [<dir>]
+codex-auth export --cpa [<dir>]
+```
+
+## Standard Export
+
+- Exports stored account auth snapshots.
+- A directory path writes direct child `*.auth.json` files to that directory.
+- Without a directory path, files are written to `CODEX_HOME/accounts/backup`.
+- The exported directory can be imported with `codex-auth import <dir>`.
+
+## CLIProxyAPI Export
+
+`--cpa` exports flat [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) token JSON.
+
+- A directory path writes direct child `.json` files to that directory.
+- Without a directory path, files are written to `CODEX_HOME/accounts/backup`.
+- The exported directory can be imported with `codex-auth import --cpa <dir>`.
+
+## Output
+
+- `stdout` receives the number of exported accounts and destination directory.

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -25,6 +25,7 @@ Managed files:
 - `<codex_home>/auth.json`
 - `<codex_home>/accounts/registry.json`
 - `<codex_home>/accounts/<account file key>.auth.json`
+- `<codex_home>/accounts/backup/`
 - `<codex_home>/accounts/auth.json.bak.YYYYMMDD-hhmmss[.N]`
 - `<codex_home>/accounts/registry.json.bak.YYYYMMDD-hhmmss[.N]`
 - `<codex_home>/sessions/...`

--- a/src/auth/auth.zig
+++ b/src/auth/auth.zig
@@ -34,6 +34,14 @@ const StandardAuthJson = struct {
     last_refresh: []const u8,
 };
 
+const CpaAuthJson = struct {
+    id_token: []const u8,
+    access_token: []const u8,
+    refresh_token: []const u8,
+    account_id: []const u8,
+    last_refresh: []const u8,
+};
+
 fn normalizeEmailAlloc(allocator: std.mem.Allocator, email: []const u8) ![]u8 {
     var buf = try allocator.alloc(u8, email.len);
     for (email, 0..) |ch, i| {
@@ -250,6 +258,36 @@ pub fn convertCpaAuthJson(allocator: std.mem.Allocator, data: []const u8) ![]u8 
             .refresh_token = refresh_token,
             .account_id = jsonStringFieldOrDefault(obj, "account_id"),
         },
+        .last_refresh = jsonStringFieldOrDefault(obj, "last_refresh"),
+    }, .{ .whitespace = .indent_2 }, &out.writer);
+    try out.writer.writeAll("\n");
+    return try out.toOwnedSlice();
+}
+
+pub fn convertStandardAuthJsonToCpa(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return error.InvalidAuthFormat,
+    };
+    const tokens_val = obj.get("tokens") orelse return error.MissingTokens;
+    const tokens = switch (tokens_val) {
+        .object => |tokens| tokens,
+        else => return error.MissingTokens,
+    };
+    const refresh_token = jsonStringField(tokens, "refresh_token") orelse return error.MissingRefreshToken;
+    if (refresh_token.len == 0) return error.MissingRefreshToken;
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+
+    try std.json.Stringify.value(CpaAuthJson{
+        .id_token = jsonStringFieldOrDefault(tokens, "id_token"),
+        .access_token = jsonStringFieldOrDefault(tokens, "access_token"),
+        .refresh_token = refresh_token,
+        .account_id = jsonStringFieldOrDefault(tokens, "account_id"),
         .last_refresh = jsonStringFieldOrDefault(obj, "last_refresh"),
     }, .{ .whitespace = .indent_2 }, &out.writer);
     try out.writer.writeAll("\n");

--- a/src/cli/commands/export.zig
+++ b/src/cli/commands/export.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const types = @import("../types.zig");
+const common = @import("common.zig");
+
+pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.ParseResult {
+    if (args.len == 1 and common.isHelpFlag(std.mem.sliceTo(args[0], 0))) {
+        return .{ .command = .{ .help = .export_auth } };
+    }
+
+    var dest_path: ?[]u8 = null;
+    var format: types.ExportFormat = .standard;
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = std.mem.sliceTo(args[i], 0);
+        if (std.mem.eql(u8, arg, "--cpa")) {
+            if (format == .cpa) {
+                if (dest_path) |path| allocator.free(path);
+                return common.usageErrorResult(allocator, .export_auth, "duplicate `--cpa` for `export`.", .{});
+            }
+            format = .cpa;
+        } else if (common.isHelpFlag(arg)) {
+            if (dest_path) |path| allocator.free(path);
+            return common.usageErrorResult(allocator, .export_auth, "`--help` must be used by itself for `export`.", .{});
+        } else if (std.mem.startsWith(u8, arg, "-")) {
+            if (dest_path) |path| allocator.free(path);
+            return common.usageErrorResult(allocator, .export_auth, "unknown flag `{s}` for `export`.", .{arg});
+        } else {
+            if (dest_path != null) {
+                if (dest_path) |path| allocator.free(path);
+                return common.usageErrorResult(allocator, .export_auth, "unexpected extra path `{s}` for `export`.", .{arg});
+            }
+            dest_path = try allocator.dupe(u8, arg);
+        }
+    }
+
+    return .{ .command = .{ .export_auth = .{
+        .dest_path = dest_path,
+        .format = format,
+    } } };
+}

--- a/src/cli/commands/root.zig
+++ b/src/cli/commands/root.zig
@@ -5,6 +5,7 @@ const common = @import("common.zig");
 const clean = @import("clean.zig");
 const config = @import("config.zig");
 const daemon = @import("daemon.zig");
+const export_auth = @import("export.zig");
 const import_auth = @import("import.zig");
 const list = @import("list.zig");
 const login = @import("login.zig");
@@ -41,6 +42,7 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !type
     if (std.mem.eql(u8, cmd, "list")) return list.parse(allocator, args[2..]);
     if (std.mem.eql(u8, cmd, "login")) return login.parse(allocator, args[2..]);
     if (std.mem.eql(u8, cmd, "import")) return import_auth.parse(allocator, args[2..]);
+    if (std.mem.eql(u8, cmd, "export")) return export_auth.parse(allocator, args[2..]);
     if (std.mem.eql(u8, cmd, "switch")) return switch_account.parse(allocator, args[2..]);
     if (std.mem.eql(u8, cmd, "remove")) return remove.parse(allocator, args[2..]);
     if (std.mem.eql(u8, cmd, "clean")) return clean.parse(allocator, args[2..]);
@@ -62,6 +64,9 @@ pub fn freeParseResult(allocator: std.mem.Allocator, result: *types.ParseResult)
 fn freeCommand(allocator: std.mem.Allocator, cmd: *types.Command) void {
     switch (cmd.*) {
         .import_auth => |opts| common.freeImportOptions(allocator, opts.auth_path, opts.alias),
+        .export_auth => |opts| {
+            if (opts.dest_path) |path| allocator.free(path);
+        },
         .switch_account => |opts| {
             if (opts.query) |query| allocator.free(query);
         },
@@ -92,6 +97,7 @@ fn helpTopicForName(name: []const u8) ?types.HelpTopic {
     if (std.mem.eql(u8, name, "status")) return .status;
     if (std.mem.eql(u8, name, "login")) return .login;
     if (std.mem.eql(u8, name, "import")) return .import_auth;
+    if (std.mem.eql(u8, name, "export")) return .export_auth;
     if (std.mem.eql(u8, name, "switch")) return .switch_account;
     if (std.mem.eql(u8, name, "remove")) return .remove_account;
     if (std.mem.eql(u8, name, "clean")) return .clean;

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -70,6 +70,7 @@ pub fn writeHelp(
     try writeCommandDetail(out, use_color, "import <path> [--alias <alias>]");
     try writeCommandDetail(out, use_color, "import --cpa [<path>] [--alias <alias>]");
     try writeCommandDetail(out, use_color, "import --purge [<path>]");
+    try writeCommandSummary(out, use_color, "export [<dir>] [--cpa]", "Export stored account auth files");
     try writeCommandSummary(out, use_color, "switch", "Switch the active account");
     try writeCommandDetail(out, use_color, "switch [--live] [--api|--skip-api]");
     try writeCommandDetail(out, use_color, "switch <alias|email|display-number|query>");
@@ -156,6 +157,7 @@ fn commandNameForTopic(topic: HelpTopic) []const u8 {
         .status => "status",
         .login => "login",
         .import_auth => "import",
+        .export_auth => "export",
         .switch_account => "switch",
         .remove_account => "remove",
         .clean => "clean",
@@ -171,6 +173,7 @@ fn commandDescriptionForTopic(topic: HelpTopic) []const u8 {
         .status => "Show auto-switch, service, and usage API status.",
         .login => "Run `codex login` or `codex login --device-auth`, then add the current account.",
         .import_auth => "Import auth files or rebuild the registry.",
+        .export_auth => "Export stored account auth files.",
         .switch_account => "Switch the active account by alias, email, display number, or partial query.",
         .remove_account => "Remove one or more accounts by alias, email, display number, or partial query.",
         .clean => "Delete backup and stale files under accounts/.",
@@ -181,14 +184,14 @@ fn commandDescriptionForTopic(topic: HelpTopic) []const u8 {
 
 fn commandHelpHasExamples(topic: HelpTopic) bool {
     return switch (topic) {
-        .import_auth, .switch_account, .remove_account, .config, .daemon => true,
+        .import_auth, .export_auth, .switch_account, .remove_account, .config, .daemon => true,
         else => false,
     };
 }
 
 fn commandHelpHasOptions(topic: HelpTopic) bool {
     return switch (topic) {
-        .list, .login, .import_auth, .switch_account, .remove_account, .config, .daemon => true,
+        .list, .login, .import_auth, .export_auth, .switch_account, .remove_account, .config, .daemon => true,
         else => false,
     };
 }
@@ -227,6 +230,10 @@ fn writeUsageLines(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  codex-auth import --cpa [<path>] [--alias <alias>]\n");
             try out.writeAll("  codex-auth import --purge [<path>]\n");
         },
+        .export_auth => {
+            try out.writeAll("  codex-auth export [<dir>]\n");
+            try out.writeAll("  codex-auth export --cpa [<dir>]\n");
+        },
         .switch_account => {
             try out.writeAll("  codex-auth switch [--live] [--api|--skip-api]\n");
             try out.writeAll("  codex-auth switch <alias|email|display-number|query>\n");
@@ -260,6 +267,7 @@ pub fn helpCommandForTopic(topic: HelpTopic) []const u8 {
         .status => "codex-auth status --help",
         .login => "codex-auth login --help",
         .import_auth => "codex-auth import --help",
+        .export_auth => "codex-auth export --help",
         .switch_account => "codex-auth switch --help",
         .remove_account => "codex-auth remove --help",
         .clean => "codex-auth clean --help",
@@ -289,6 +297,10 @@ fn writeOptionLines(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  --cpa [<path>]   Import CPA flat token JSON from a file or directory. Uses `~/.cli-proxy-api` when omitted.\n");
             try out.writeAll("  --alias <alias>  Set an alias for a single imported account.\n");
             try out.writeAll("  --purge [<path>] Rebuild `registry.json` from auth files. Uses the accounts directory when omitted.\n");
+        },
+        .export_auth => {
+            try out.writeAll("  <dir>   Directory to write exported account files. Uses `CODEX_HOME/accounts/backup` when omitted.\n");
+            try out.writeAll("  --cpa   Export CPA flat token JSON. Without this, exports Codex auth snapshots.\n");
         },
         .switch_account => {
             try out.writeAll("  --live       Open the live switch UI.\n");
@@ -352,6 +364,11 @@ fn writeExampleLines(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  codex-auth import /path/to/auth.json --alias personal\n");
             try out.writeAll("  codex-auth import --cpa /path/to/token.json --alias work\n");
             try out.writeAll("  codex-auth import --purge\n");
+        },
+        .export_auth => {
+            try out.writeAll("  codex-auth export\n");
+            try out.writeAll("  codex-auth export /path/to/backup\n");
+            try out.writeAll("  codex-auth export --cpa /path/to/cpa-backup\n");
         },
         .switch_account => {
             try out.writeAll("  codex-auth switch\n");

--- a/src/cli/types.zig
+++ b/src/cli/types.zig
@@ -18,6 +18,11 @@ pub const ImportOptions = struct {
     purge: bool,
     source: ImportSource,
 };
+pub const ExportFormat = enum { standard, cpa };
+pub const ExportOptions = struct {
+    dest_path: ?[]u8,
+    format: ExportFormat,
+};
 pub const SwitchOptions = struct {
     query: ?[]u8,
     live: bool = false,
@@ -56,6 +61,7 @@ pub const HelpTopic = enum {
     status,
     login,
     import_auth,
+    export_auth,
     switch_account,
     remove_account,
     clean,
@@ -67,6 +73,7 @@ pub const Command = union(enum) {
     list: ListOptions,
     login: LoginOptions,
     import_auth: ImportOptions,
+    export_auth: ExportOptions,
     switch_account: SwitchOptions,
     remove_account: RemoveOptions,
     clean: CleanOptions,

--- a/src/registry/export.zig
+++ b/src/registry/export.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+const app_runtime = @import("../core/runtime.zig");
+const auth = @import("../auth/auth.zig");
+const common = @import("common.zig");
+
+const Registry = common.Registry;
+const accountAuthPath = common.accountAuthPath;
+const accountSnapshotFileName = common.accountSnapshotFileName;
+const copyManagedFile = common.copyManagedFile;
+const ensurePrivateDir = common.ensurePrivateDir;
+const readFileAlloc = common.readFileAlloc;
+const writeFile = common.writeFile;
+
+pub const ExportFormat = enum { standard, cpa };
+
+pub const ExportSummary = struct {
+    dest_path: []u8,
+    exported: usize,
+
+    pub fn deinit(self: *ExportSummary, allocator: std.mem.Allocator) void {
+        allocator.free(self.dest_path);
+    }
+};
+
+pub fn defaultExportDirectory(allocator: std.mem.Allocator, codex_home: []const u8) ![]u8 {
+    return try std.fs.path.join(allocator, &[_][]const u8{ codex_home, "accounts", "backup" });
+}
+
+pub fn exportAccounts(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *const Registry,
+    maybe_dest_path: ?[]const u8,
+    format: ExportFormat,
+) !ExportSummary {
+    const dest_path = if (maybe_dest_path) |path|
+        try allocator.dupe(u8, path)
+    else
+        try defaultExportDirectory(allocator, codex_home);
+    errdefer allocator.free(dest_path);
+
+    try ensurePrivateDir(dest_path);
+
+    var exported: usize = 0;
+    for (reg.accounts.items) |rec| {
+        const src = try accountAuthPath(allocator, codex_home, rec.account_key);
+        defer allocator.free(src);
+
+        const base_name = try accountSnapshotFileName(allocator, rec.account_key);
+        defer allocator.free(base_name);
+
+        const dest_name = switch (format) {
+            .standard => try allocator.dupe(u8, base_name),
+            .cpa => try cpaExportFileName(allocator, base_name),
+        };
+        defer allocator.free(dest_name);
+
+        const dest = try std.fs.path.join(allocator, &[_][]const u8{ dest_path, dest_name });
+        defer allocator.free(dest);
+
+        switch (format) {
+            .standard => try copyManagedFile(src, dest),
+            .cpa => try exportCpaFile(allocator, src, dest),
+        }
+        exported += 1;
+    }
+
+    return .{
+        .dest_path = dest_path,
+        .exported = exported,
+    };
+}
+
+fn cpaExportFileName(allocator: std.mem.Allocator, auth_name: []const u8) ![]u8 {
+    if (std.mem.endsWith(u8, auth_name, ".auth.json")) {
+        return try std.mem.concat(allocator, u8, &[_][]const u8{ auth_name[0 .. auth_name.len - ".auth.json".len], ".json" });
+    }
+    return try std.mem.concat(allocator, u8, &[_][]const u8{ auth_name, ".json" });
+}
+
+fn exportCpaFile(allocator: std.mem.Allocator, src: []const u8, dest: []const u8) !void {
+    var file = try std.Io.Dir.cwd().openFile(app_runtime.io(), src, .{});
+    defer file.close(app_runtime.io());
+    const data = try readFileAlloc(file, allocator, 10 * 1024 * 1024);
+    defer allocator.free(data);
+
+    const converted = try auth.convertStandardAuthJsonToCpa(allocator, data);
+    defer allocator.free(converted);
+    try writeFile(dest, converted);
+}

--- a/src/registry/root.zig
+++ b/src/registry/root.zig
@@ -7,6 +7,7 @@ const clean = @import("clean.zig");
 const account_ops = @import("account_ops.zig");
 const parse = @import("parse.zig");
 const import_mod = @import("import.zig");
+const export_mod = @import("export.zig");
 const storage = @import("storage.zig");
 pub const PlanType = common.PlanType;
 pub const AuthMode = common.AuthMode;
@@ -115,6 +116,10 @@ const importAuthInfo = import_mod.importAuthInfo;
 const importAccountsSnapshotDirectory = import_mod.importAccountsSnapshotDirectory;
 const sortAccountsByEmail = import_mod.sortAccountsByEmail;
 const syncCurrentAuthBestEffort = import_mod.syncCurrentAuthBestEffort;
+
+pub const ExportSummary = export_mod.ExportSummary;
+pub const defaultExportDirectory = export_mod.defaultExportDirectory;
+pub const exportAccounts = export_mod.exportAccounts;
 
 pub const findAccountIndexByAccountKey = account_ops.findAccountIndexByAccountKey;
 pub const setActiveAccountKey = account_ops.setActiveAccountKey;

--- a/src/workflows/export.zig
+++ b/src/workflows/export.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const cli = @import("../cli/root.zig");
+const registry = @import("../registry/root.zig");
+const io_util = @import("../core/io_util.zig");
+
+pub fn handleExport(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.types.ExportOptions) !void {
+    var reg = try registry.loadRegistry(allocator, codex_home);
+    defer reg.deinit(allocator);
+
+    var summary = try registry.exportAccounts(allocator, codex_home, &reg, opts.dest_path, switch (opts.format) {
+        .standard => .standard,
+        .cpa => .cpa,
+    });
+    defer summary.deinit(allocator);
+
+    var stdout: io_util.Stdout = undefined;
+    stdout.init();
+    const out = stdout.out();
+    try out.print("Exported {d} {s} to {s}\n", .{
+        summary.exported,
+        if (summary.exported == 1) "account" else "accounts",
+        summary.dest_path,
+    });
+    try out.flush();
+}

--- a/src/workflows/root.zig
+++ b/src/workflows/root.zig
@@ -21,6 +21,7 @@ const config_workflow = @import("config.zig");
 const list_workflow = @import("list.zig");
 const login_workflow = @import("login.zig");
 const import_workflow = @import("import.zig");
+const export_workflow = @import("export.zig");
 const switch_workflow = @import("switch.zig");
 const remove_workflow = @import("remove.zig");
 const workflow_env = @import("env.zig");
@@ -153,6 +154,7 @@ fn runMain(init: std.process.Init.Minimal) !void {
         .list => |opts| try list_workflow.handleList(allocator, codex_home.?, opts),
         .login => |opts| try login_workflow.handleLogin(allocator, codex_home.?, opts),
         .import_auth => |opts| try import_workflow.handleImport(allocator, codex_home.?, opts),
+        .export_auth => |opts| try export_workflow.handleExport(allocator, codex_home.?, opts),
         .switch_account => |opts| try switch_workflow.handleSwitch(allocator, codex_home.?, opts),
         .remove_account => |opts| try remove_workflow.handleRemove(allocator, codex_home.?, opts),
         .clean => try clean_workflow.handleClean(allocator, codex_home.?),

--- a/tests/cli_behavior_test.zig
+++ b/tests/cli_behavior_test.zig
@@ -153,6 +153,43 @@ test "Scenario: Given import cpa with purge when parsing then usage error is ret
     try expectUsageError(result, .import_auth, "`--purge`");
 }
 
+test "Scenario: Given export directory when parsing then export options are preserved" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "export", "/tmp/codex-backup" };
+    var result = try cli.commands.parseArgs(gpa, &args);
+    defer cli.commands.freeParseResult(gpa, &result);
+
+    switch (result) {
+        .command => |cmd| switch (cmd) {
+            .export_auth => |opts| {
+                try std.testing.expect(opts.dest_path != null);
+                try std.testing.expectEqualStrings("/tmp/codex-backup", opts.dest_path.?);
+                try std.testing.expectEqual(cli.types.ExportFormat.standard, opts.format);
+            },
+            else => return error.TestExpectedEqual,
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "Scenario: Given export cpa without directory when parsing then cpa mode is preserved" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "export", "--cpa" };
+    var result = try cli.commands.parseArgs(gpa, &args);
+    defer cli.commands.freeParseResult(gpa, &result);
+
+    switch (result) {
+        .command => |cmd| switch (cmd) {
+            .export_auth => |opts| {
+                try std.testing.expect(opts.dest_path == null);
+                try std.testing.expectEqual(cli.types.ExportFormat.cpa, opts.format);
+            },
+            else => return error.TestExpectedEqual,
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
 test "Scenario: Given import unknown short purge flag when parsing then usage error is returned" {
     const gpa = std.testing.allocator;
     const args = [_][:0]const u8{ "codex-auth", "import", "-P", "/tmp/auth.json" };

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -1649,3 +1649,85 @@ test "import cpa path with directory imports multiple json files and skips bad f
     try std.testing.expect(report.total_files == 4);
     try std.testing.expectEqual(@as(usize, 2), reg.accounts.items.len);
 }
+
+test "export accounts writes standard auth snapshots to explicit directory" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "export-standard@example.com", "plus");
+    defer gpa.free(cpa_json);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/source.json", .data = cpa_json });
+
+    const import_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "imports", "source.json" });
+    defer gpa.free(import_path);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+    var import_report = try registry.importCpaPath(gpa, codex_home, &reg, import_path, null);
+    defer import_report.deinit(gpa);
+
+    const export_dir = try fs.path.join(gpa, &[_][]const u8{ codex_home, "exports" });
+    defer gpa.free(export_dir);
+    var summary = try registry.exportAccounts(gpa, codex_home, &reg, export_dir, .standard);
+    defer summary.deinit(gpa);
+
+    try std.testing.expectEqual(@as(usize, 1), summary.exported);
+    const account_key = try fixtures.accountKeyForEmailAlloc(gpa, "export-standard@example.com");
+    defer gpa.free(account_key);
+    const snapshot_name = try registry.accountSnapshotFileName(gpa, account_key);
+    defer gpa.free(snapshot_name);
+    const exported_path = try fs.path.join(gpa, &[_][]const u8{ export_dir, snapshot_name });
+    defer gpa.free(exported_path);
+    const exported = try fixtures.readFileAlloc(gpa, exported_path);
+    defer gpa.free(exported);
+    try std.testing.expect(std.mem.indexOf(u8, exported, "\"tokens\": {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, exported, "\"refresh_token\": \"refresh-export-standard@example.com\"") != null);
+}
+
+test "export accounts writes cpa token files to default backup directory" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "export-cpa@example.com", "pro");
+    defer gpa.free(cpa_json);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/source.json", .data = cpa_json });
+
+    const import_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "imports", "source.json" });
+    defer gpa.free(import_path);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+    var import_report = try registry.importCpaPath(gpa, codex_home, &reg, import_path, null);
+    defer import_report.deinit(gpa);
+
+    var summary = try registry.exportAccounts(gpa, codex_home, &reg, null, .cpa);
+    defer summary.deinit(gpa);
+
+    const default_dir = try registry.defaultExportDirectory(gpa, codex_home);
+    defer gpa.free(default_dir);
+    try std.testing.expectEqualStrings(default_dir, summary.dest_path);
+    try std.testing.expectEqual(@as(usize, 1), summary.exported);
+
+    const account_key = try fixtures.accountKeyForEmailAlloc(gpa, "export-cpa@example.com");
+    defer gpa.free(account_key);
+    const snapshot_name = try registry.accountSnapshotFileName(gpa, account_key);
+    defer gpa.free(snapshot_name);
+    const cpa_name = try std.mem.concat(gpa, u8, &[_][]const u8{ snapshot_name[0 .. snapshot_name.len - ".auth.json".len], ".json" });
+    defer gpa.free(cpa_name);
+    const exported_path = try fs.path.join(gpa, &[_][]const u8{ default_dir, cpa_name });
+    defer gpa.free(exported_path);
+    const exported = try fixtures.readFileAlloc(gpa, exported_path);
+    defer gpa.free(exported);
+    try std.testing.expect(std.mem.indexOf(u8, exported, "\"refresh_token\": \"refresh-export-cpa@example.com\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, exported, "\"tokens\"") == null);
+}


### PR DESCRIPTION
Adds `codex-auth export [<dir>]` for exporting stored account auth snapshots.

When no directory is provided, exports to `CODEX_HOME/accounts/backup`.

Also adds `codex-auth export --cpa [<dir>]` to export CPA flat token JSON that can be imported with `codex-auth import --cpa <new_dir>`.

Closes #89