### PR TITLE
fix: Hide API child process window on Windows

### DIFF
--- a/src/api/http_child.zig
+++ b/src/api/http_child.zig
@@ -45,6 +45,7 @@ pub fn runChildCaptureWithInputAndOutputLimit(
         .stdin = if (stdin_bytes != null) .pipe else .ignore,
         .stdout = .pipe,
         .stderr = .pipe,
+        .create_no_window = true,
     }) catch |err| switch (err) {
         else => return err,
     };


### PR DESCRIPTION
## Summary
- Set API child process launches to use the Windows no-window process flag.
- Prevent background API refreshes from opening transient console windows when auto-switch is enabled.

## Validation
- Passed: `zig build run -- list`
- Passed: `zig build`
- Not clean in this local Windows environment: `zig build test` still has environment-specific failures because `pwsh.exe` is unavailable and Windows symlink creation requires privilege/developer mode.