### PR TITLE
feat: remove persistent api config toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Detailed command documentation lives in [docs/commands/README.md](./docs/command
 |---------|-------------|
 | [`codex-auth config auto enable\|disable`](./docs/commands/config.md) | Enable or disable background auto-switching |
 | [`codex-auth config auto --5h <percent> [--weekly <percent>]`](./docs/commands/config.md) | Configure background auto-switch thresholds |
-| [`codex-auth config api enable\|disable`](./docs/commands/config.md) | Enable or disable default API-backed refresh |
+| [`codex-auth config live --interval <seconds>`](./docs/commands/config.md) | Configure live TUI refresh interval |
 
 ## Quick Examples
 
@@ -95,7 +95,7 @@ codex-auth switch
 codex-auth switch 02
 codex-auth remove work
 codex-auth import /path/to/auth.json --alias personal
-codex-auth config api disable
+codex-auth list --skip-api
 codex-auth status
 ```
 
@@ -103,23 +103,21 @@ codex-auth status
 
 ### Why is my usage limit not refreshing?
 
-If `codex-auth` is using local-only usage refresh, it reads the newest `~/.codex/sessions/**/rollout-*.jsonl` file. Recent Codex builds often write `token_count` events with `rate_limits: null`. The local files may still contain older usable usage limit data, but in practice they can lag by several hours, so local-only refresh may show a usage limit snapshot from hours ago instead of your latest state.
+API-backed refresh is the default. When you pass `--skip-api`, `codex-auth` reads the newest `~/.codex/sessions/**/rollout-*.jsonl` file instead. Recent Codex builds often write `token_count` events with `rate_limits: null`. The local files may still contain older usable usage limit data, but in practice they can lag by several hours, so local-only refresh may show a usage limit snapshot from hours ago instead of your latest state.
 
 - Upstream Codex issue: [openai/codex#14880](https://github.com/openai/codex/issues/14880)
 
-You can switch usage limit refresh to the usage API with:
+Run the API-backed default with:
 
 ```shell
-codex-auth config api enable
+codex-auth list
 ```
 
-Then confirm the current mode with:
+Run one local-only command with:
 
 ```shell
-codex-auth status
+codex-auth list --skip-api
 ```
-
-`status` should show `usage: api`.
 
 Verify with:
 
@@ -134,8 +132,8 @@ This project is provided as-is and use is at your own risk.
 **Usage Data Refresh Source:**
 `codex-auth` supports two sources for refreshing account usage/usage limit information:
 
-1. **API (default):** When `config api enable` is on, the tool makes direct HTTPS requests to OpenAI's endpoints using your account's access token. This enables both usage refresh and team name refresh. npm installs already satisfy the runtime requirement.
-2. **Local-only:** When `config api disable` is on, the tool scans local `~/.codex/sessions/*/rollout-*.jsonl` files for usage data and skips team name refresh API calls. This mode is safer, but it can be less accurate because recent Codex rollout files often contain `rate_limits: null`, so the latest local usage limit data may lag by several hours.
+1. **API (default):** The tool makes direct HTTPS requests to OpenAI's endpoints using your account's access token. This enables both usage refresh and team name refresh. npm installs already satisfy the runtime requirement.
+2. **Local-only:** With per-command `--skip-api`, the tool scans local `~/.codex/sessions/*/rollout-*.jsonl` files for usage data and skips team name refresh API calls. This mode is safer, but it can be less accurate because recent Codex rollout files often contain `rate_limits: null`, so the latest local usage limit data may lag by several hours.
 
 **API Call Declaration:**
-By enabling API(`codex-auth config api enable`), this tool will send your ChatGPT access token to OpenAI's servers, including `https://chatgpt.com/backend-api/wham/usage` for usage limit and `https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27` for team name. This behavior may be detected by OpenAI and could violate their terms of service, potentially leading to account suspension or other risks. The decision to use this feature and any resulting consequences are entirely yours.
+By using the default API-backed refresh, this tool will send your ChatGPT access token to OpenAI's servers, including `https://chatgpt.com/backend-api/wham/usage` for usage limit and `https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27` for team name. This behavior may be detected by OpenAI and could violate their terms of service, potentially leading to account suspension or other risks. The decision to use this feature and any resulting consequences are entirely yours.

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,18 +39,17 @@ The `accounts/check` response is parsed by `chatgpt_account_id`. `name: null` an
 
 ## Usage Refresh Rules
 
-- `api.usage = true`: foreground refresh uses the usage API.
-- `api.usage = false`: foreground refresh reads only the newest local `~/.codex/sessions/**/rollout-*.jsonl`.
-- when `api.usage = true`, `list` and interactive `switch` refresh all stored accounts before rendering, using stored auth snapshots under `accounts/` with a maximum concurrency of `3`
+- foreground refresh uses the usage API by default.
+- `--skip-api` reads only the newest local `~/.codex/sessions/**/rollout-*.jsonl`.
+- by default, `list` and interactive `switch` refresh all stored accounts before rendering, using stored auth snapshots under `accounts/` with a maximum concurrency of `3`
 - when one of those per-account foreground usage requests returns a non-`200` HTTP status, the corresponding `list` / `switch` row shows that response status in both usage columns until a later successful refresh replaces it
 - when a stored account snapshot cannot make a ChatGPT usage request because it is missing the required ChatGPT auth fields, the corresponding `list` / `switch` row shows `MissingAuth` in both usage columns until a later successful refresh replaces it
-- when `api.usage = false`, foreground refresh still uses only the active local rollout data because local session files do not identify the other stored accounts
-- `list` and interactive `switch` follow the same foreground usage mode by default: they honor the stored `api.usage` setting unless the command line overrides it
-- `list --api` and interactive `switch --api` force foreground usage refresh for that command even when `api.usage = false`
+- with `--skip-api`, foreground refresh still uses only the active local rollout data because local session files do not identify the other stored accounts
+- `list` and interactive `switch` use the API-backed path by default; `--api` is accepted as an explicit equivalent
 - `list --skip-api` and interactive `switch --skip-api` disable the foreground usage API path for that command
 - in `switch --live`, the initial live display and later refreshed displays trigger a foreground auto-switch when the active account shows `0%` on the 5h window, `0%` on the weekly window, or a numeric non-`200` usage API status overlay for the active row
 - `switch --live` still excludes errored rows from candidate selection, and it also skips candidates whose current displayed 5h or weekly value is already `0%`
-- with `--skip-api` or `api.usage = false`, `list` and `switch --live` can still refresh only the active account from local rollout data; non-active `switch` rows and non-active foreground auto-switch candidates still come from stored registry data
+- with `--skip-api`, `list` and `switch --live` can still refresh only the active account from local rollout data; non-active `switch` rows and non-active foreground auto-switch candidates still come from stored registry data
 - single-shot `switch --skip-api` skips the pre-render refresh round entirely and shows the stored registry picker directly
 - `switch <query>` always resolves selectors locally from stored data and does not accept `--live`, `--api`, or `--skip-api`
 - interactive `remove`, including `remove --live`, always stays local-only and never makes foreground usage API requests
@@ -65,12 +64,12 @@ The `accounts/check` response is parsed by `chatgpt_account_id`. `name: null` an
 
 ## Account Name Refresh Rules
 
-- `api.account = true` is required.
+- Account-name refresh uses the account API by default.
 - A usable ChatGPT auth context with both `access_token` and `chatgpt_account_id` is required. If either value is missing, refresh is skipped before any request is sent.
 - `login` refreshes immediately after the new active auth is ready.
 - Single-file `import` refreshes immediately for the imported auth context.
-- `list` and interactive `switch` follow the same foreground account-name refresh mode by default: they honor the stored `api.account` setting unless the command line overrides it.
-- `list --api` and interactive `switch --api` force synchronous `accounts/check` refresh for that command even when `api.account = false`; `list --skip-api` and interactive `switch --skip-api` skip it and use stored metadata only.
+- `list` and interactive `switch` refresh account names by default; `--api` is accepted as an explicit equivalent.
+- `list --skip-api` and interactive `switch --skip-api` skip account-name refresh and use stored metadata only.
 - `switch <query>` always stays local-only and does not accept `--live`, `--api`, or `--skip-api`.
 - `remove <query>` and `remove --all` always stay local-only and do not accept `--live`.
 - `list` and interactive `switch` load the request auth context from the current active `auth.json` when they do refresh.

--- a/docs/auto-switch.md
+++ b/docs/auto-switch.md
@@ -11,15 +11,12 @@ User-facing commands:
 - `codex-auth config auto enable`
 - `codex-auth config auto disable`
 - `codex-auth config auto [--5h <percent>] [--weekly <percent>]`
-- `codex-auth config api enable`
-- `codex-auth config api disable`
 
 Stored registry fields:
 
 - `auto_switch.enabled`
 - `auto_switch.threshold_5h_percent`
 - `auto_switch.threshold_weekly_percent`
-- `api.usage`
 
 The feature is off by default.
 
@@ -36,7 +33,7 @@ Each cycle:
 2. reloads `registry.json` only when the on-disk file changed, then rebuilds that in-memory index
 3. syncs the currently active `auth.json` into the in-memory registry when the active auth snapshot changed
 4. tries to refresh usage from the newest local rollout event first
-5. if no new local rollout event is available, or the newest event has no usable rate-limit windows, and `api.usage = true`, falls back to the ChatGPT usage API at most once per minute for the current active account
+5. if no new local rollout event is available, or the newest event has no usable rate-limit windows, falls back to the ChatGPT usage API at most once per minute for the current active account
 6. keeps the candidate index warm with a bounded candidate upkeep pass instead of batch-refreshing every candidate
 7. if the active account should switch, revalidates only the top few stale candidates before making the final switch decision
 8. writes `registry.json` only when state changed
@@ -51,11 +48,10 @@ The watcher also emits English-only service logs for debugging:
 
 ## Data Source Priority
 
-The background watcher is intentionally not API-only, even when `api.usage = true`.
+The background watcher is intentionally not API-only.
 
 - Local rollout events are preferred because they arrive much faster than periodic usage API polling.
 - API refresh remains useful as a slower fallback and calibration path when rollout data is missing or stale.
-- When `api.usage = false`, the watcher uses local rollout data only and makes no usage API requests.
 - When a new rollout event arrives but its `rate_limits` payload is `null`, `{}`, or otherwise lacks usable 5h/weekly windows, the watcher keeps the previous `last_usage` snapshot and relies on the API fallback path instead of overwriting usage with empty data.
 - The watcher resets the active-account API fallback cooldown when `active_account_key` changes, so a newly active account is not forced to wait behind the previous account's cooldown window.
 - API timeout and request-failure logs come from the same 5-second limit used by the underlying request path.
@@ -89,7 +85,7 @@ Candidate scoring is reset-aware:
 - if only one window is known, that window becomes the score
 - free accounts that expose only a single `10080`-minute weekly window remain eligible auto-switch candidates and use that weekly remaining percentage as their score
 - the watcher keeps that candidate score ordering in a daemon-local in-memory index; it is rebuilt on daemon start or whenever `registry.json` changes externally
-- when `api.usage = true`, watcher upkeep refreshes at most one stale top candidate per cycle while the current account is still healthy
+- watcher upkeep refreshes at most one stale top candidate per cycle while the current account is still healthy
 - when auto-switch is about to leave the current account, the watcher revalidates only the current heap top and then the next top candidates as needed, up to a small bounded budget, instead of refreshing every candidate
 - candidate freshness bookkeeping is daemon-local runtime state and is not persisted to `registry.json`
 - if no usage snapshot exists after that refresh step, the account is treated as fresh with score `100`
@@ -105,7 +101,7 @@ Platform bootstrap:
 
 Service definition files stay in the platform-standard per-user locations. The managed watcher process uses the current `codex_home` root, so when `CODEX_HOME` is set during enablement the watcher keeps reading and writing that override after it starts in the background.
 Foreground commands other than `help`, `version`, `status`, and `daemon` still reconcile the managed service definition after they complete.
-`config auto enable` also prints a short usage-mode note so the user can see whether switching is currently running with default API-backed usage data or local-only fallback semantics.
+`config auto enable` prints a short confirmation after the service is installed.
 When migrating from older Linux/WSL timer-based installs, enable/reconcile also removes the legacy `codex-auth-autoswitch.timer` unit file instead of leaving the old minute timer behind.
 
 ## Limits

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -21,6 +21,6 @@ This directory documents command behavior by command. Use `codex-auth <command> 
 
 - Commands resolve `codex_home` from `CODEX_HOME`, then `HOME/.codex`, then `USERPROFILE/.codex` on Windows.
 - Account selection commands use the same row ordering and display grouping.
-- `--api` forces remote usage and account-name refresh for the current command.
+- `--api` explicitly selects the default remote usage and account-name refresh path for the current command.
 - `--skip-api` forbids remote refresh for the current command.
 - Local-only usage refresh can update the active account from local Codex rollout files when usable local data exists.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -6,8 +6,8 @@
 codex-auth config auto enable
 codex-auth config auto disable
 codex-auth config auto --5h <percent> [--weekly <percent>]
-codex-auth config api enable
-codex-auth config api disable
+codex-auth config auto --weekly <percent>
+codex-auth config live --interval <seconds>
 ```
 
 ## Auto-Switch Config
@@ -22,12 +22,14 @@ codex-auth config api disable
 
 Threshold flags update the stored background auto-switch thresholds. Auto-switch behavior and platform integration details live in [docs/auto-switch.md](../auto-switch.md).
 
-## API Refresh Config
+## Live Refresh Config
 
-`config api enable` enables remote usage and account-name refresh by default.
+`config live --interval <seconds>` sets the live TUI refresh interval.
 
-`config api disable` switches default foreground behavior to local-only mode.
+- Allowed range: `5` to `3600`.
 
-Changing `config api` updates `registry.json` immediately. Per-command `--api` and `--skip-api` can override the stored mode for a single foreground command.
+## API Refresh
+
+API-backed refresh is the default for supported foreground and background paths. Use per-command `--skip-api` to run a foreground command with local data only. Older `registry.json` files may contain an `api` object; current builds ignore it and omit it on the next registry save.
 
 API behavior and endpoint details live in [docs/api.md](../api.md).

--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -33,7 +33,7 @@ codex-auth import --purge [<path>]
 - Without a path, it scans `~/.codex/accounts/`.
 - With a path, it scans auth files from that directory.
 - It also tries to import the current `~/.codex/auth.json` last.
-- It preserves stored `auto_switch` and `api` configuration.
+- It preserves stored `auto_switch` and live refresh configuration.
 - It clears and rebuilds account records, stored usage, active-account activation time, and local rollout dedupe state.
 - It does not delete old snapshot files or backups.
 

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -19,8 +19,8 @@ codex-auth list --skip-api
 
 ## Refresh Modes
 
-- Default mode honors the stored `config api` setting.
-- `--api` forces foreground usage and account-name API refresh.
+- Default mode performs foreground usage and account-name API refresh.
+- `--api` is accepted as an explicit equivalent to default mode.
 - `--skip-api` forbids remote API calls for this command.
 - `--live` keeps refreshing the terminal view and requires a TTY.
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -11,8 +11,7 @@ codex-auth status
 Shows local operational state for:
 
 - auto-switch configuration,
-- managed service or scheduled-task status,
-- usage refresh mode, and
-- the active account's latest stored usage state when available.
+- managed service or scheduled-task status, and
+- live refresh interval.
 
 `status` is read-only and does not reconcile the managed service definition.

--- a/docs/schema-migration.md
+++ b/docs/schema-migration.md
@@ -10,7 +10,7 @@ This document defines how `codex-auth` versions the on-disk `~/.codex/accounts/r
 
 ## Current Policy
 
-- `codex-auth` keeps a single `registry.json`; feature state such as `auto_switch` and `api` stays in that file.
+- `codex-auth` keeps a single `registry.json`; persisted feature state such as `auto_switch` and `live` stays in that file.
 - The latest binary supports every released schema. Right now that means:
   - legacy `version = 2`
   - current `schema_version = 4`
@@ -36,7 +36,7 @@ This document defines how `codex-auth` versions the on-disk `~/.codex/accounts/r
   - `active_account_activated_at_ms`
   - Per-account `last_local_rollout`
   - Current `auto_switch` block
-  - Current top-level `api` block
+  - Legacy top-level `api` block, now ignored and omitted on rewrite
   - Per-account `account_key`
   - Each account also stores `chatgpt_account_id` and `chatgpt_user_id`
 - `schema_version = 4`

--- a/src/auto/root.zig
+++ b/src/auto/root.zig
@@ -118,15 +118,6 @@ pub fn handleAutoCommand(allocator: std.mem.Allocator, codex_home: []const u8, c
     }
 }
 
-pub fn handleApiCommand(allocator: std.mem.Allocator, codex_home: []const u8, action: cli.types.ApiAction) !void {
-    var reg = try registry.loadRegistry(allocator, codex_home);
-    defer reg.deinit(allocator);
-    const enabled = action == .enable;
-    reg.api.usage = enabled;
-    reg.api.account = enabled;
-    try registry.saveRegistry(allocator, codex_home, &reg);
-}
-
 pub fn shouldEnsureManagedService(enabled: bool, runtime: RuntimeState, definition_matches: bool) bool {
     if (!enabled) return false;
     return runtime != .running or !definition_matches;
@@ -313,21 +304,16 @@ pub fn enableWithServiceHooksAndPreflight(
     // any managed artifacts before persisting the disabled rollback state.
     errdefer uninstaller(allocator, codex_home) catch {};
     try installer(allocator, codex_home, self_exe);
-    printAutoEnableUsageNote(reg.api.usage) catch |err| {
+    printAutoEnableUsageNote() catch |err| {
         std.log.warn("failed to print auto-enable usage note: {}", .{err});
     };
 }
 
-fn printAutoEnableUsageNote(api_enabled: bool) !void {
+fn printAutoEnableUsageNote() !void {
     var stdout: io_util.Stdout = undefined;
     stdout.init();
     const out = stdout.out();
-    if (api_enabled) {
-        try out.writeAll("auto-switch enabled; usage mode: api (default, most accurate for switching decisions)\n");
-    } else {
-        try out.writeAll("auto-switch enabled; usage mode: local-only (switching still works, but candidate validation is less accurate)\n");
-        try out.writeAll("Tip: run `codex-auth config api enable` for the most accurate switching decisions.\n");
-    }
+    try out.writeAll("auto-switch enabled\n");
     try out.flush();
 }
 

--- a/src/auto/status.zig
+++ b/src/auto/status.zig
@@ -12,8 +12,6 @@ pub const Status = struct {
     runtime: RuntimeState,
     threshold_5h_percent: u8,
     threshold_weekly_percent: u8,
-    api_usage_enabled: bool,
-    api_account_enabled: bool,
     live_interval_seconds: u16,
 };
 
@@ -40,8 +38,6 @@ pub fn getStatus(allocator: std.mem.Allocator, codex_home: []const u8) !Status {
         .runtime = queryRuntimeState(allocator),
         .threshold_5h_percent = reg.auto_switch.threshold_5h_percent,
         .threshold_weekly_percent = reg.auto_switch.threshold_weekly_percent,
-        .api_usage_enabled = reg.api.usage,
-        .api_account_enabled = reg.api.account,
         .live_interval_seconds = reg.live.interval_seconds,
     };
 }
@@ -65,14 +61,6 @@ fn writeStatusWithColor(out: *std.Io.Writer, status: Status, use_color: bool) !v
         "5h<{d}%, weekly<{d}%",
         .{ status.threshold_5h_percent, status.threshold_weekly_percent },
     );
-    try out.writeAll("\n");
-
-    try out.writeAll("usage: ");
-    try out.writeAll(if (status.api_usage_enabled) "api" else "local");
-    try out.writeAll("\n");
-
-    try out.writeAll("account: ");
-    try out.writeAll(if (status.api_account_enabled) "api" else "disabled");
     try out.writeAll("\n");
 
     try out.writeAll("live refresh: ");

--- a/src/cli/commands/config.zig
+++ b/src/cli/commands/config.zig
@@ -12,9 +12,6 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.Pa
     if (std.mem.eql(u8, scope, "auto")) {
         return parseAuto(allocator, args[1..]);
     }
-    if (std.mem.eql(u8, scope, "api")) {
-        return parseApi(allocator, args[1..]);
-    }
     if (std.mem.eql(u8, scope, "live")) {
         return parseLive(allocator, args[1..]);
     }
@@ -64,17 +61,6 @@ fn parseAuto(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.Pa
         .threshold_5h_percent = threshold_5h_percent,
         .threshold_weekly_percent = threshold_weekly_percent,
     } } } } };
-}
-
-fn parseApi(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.ParseResult {
-    if (args.len == 1 and common.isHelpFlag(std.mem.sliceTo(args[0], 0))) {
-        return .{ .command = .{ .help = .config } };
-    }
-    if (args.len != 1) return common.usageErrorResult(allocator, .config, "`config api` requires `enable` or `disable`.", .{});
-    const action = std.mem.sliceTo(args[0], 0);
-    if (std.mem.eql(u8, action, "enable")) return .{ .command = .{ .config = .{ .api = .enable } } };
-    if (std.mem.eql(u8, action, "disable")) return .{ .command = .{ .config = .{ .api = .disable } } };
-    return common.usageErrorResult(allocator, .config, "unknown action `{s}` for `config api`.", .{action});
 }
 
 fn parseLive(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.ParseResult {

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -7,12 +7,12 @@ const style = @import("style.zig");
 
 const HelpTopic = types.HelpTopic;
 
-pub fn printHelp(auto_cfg: *const registry.AutoSwitchConfig, api_cfg: *const registry.ApiConfig) !void {
+pub fn printHelp(auto_cfg: *const registry.AutoSwitchConfig) !void {
     var stdout: io_util.Stdout = undefined;
     stdout.init();
     const out = stdout.out();
     const use_color = style.stdoutColorEnabled();
-    try writeHelp(out, use_color, auto_cfg, api_cfg);
+    try writeHelp(out, use_color, auto_cfg);
     try out.flush();
 }
 
@@ -20,7 +20,6 @@ pub fn writeHelp(
     out: *std.Io.Writer,
     use_color: bool,
     auto_cfg: *const registry.AutoSwitchConfig,
-    api_cfg: *const registry.ApiConfig,
 ) !void {
     if (use_color) try out.writeAll(style.ansi.cyan);
     try out.writeAll("codex-auth");
@@ -39,21 +38,7 @@ pub fn writeHelp(
         .{ if (auto_cfg.enabled) "ON" else "OFF", auto_cfg.threshold_5h_percent, auto_cfg.threshold_weekly_percent },
     );
 
-    if (use_color) try out.writeAll(style.ansi.cyan);
-    try out.writeAll("Usage API:");
-    if (use_color) try out.writeAll(style.ansi.reset);
-    try out.print(
-        " {s} ({s})\n",
-        .{ if (api_cfg.usage) "ON" else "OFF", if (api_cfg.usage) "api" else "local" },
-    );
-
-    if (use_color) try out.writeAll(style.ansi.cyan);
-    try out.writeAll("Account API:");
-    if (use_color) try out.writeAll(style.ansi.reset);
-    try out.print(
-        " {s}\n\n",
-        .{if (api_cfg.account) "ON" else "OFF"},
-    );
+    try out.writeAll("\n");
 
     if (use_color) try out.writeAll(style.ansi.cyan);
     try out.writeAll("Commands:");
@@ -64,7 +49,7 @@ pub fn writeHelp(
     try writeCommandSummary(out, use_color, "help <command>", "Show command-specific help");
     try writeCommandSummary(out, use_color, "--version, -V", "Show version");
     try writeCommandSummary(out, use_color, "list [--live] [--api|--skip-api]", "List available accounts");
-    try writeCommandSummary(out, use_color, "status", "Show auto-switch, service, and usage API status");
+    try writeCommandSummary(out, use_color, "status", "Show auto-switch and service status");
     try writeCommandSummary(out, use_color, "login [--device-auth]", "Login and add the current account");
     try writeCommandSummary(out, use_color, "import", "Import auth files or rebuild registry");
     try writeCommandDetail(out, use_color, "import <path> [--alias <alias>]");
@@ -84,8 +69,6 @@ pub fn writeHelp(
     try writeCommandDetail(out, use_color, "config auto disable");
     try writeCommandDetail(out, use_color, "config auto --5h <percent> [--weekly <percent>]");
     try writeCommandDetail(out, use_color, "config auto --weekly <percent>");
-    try writeCommandDetail(out, use_color, "config api enable");
-    try writeCommandDetail(out, use_color, "config api disable");
     try writeCommandDetail(out, use_color, "config live --interval <seconds>");
     try writeCommandSummary(out, use_color, "daemon --watch|--once", "Run the background auto-switch daemon");
 
@@ -95,7 +78,7 @@ pub fn writeHelp(
     if (use_color) try out.writeAll(style.ansi.reset);
     try out.writeAll("\n");
     try out.writeAll("  Run `codex-auth <command> --help` for command-specific usage details.\n");
-    try out.writeAll("  `config api enable` may trigger OpenAI account restrictions or suspension in some environments.\n");
+    try out.writeAll("  API-backed refresh is the default; use `--skip-api` for a local-only foreground command.\n");
 }
 
 fn writeCommandSummary(out: *std.Io.Writer, use_color: bool, command: []const u8, description: []const u8) !void {
@@ -170,14 +153,14 @@ fn commandDescriptionForTopic(topic: HelpTopic) []const u8 {
     return switch (topic) {
         .top_level => "Command-line account management for Codex.",
         .list => "List available accounts.",
-        .status => "Show auto-switch, service, and usage API status.",
+        .status => "Show auto-switch and service status.",
         .login => "Run `codex login` or `codex login --device-auth`, then add the current account.",
         .import_auth => "Import auth files or rebuild the registry.",
         .export_auth => "Export stored account auth files.",
         .switch_account => "Switch the active account by alias, email, display number, or partial query.",
         .remove_account => "Remove one or more accounts by alias, email, display number, or partial query.",
         .clean => "Delete backup and stale files under accounts/.",
-        .config => "Manage auto-switch, API, and live refresh configuration.",
+        .config => "Manage auto-switch and live refresh configuration.",
         .daemon => "Run the background auto-switch daemon.",
     };
 }
@@ -249,8 +232,6 @@ fn writeUsageLines(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  codex-auth config auto disable\n");
             try out.writeAll("  codex-auth config auto --5h <percent> [--weekly <percent>]\n");
             try out.writeAll("  codex-auth config auto --weekly <percent>\n");
-            try out.writeAll("  codex-auth config api enable\n");
-            try out.writeAll("  codex-auth config api disable\n");
             try out.writeAll("  codex-auth config live --interval <seconds>\n");
         },
         .daemon => {
@@ -323,8 +304,6 @@ fn writeOptionLines(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  --5h <percent>    Set the 5-hour usage threshold from 1 to 100.\n");
             try out.writeAll("  --weekly <percent>\n");
             try out.writeAll("                    Set the weekly usage threshold from 1 to 100.\n");
-            try out.writeAll("  api enable        Enable usage and account APIs.\n");
-            try out.writeAll("  api disable       Disable usage and account APIs.\n");
             try out.writeAll("  live --interval <seconds>\n");
             try out.writeAll("                    Set the live TUI refresh interval from 5 to 3600 seconds.\n");
         },
@@ -393,7 +372,6 @@ fn writeExampleLines(out: *std.Io.Writer, topic: HelpTopic) !void {
         .clean => try out.writeAll("  codex-auth clean\n"),
         .config => {
             try out.writeAll("  codex-auth config auto --5h 12 --weekly 8\n");
-            try out.writeAll("  codex-auth config api enable\n");
             try out.writeAll("  codex-auth config live --interval 60\n");
         },
         .daemon => {

--- a/src/cli/types.zig
+++ b/src/cli/types.zig
@@ -44,13 +44,11 @@ pub const AutoOptions = union(enum) {
     action: AutoAction,
     configure: AutoThresholdOptions,
 };
-pub const ApiAction = enum { enable, disable };
 pub const LiveOptions = struct {
     interval_seconds: u16,
 };
 pub const ConfigOptions = union(enum) {
     auto_switch: AutoOptions,
-    api: ApiAction,
     live: LiveOptions,
 };
 pub const DaemonMode = enum { watch, once };

--- a/src/registry/common.zig
+++ b/src/registry/common.zig
@@ -98,12 +98,6 @@ pub const LiveConfig = struct {
     interval_seconds: u16 = default_live_refresh_interval_seconds,
 };
 
-pub const ApiConfigParseResult = struct {
-    has_object: bool = false,
-    has_usage: bool = false,
-    has_account: bool = false,
-};
-
 pub const AccountRecord = struct {
     account_key: []u8,
     chatgpt_account_id: []u8,

--- a/src/registry/import.zig
+++ b/src/registry/import.zig
@@ -9,11 +9,9 @@ const account_ops = @import("account_ops.zig");
 
 const PlanType = common.PlanType;
 const AutoSwitchConfig = common.AutoSwitchConfig;
-const ApiConfig = common.ApiConfig;
 const AccountRecord = common.AccountRecord;
 const Registry = common.Registry;
 const defaultAutoSwitchConfig = common.defaultAutoSwitchConfig;
-const defaultApiConfig = common.defaultApiConfig;
 const freeAccountRecord = common.freeAccountRecord;
 const normalizeEmailAlloc = common.normalizeEmailAlloc;
 const activeAuthPath = common.activeAuthPath;
@@ -31,7 +29,6 @@ const registryPath = common.registryPath;
 const backupAuthIfChanged = clean.backupAuthIfChanged;
 const backupDir = clean.backupDir;
 const parseAutoSwitch = parse.parseAutoSwitch;
-const parseApiConfig = parse.parseApiConfig;
 const findAccountIndexByAccountKey = account_ops.findAccountIndexByAccountKey;
 const setActiveAccountKey = account_ops.setActiveAccountKey;
 const activateAccountByKey = account_ops.activateAccountByKey;
@@ -45,7 +42,7 @@ fn defaultRegistry() Registry {
         .active_account_key = null,
         .active_account_activated_at_ms = null,
         .auto_switch = defaultAutoSwitchConfig(),
-        .api = defaultApiConfig(),
+        .api = common.defaultApiConfig(),
         .accounts = std.ArrayList(AccountRecord).empty,
     };
 }
@@ -85,7 +82,6 @@ pub fn purgeRegistryFromImportSourceWithSaver(
 
     var reg = defaultRegistry();
     reg.auto_switch = carry_forward.auto_switch;
-    reg.api = carry_forward.api;
     reg.live = carry_forward.live;
     defer reg.deinit(allocator);
 

--- a/src/registry/import_carry.zig
+++ b/src/registry/import_carry.zig
@@ -4,20 +4,16 @@ const common = @import("common.zig");
 const parse = @import("parse.zig");
 
 const AutoSwitchConfig = common.AutoSwitchConfig;
-const ApiConfig = common.ApiConfig;
 const LiveConfig = common.LiveConfig;
 const defaultAutoSwitchConfig = common.defaultAutoSwitchConfig;
-const defaultApiConfig = common.defaultApiConfig;
 const defaultLiveConfig = common.defaultLiveConfig;
 const registryPath = common.registryPath;
 const readFileAlloc = common.readFileAlloc;
 const parseAutoSwitch = parse.parseAutoSwitch;
-const parseApiConfig = parse.parseApiConfig;
 const parseLiveConfig = parse.parseLiveConfig;
 
 const PurgeCarryForwardConfig = struct {
     auto_switch: AutoSwitchConfig = defaultAutoSwitchConfig(),
-    api: ApiConfig = defaultApiConfig(),
     live: LiveConfig = defaultLiveConfig(),
 };
 
@@ -43,7 +39,6 @@ fn parsePurgeCarryForwardConfig(allocator: std.mem.Allocator, data: []const u8) 
 
     var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch {
         applyCarryForwardObjectSlice(allocator, data, "auto_switch", &cfg.auto_switch, parseCarryForwardAutoSwitch);
-        applyCarryForwardObjectSlice(allocator, data, "api", &cfg.api, parseCarryForwardApiConfig);
         applyCarryForwardObjectSlice(allocator, data, "live", &cfg.live, parseCarryForwardLiveConfig);
         return cfg;
     };
@@ -52,7 +47,6 @@ fn parsePurgeCarryForwardConfig(allocator: std.mem.Allocator, data: []const u8) 
     switch (parsed.value) {
         .object => |obj| {
             if (obj.get("auto_switch")) |v| parseAutoSwitch(allocator, &cfg.auto_switch, v);
-            if (obj.get("api")) |v| parseApiConfig(&cfg.api, v);
             if (obj.get("live")) |v| parseLiveConfig(&cfg.live, v);
         },
         else => {},
@@ -62,10 +56,6 @@ fn parsePurgeCarryForwardConfig(allocator: std.mem.Allocator, data: []const u8) 
 
 fn parseCarryForwardAutoSwitch(allocator: std.mem.Allocator, value: std.json.Value, target: *AutoSwitchConfig) void {
     parseAutoSwitch(allocator, target, value);
-}
-
-fn parseCarryForwardApiConfig(_: std.mem.Allocator, value: std.json.Value, target: *ApiConfig) void {
-    parseApiConfig(target, value);
 }
 
 fn parseCarryForwardLiveConfig(_: std.mem.Allocator, value: std.json.Value, target: *LiveConfig) void {

--- a/src/registry/parse.zig
+++ b/src/registry/parse.zig
@@ -4,14 +4,11 @@ const common = @import("common.zig");
 const PlanType = common.PlanType;
 const AuthMode = common.AuthMode;
 const AutoSwitchConfig = common.AutoSwitchConfig;
-const ApiConfig = common.ApiConfig;
-const ApiConfigParseResult = common.ApiConfigParseResult;
 const LiveConfig = common.LiveConfig;
 const RateLimitSnapshot = common.RateLimitSnapshot;
 const RateLimitWindow = common.RateLimitWindow;
 const RolloutSignature = common.RolloutSignature;
 const CreditsSnapshot = common.CreditsSnapshot;
-const defaultApiConfig = common.defaultApiConfig;
 
 pub fn parsePlanType(s: []const u8) ?PlanType {
     if (std.mem.eql(u8, s, "free")) return .free;
@@ -74,16 +71,6 @@ pub fn parseAutoSwitch(allocator: std.mem.Allocator, cfg: *AutoSwitchConfig, v: 
     }
 }
 
-pub fn parseApiConfig(cfg: *ApiConfig, v: std.json.Value) void {
-    _ = parseApiConfigDetailed(cfg, v);
-}
-
-pub fn apiConfigNeedsRewrite(v: std.json.Value) bool {
-    var cfg = defaultApiConfig();
-    const result = parseApiConfigDetailed(&cfg, v);
-    return !result.has_object or !result.has_usage or !result.has_account;
-}
-
 pub fn parseLiveConfig(cfg: *LiveConfig, v: std.json.Value) void {
     const obj = switch (v) {
         .object => |o| o,
@@ -107,38 +94,6 @@ pub fn liveConfigNeedsRewrite(v: std.json.Value) bool {
         }
     }
     return true;
-}
-
-pub fn parseApiConfigDetailed(cfg: *ApiConfig, v: std.json.Value) ApiConfigParseResult {
-    const obj = switch (v) {
-        .object => |o| o,
-        else => return .{},
-    };
-    var result = ApiConfigParseResult{ .has_object = true };
-    if (obj.get("usage")) |usage| {
-        switch (usage) {
-            .bool => |flag| {
-                cfg.usage = flag;
-                result.has_usage = true;
-            },
-            else => {},
-        }
-    }
-    if (obj.get("account")) |account| {
-        switch (account) {
-            .bool => |flag| {
-                cfg.account = flag;
-                result.has_account = true;
-            },
-            else => {},
-        }
-    }
-    if (result.has_usage and !result.has_account) {
-        cfg.account = cfg.usage;
-    } else if (result.has_account and !result.has_usage) {
-        cfg.usage = cfg.account;
-    }
-    return result;
 }
 
 pub fn parseRolloutSignature(allocator: std.mem.Allocator, v: std.json.Value) ?RolloutSignature {

--- a/src/registry/root.zig
+++ b/src/registry/root.zig
@@ -30,7 +30,6 @@ pub const RateLimitSnapshot = common.RateLimitSnapshot;
 pub const RolloutSignature = common.RolloutSignature;
 pub const AutoSwitchConfig = common.AutoSwitchConfig;
 pub const ApiConfig = common.ApiConfig;
-pub const ApiConfigParseResult = common.ApiConfigParseResult;
 pub const default_live_refresh_interval_seconds = common.default_live_refresh_interval_seconds;
 pub const min_live_refresh_interval_seconds = common.min_live_refresh_interval_seconds;
 pub const max_live_refresh_interval_seconds = common.max_live_refresh_interval_seconds;

--- a/src/registry/storage.zig
+++ b/src/registry/storage.zig
@@ -15,7 +15,6 @@ const AuthMode = common.AuthMode;
 const RateLimitSnapshot = common.RateLimitSnapshot;
 const RolloutSignature = common.RolloutSignature;
 const AutoSwitchConfig = common.AutoSwitchConfig;
-const ApiConfig = common.ApiConfig;
 const LiveConfig = common.LiveConfig;
 const AccountRecord = common.AccountRecord;
 const Registry = common.Registry;
@@ -42,9 +41,6 @@ const parsePlanType = parse.parsePlanType;
 const parseAuthMode = parse.parseAuthMode;
 const parseUsage = parse.parseUsage;
 const parseAutoSwitch = parse.parseAutoSwitch;
-const parseApiConfig = parse.parseApiConfig;
-const apiConfigNeedsRewrite = parse.apiConfigNeedsRewrite;
-const parseApiConfigDetailed = parse.parseApiConfigDetailed;
 const parseLiveConfig = parse.parseLiveConfig;
 const liveConfigNeedsRewrite = parse.liveConfigNeedsRewrite;
 const parseRolloutSignature = parse.parseRolloutSignature;
@@ -307,9 +303,6 @@ fn loadLegacyRegistryV2(
     if (root_obj.get("auto_switch")) |v| {
         parseAutoSwitch(allocator, &reg.auto_switch, v);
     }
-    if (root_obj.get("api")) |v| {
-        parseApiConfig(&reg.api, v);
-    }
     if (root_obj.get("live")) |v| {
         parseLiveConfig(&reg.live, v);
     }
@@ -357,9 +350,6 @@ fn loadCurrentRegistry(allocator: std.mem.Allocator, root_obj: std.json.ObjectMa
     if (root_obj.get("auto_switch")) |v| {
         parseAutoSwitch(allocator, &reg.auto_switch, v);
     }
-    if (root_obj.get("api")) |v| {
-        parseApiConfig(&reg.api, v);
-    }
     if (root_obj.get("live")) |v| {
         parseLiveConfig(&reg.live, v);
     }
@@ -385,11 +375,7 @@ fn usesLegacyVersionField(root_obj: std.json.ObjectMap) bool {
 
 fn currentLayoutNeedsRewrite(root_obj: std.json.ObjectMap) bool {
     if (root_obj.get("last_attributed_rollout") != null) return true;
-    if (root_obj.get("api")) |v| {
-        if (apiConfigNeedsRewrite(v)) return true;
-    } else {
-        return true;
-    }
+    if (root_obj.get("api") != null) return true;
     if (root_obj.get("live")) |v| {
         if (liveConfigNeedsRewrite(v)) return true;
     } else {

--- a/src/registry/storage_write.zig
+++ b/src/registry/storage_write.zig
@@ -5,7 +5,6 @@ const clean = @import("clean.zig");
 const common = @import("common.zig");
 
 const AccountRecord = common.AccountRecord;
-const ApiConfig = common.ApiConfig;
 const AutoSwitchConfig = common.AutoSwitchConfig;
 const LiveConfig = common.LiveConfig;
 const Registry = common.Registry;
@@ -28,7 +27,6 @@ pub fn saveRegistry(allocator: std.mem.Allocator, codex_home: []const u8, reg: *
         .active_account_key = reg.active_account_key,
         .active_account_activated_at_ms = reg.active_account_activated_at_ms,
         .auto_switch = reg.auto_switch,
-        .api = reg.api,
         .live = reg.live,
         .accounts = reg.accounts.items,
     };
@@ -109,7 +107,6 @@ const RegistryOut = struct {
     active_account_key: ?[]const u8,
     active_account_activated_at_ms: ?i64,
     auto_switch: AutoSwitchConfig,
-    api: ApiConfig,
     live: LiveConfig,
     accounts: []const AccountRecord,
 };

--- a/src/workflows/config.zig
+++ b/src/workflows/config.zig
@@ -7,7 +7,6 @@ const registry = @import("../registry/root.zig");
 pub fn handleConfig(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.types.ConfigOptions) !void {
     switch (opts) {
         .auto_switch => |auto_opts| try auto.handleAutoCommand(allocator, codex_home, auto_opts),
-        .api => |action| try auto.handleApiCommand(allocator, codex_home, action),
         .live => |live_opts| try handleLiveCommand(allocator, codex_home, live_opts),
     }
 }

--- a/src/workflows/help.zig
+++ b/src/workflows/help.zig
@@ -4,24 +4,21 @@ const registry = @import("../registry/root.zig");
 
 pub const HelpConfig = struct {
     auto_switch: registry.AutoSwitchConfig,
-    api: registry.ApiConfig,
 };
 
 pub fn loadHelpConfig(allocator: std.mem.Allocator, codex_home: []const u8) HelpConfig {
     var reg = registry.loadRegistry(allocator, codex_home) catch {
         return .{
             .auto_switch = registry.defaultAutoSwitchConfig(),
-            .api = registry.defaultApiConfig(),
         };
     };
     defer reg.deinit(allocator);
     return .{
         .auto_switch = reg.auto_switch,
-        .api = reg.api,
     };
 }
 
 pub fn handleTopLevelHelp(allocator: std.mem.Allocator, codex_home: []const u8) !void {
     const help_cfg = loadHelpConfig(allocator, codex_home);
-    try cli.help.printHelp(&help_cfg.auto_switch, &help_cfg.api);
+    try cli.help.printHelp(&help_cfg.auto_switch);
 }

--- a/tests/auto_daemon_test.zig
+++ b/tests/auto_daemon_test.zig
@@ -160,7 +160,7 @@ fn fetchGroupedAccountNames(
     return buildGroupedAccountNamesFetchResult(allocator);
 }
 
-fn fetchGroupedAccountNamesAfterConcurrentUsageDisable(
+fn fetchGroupedAccountNamesAfterConcurrentRegistryRewrite(
     allocator: std.mem.Allocator,
     access_token: []const u8,
     account_id: []const u8,
@@ -172,7 +172,7 @@ fn fetchGroupedAccountNamesAfterConcurrentUsageDisable(
     const codex_home = daemon_account_name_fetch_registry_rewrite_codex_home orelse return error.TestMissingCodexHome;
     var latest = try registry.loadRegistry(allocator, codex_home);
     defer latest.deinit(allocator);
-    latest.api.usage = false;
+    latest.live.interval_seconds = 45;
     try registry.saveRegistry(allocator, codex_home, &latest);
 
     return buildGroupedAccountNamesFetchResult(allocator);
@@ -283,13 +283,13 @@ test "Scenario: Given daemon account-name refresh when registry changes during f
         gpa,
         codex_home,
         &refresh_state,
-        fetchGroupedAccountNamesAfterConcurrentUsageDisable,
+        fetchGroupedAccountNamesAfterConcurrentRegistryRewrite,
     ));
 
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
     try std.testing.expectEqual(@as(usize, 1), daemon_account_name_fetch_count);
-    try std.testing.expect(!loaded.api.usage);
+    try std.testing.expectEqual(@as(u16, 45), loaded.live.interval_seconds);
     try std.testing.expectEqualStrings("Primary Workspace", loaded.accounts.items[0].account_name.?);
     try std.testing.expectEqualStrings("Backup Workspace", loaded.accounts.items[1].account_name.?);
 }
@@ -1600,7 +1600,7 @@ test "Scenario: Given windows task state output when parsing then localized text
     try std.testing.expect(auto.parseWindowsTaskStateOutput("garbled\r\n") == .unknown);
 }
 
-test "Scenario: Given status when rendering then auto and usage api settings are shown" {
+test "Scenario: Given status when rendering then auto settings are shown" {
     const gpa = std.testing.allocator;
     var aw: std.Io.Writer.Allocating = .init(gpa);
     defer aw.deinit();
@@ -1610,8 +1610,6 @@ test "Scenario: Given status when rendering then auto and usage api settings are
         .runtime = .running,
         .threshold_5h_percent = 12,
         .threshold_weekly_percent = 8,
-        .api_usage_enabled = false,
-        .api_account_enabled = false,
         .live_interval_seconds = 60,
     });
 
@@ -1619,13 +1617,13 @@ test "Scenario: Given status when rendering then auto and usage api settings are
     try std.testing.expect(std.mem.indexOf(u8, output, "auto-switch: ON") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "service: running") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "thresholds: 5h<12%, weekly<8%") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "usage: local") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "account: disabled") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "live refresh: 60s") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "usage:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "account:") == null);
     try std.testing.expect(std.mem.indexOf(u8, output, "Warning: Usage refresh is currently using the ChatGPT usage API") == null);
 }
 
-test "Scenario: Given api usage mode when rendering status body then risk warning stays off stdout" {
+test "Scenario: Given status with custom live interval when rendering status body then risk warning stays off stdout" {
     const gpa = std.testing.allocator;
     var aw: std.Io.Writer.Allocating = .init(gpa);
     defer aw.deinit();
@@ -1635,17 +1633,14 @@ test "Scenario: Given api usage mode when rendering status body then risk warnin
         .runtime = .running,
         .threshold_5h_percent = 12,
         .threshold_weekly_percent = 8,
-        .api_usage_enabled = true,
-        .api_account_enabled = true,
         .live_interval_seconds = 45,
     });
 
     const output = aw.written();
-    try std.testing.expect(std.mem.indexOf(u8, output, "usage: api") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "account: api") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "live refresh: 45s") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "usage:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "account:") == null);
     try std.testing.expect(std.mem.indexOf(u8, output, "Warning: Usage refresh is currently using the ChatGPT usage API") == null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "`codex-auth config api disable`") == null);
 }
 
 test "Scenario: Given missing sessions dir when refreshing active usage then it is skipped without error" {

--- a/tests/cli_behavior_test.zig
+++ b/tests/cli_behavior_test.zig
@@ -318,20 +318,17 @@ test "Scenario: Given help when rendering then login and command help notes are 
     var aw: std.Io.Writer.Allocating = .init(gpa);
     defer aw.deinit();
     var auto_cfg = registry.defaultAutoSwitchConfig();
-    var api_cfg = registry.defaultApiConfig();
     auto_cfg.enabled = true;
     auto_cfg.threshold_5h_percent = 12;
     auto_cfg.threshold_weekly_percent = 8;
-    api_cfg.usage = true;
-    api_cfg.account = true;
 
-    try cli.help.writeHelp(&aw.writer, false, &auto_cfg, &api_cfg);
+    try cli.help.writeHelp(&aw.writer, false, &auto_cfg);
 
     const help = aw.written();
     try std.testing.expect(std.mem.indexOf(u8, help, "Auto Switch: ON (5h<12%, weekly<8%)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help, "Usage API: ON (api)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help, "Account API: ON") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help, "Auto Switch: ON (5h<12%, weekly<8%)\nUsage API: ON (api)\nAccount API: ON\n\nCommands:\n  --help, -h") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "Usage API:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "Account API:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "Auto Switch: ON (5h<12%, weekly<8%)\n\nCommands:\n  --help, -h") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "help <command>") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "--version, -V") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "list [--live] [--api|--skip-api]") != null);
@@ -340,7 +337,7 @@ test "Scenario: Given help when rendering then login and command help notes are 
     try std.testing.expect(std.mem.indexOf(u8, help, "import --cpa [<path>] [--alias <alias>]") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "import --alias <alias>\n") == null);
     try std.testing.expect(std.mem.indexOf(u8, help, "Run `codex-auth <command> --help` for command-specific usage details.") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help, "`config api enable` may trigger OpenAI account restrictions or suspension in some environments.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "API-backed refresh is the default") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "login") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "clean") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "switch [--live] [--api|--skip-api]") != null);
@@ -355,8 +352,8 @@ test "Scenario: Given help when rendering then login and command help notes are 
     try std.testing.expect(std.mem.indexOf(u8, help, "auto disable") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "auto --5h <percent> [--weekly <percent>]") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "auto --weekly <percent>") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help, "api enable") != null);
-    try std.testing.expect(std.mem.indexOf(u8, help, "api disable") != null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "api enable") == null);
+    try std.testing.expect(std.mem.indexOf(u8, help, "api disable") == null);
     try std.testing.expect(std.mem.indexOf(u8, help, "live --interval <seconds>") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "daemon --watch|--once") != null);
     try std.testing.expect(std.mem.indexOf(u8, help, "auto ...") == null);
@@ -611,42 +608,6 @@ test "Scenario: Given config auto enable when parsing then auto action is preser
     }
 }
 
-test "Scenario: Given config api enable when parsing then api action is preserved" {
-    const gpa = std.testing.allocator;
-    const args = [_][:0]const u8{ "codex-auth", "config", "api", "enable" };
-    var result = try cli.commands.parseArgs(gpa, &args);
-    defer cli.commands.freeParseResult(gpa, &result);
-
-    switch (result) {
-        .command => |cmd| switch (cmd) {
-            .config => |opts| switch (opts) {
-                .api => |action| try std.testing.expectEqual(cli.types.ApiAction.enable, action),
-                else => return error.TestExpectedEqual,
-            },
-            else => return error.TestExpectedEqual,
-        },
-        else => return error.TestExpectedEqual,
-    }
-}
-
-test "Scenario: Given config api disable when parsing then api disable action is preserved" {
-    const gpa = std.testing.allocator;
-    const args = [_][:0]const u8{ "codex-auth", "config", "api", "disable" };
-    var result = try cli.commands.parseArgs(gpa, &args);
-    defer cli.commands.freeParseResult(gpa, &result);
-
-    switch (result) {
-        .command => |cmd| switch (cmd) {
-            .config => |opts| switch (opts) {
-                .api => |action| try std.testing.expectEqual(cli.types.ApiAction.disable, action),
-                else => return error.TestExpectedEqual,
-            },
-            else => return error.TestExpectedEqual,
-        },
-        else => return error.TestExpectedEqual,
-    }
-}
-
 test "Scenario: Given config auto action mixed with threshold flags when parsing then usage error is returned" {
     const gpa = std.testing.allocator;
     const args = [_][:0]const u8{ "codex-auth", "config", "auto", "enable", "--5h", "12" };
@@ -726,13 +687,13 @@ test "Scenario: Given removed top-level auto command when parsing then usage err
     try expectUsageError(result, .top_level, "unknown command `auto`");
 }
 
-test "Scenario: Given config api unknown action when parsing then usage error is returned" {
+test "Scenario: Given removed config api section when parsing then usage error is returned" {
     const gpa = std.testing.allocator;
     const args = [_][:0]const u8{ "codex-auth", "config", "api", "status" };
     var result = try cli.commands.parseArgs(gpa, &args);
     defer cli.commands.freeParseResult(gpa, &result);
 
-    try expectUsageError(result, .config, "unknown action `status`");
+    try expectUsageError(result, .config, "unknown config section `api`");
 }
 
 test "Scenario: Given config live interval when parsing then interval is preserved" {

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -627,22 +627,6 @@ fn seedRegistryWithAccounts(
     try registry.saveRegistry(allocator, codex_home, &reg);
 }
 
-fn setRegistryApiConfig(
-    allocator: std.mem.Allocator,
-    home_root: []const u8,
-    usage_enabled: bool,
-    account_enabled: bool,
-) !void {
-    const codex_home = try codexHomeAlloc(allocator, home_root);
-    defer allocator.free(codex_home);
-
-    var reg = try registry.loadRegistry(allocator, codex_home);
-    defer reg.deinit(allocator);
-    reg.api.usage = usage_enabled;
-    reg.api.account = account_enabled;
-    try registry.saveRegistry(allocator, codex_home, &reg);
-}
-
 fn makeUsageSnapshot(primary_used_percent: f64, secondary_used_percent: f64) registry.RateLimitSnapshot {
     return .{
         .primary = .{
@@ -1635,7 +1619,7 @@ test "Scenario: Given cpa file import when running import cpa then it stores a s
     try std.testing.expect(std.mem.eql(u8, loaded.accounts.items[0].alias, "personal"));
 }
 
-test "Scenario: Given default api usage when rendering help then the api enable risk note stays in stdout" {
+test "Scenario: Given default api usage when rendering help then skip-api note stays in stdout" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);
     defer gpa.free(project_root);
@@ -1653,9 +1637,9 @@ test "Scenario: Given default api usage when rendering help then the api enable 
 
     try expectSuccess(result);
     try std.testing.expect(std.mem.indexOf(u8, result.stdout, "codex-auth") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "Usage API: ON (api)") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "Account API: ON") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "`config api enable` may trigger OpenAI account restrictions or suspension in some environments.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "Usage API:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "Account API:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "API-backed refresh is the default") != null);
     try std.testing.expectEqualStrings("", result.stderr);
 }
 
@@ -1843,7 +1827,7 @@ test "Scenario: Given switch query with no matches when running switch then it e
     try std.testing.expect(std.mem.indexOf(u8, result.stderr, "main.zig") == null);
 }
 
-test "Scenario: Given list with api override when api config is disabled then it still requires api refresh executables" {
+test "Scenario: Given list default mode when running list then it requires api refresh executables" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);
     defer gpa.free(project_root);
@@ -1858,8 +1842,6 @@ test "Scenario: Given list with api override when api config is disabled then it
     try seedRegistryWithAccounts(gpa, home_root, "alpha@example.com", &[_]SeedAccount{
         .{ .email = "alpha@example.com", .alias = "alpha" },
     });
-    try setRegistryApiConfig(gpa, home_root, false, false);
-
     try tmp.dir.makePath("empty-bin");
     const empty_path = try tmp.dir.realpathAlloc(gpa, "empty-bin");
     defer gpa.free(empty_path);
@@ -1869,7 +1851,7 @@ test "Scenario: Given list with api override when api config is disabled then it
         project_root,
         home_root,
         empty_path,
-        &[_][]const u8{ "list", "--api" },
+        &[_][]const u8{"list"},
     );
     defer gpa.free(result.stdout);
     defer gpa.free(result.stderr);
@@ -2398,7 +2380,7 @@ test "Scenario: Given remove without api flags when running remove then it requi
     try std.testing.expect(std.mem.indexOf(u8, result.stderr, "Node.js 22+") != null);
 }
 
-test "Scenario: Given remove without selectors and api disabled in config when running remove then it does not require api refresh executables" {
+test "Scenario: Given remove without selectors in default mode when running remove then it requires api refresh executables" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);
     defer gpa.free(project_root);
@@ -2414,11 +2396,6 @@ test "Scenario: Given remove without selectors and api disabled in config when r
         .{ .email = "alpha@example.com", .alias = "" },
         .{ .email = "beta@example.com", .alias = "" },
     });
-    try setRegistryApiConfig(gpa, home_root, false, false);
-
-    const codex_home = try codexHomeAlloc(gpa, home_root);
-    defer gpa.free(codex_home);
-
     try tmp.dir.makePath("empty-bin");
     const empty_path = try tmp.dir.realpathAlloc(gpa, "empty-bin");
     defer gpa.free(empty_path);
@@ -2434,14 +2411,9 @@ test "Scenario: Given remove without selectors and api disabled in config when r
     defer gpa.free(result.stdout);
     defer gpa.free(result.stderr);
 
-    try expectSuccess(result);
-    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "Select accounts to delete:") != null);
-    try std.testing.expectEqualStrings("", result.stderr);
-
-    var loaded = try registry.loadRegistry(gpa, codex_home);
-    defer loaded.deinit(gpa);
-    try std.testing.expectEqual(@as(usize, 1), loaded.accounts.items.len);
-    try std.testing.expect(std.mem.eql(u8, loaded.accounts.items[0].email, "alpha@example.com"));
+    try expectFailure(result);
+    try std.testing.expectEqualStrings("", result.stdout);
+    try std.testing.expect(std.mem.indexOf(u8, result.stderr, "Node.js 22+") != null);
 }
 
 test "Scenario: Given remove with skip-api when running remove then it does not require api refresh executables" {
@@ -3344,8 +3316,8 @@ test "Scenario: Given default api usage when rendering status then no warning is
 
     try expectSuccess(result);
     try std.testing.expect(std.mem.indexOf(u8, result.stdout, "auto-switch: OFF") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "usage: api") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "account: api") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "usage:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.stdout, "account:") == null);
     try std.testing.expectEqualStrings("", result.stderr);
 }
 

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -1171,13 +1171,14 @@ test "Scenario: Given API key import when listing with api refresh then stale sn
     try std.testing.expect(std.mem.indexOf(u8, first_list.stdout, "apikey-flow@example.com") != null);
     try std.testing.expect(std.mem.indexOf(u8, first_list.stdout, "chatgpt-flow@example.com") != null);
     try std.testing.expect(std.mem.indexOf(u8, first_list.stdout, "API_KEY") != null);
-    try std.testing.expect(std.mem.indexOf(u8, first_list.stdout, "88%") != null);
-    try std.testing.expect(std.mem.indexOf(u8, first_list.stdout, "66%") != null);
     try std.testing.expect(std.mem.indexOf(u8, first_list.stdout, "MissingAuth") == null);
     try std.testing.expectEqualStrings("", first_list.stderr);
 
     var refreshed = try registry.loadRegistry(gpa, codex_home);
     defer refreshed.deinit(gpa);
+    const refreshed_api_idx = registry.findAccountIndexByAccountKey(&refreshed, api_account_key) orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(@as(f64, 88), refreshed.accounts.items[refreshed_api_idx].last_usage.?.primary.?.used_percent);
+    try std.testing.expectEqual(@as(f64, 66), refreshed.accounts.items[refreshed_api_idx].last_usage.?.secondary.?.used_percent);
     const chatgpt_idx = registry.findAccountIndexByAccountKey(&refreshed, chatgpt_key) orelse return error.TestExpectedEqual;
     try std.testing.expectEqual(@as(f64, 12), refreshed.accounts.items[chatgpt_idx].last_usage.?.primary.?.used_percent);
     try std.testing.expectEqual(@as(f64, 34), refreshed.accounts.items[chatgpt_idx].last_usage.?.secondary.?.used_percent);
@@ -1200,9 +1201,13 @@ test "Scenario: Given API key import when listing with api refresh then stale sn
     try std.testing.expect(std.mem.indexOf(u8, second_list.stdout, "apikey-flow@example.com") != null);
     try std.testing.expect(std.mem.indexOf(u8, second_list.stdout, "API_KEY") != null);
     try std.testing.expect(std.mem.indexOf(u8, second_list.stdout, "MissingAuth") == null);
-    try std.testing.expect(std.mem.indexOf(u8, second_list.stdout, "88%") != null);
-    try std.testing.expect(std.mem.indexOf(u8, second_list.stdout, "66%") != null);
     try std.testing.expectEqualStrings("", second_list.stderr);
+
+    var refreshed_again = try registry.loadRegistry(gpa, codex_home);
+    defer refreshed_again.deinit(gpa);
+    const refreshed_again_api_idx = registry.findAccountIndexByAccountKey(&refreshed_again, api_account_key) orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(@as(f64, 88), refreshed_again.accounts.items[refreshed_again_api_idx].last_usage.?.primary.?.used_percent);
+    try std.testing.expectEqual(@as(f64, 66), refreshed_again.accounts.items[refreshed_again_api_idx].last_usage.?.secondary.?.used_percent);
 }
 
 test "Scenario: Given single-file import missing email when running import then it exits non-zero after reporting the skipped file" {

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -299,7 +299,7 @@ test "registry save/load" {
     defer gpa.free(registry_path);
     const saved = try fixtures.readFileAlloc(gpa, registry_path);
     defer gpa.free(saved);
-    try std.testing.expect(std.mem.indexOf(u8, saved, "\"account\": true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "\"api\"") == null);
 
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
@@ -520,7 +520,7 @@ test "applyAccountNamesForUser updates same-user records across personal and tea
     try std.testing.expectEqualStrings("Unrelated Workspace", reg.accounts.items[2].account_name.?);
 }
 
-test "registry save/load round-trips api.account false" {
+test "registry save omits api config" {
     const gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});
     defer tmp.cleanup();
@@ -540,7 +540,13 @@ test "registry save/load round-trips api.account false" {
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
     try std.testing.expect(loaded.api.usage);
-    try std.testing.expect(!loaded.api.account);
+    try std.testing.expect(loaded.api.account);
+
+    const registry_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "accounts", "registry.json" });
+    defer gpa.free(registry_path);
+    const saved = try fixtures.readFileAlloc(gpa, registry_path);
+    defer gpa.free(saved);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "\"api\"") == null);
 }
 
 test "registry load defaults missing auto threshold fields" {
@@ -578,8 +584,7 @@ test "registry load defaults missing auto threshold fields" {
     defer gpa.free(registry_path);
     const saved = try fixtures.readFileAlloc(gpa, registry_path);
     defer gpa.free(saved);
-    try std.testing.expect(std.mem.indexOf(u8, saved, "\"usage\": true") != null);
-    try std.testing.expect(std.mem.indexOf(u8, saved, "\"account\": true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "\"api\"") == null);
 }
 
 test "registry load migrates old auto thresholds to default one percent" {
@@ -622,7 +627,7 @@ test "registry load migrates old auto thresholds to default one percent" {
     try std.testing.expect(std.mem.indexOf(u8, saved, "\"threshold_weekly_percent\": 1") != null);
 }
 
-test "registry load backfills missing api.account from api.usage and rewrites file" {
+test "registry load ignores legacy api.usage and rewrites file without api config" {
     const gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});
     defer tmp.cleanup();
@@ -646,18 +651,17 @@ test "registry load backfills missing api.account from api.usage and rewrites fi
 
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
-    try std.testing.expect(!loaded.api.usage);
-    try std.testing.expect(!loaded.api.account);
+    try std.testing.expect(loaded.api.usage);
+    try std.testing.expect(loaded.api.account);
 
     const registry_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "accounts", "registry.json" });
     defer gpa.free(registry_path);
     const saved = try fixtures.readFileAlloc(gpa, registry_path);
     defer gpa.free(saved);
-    try std.testing.expect(std.mem.indexOf(u8, saved, "\"usage\": false") != null);
-    try std.testing.expect(std.mem.indexOf(u8, saved, "\"account\": false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "\"api\"") == null);
 }
 
-test "registry load backfills missing api.usage from api.account and rewrites file" {
+test "registry load ignores legacy api.account and rewrites file without api config" {
     const gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});
     defer tmp.cleanup();
@@ -681,15 +685,14 @@ test "registry load backfills missing api.usage from api.account and rewrites fi
 
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
-    try std.testing.expect(!loaded.api.usage);
-    try std.testing.expect(!loaded.api.account);
+    try std.testing.expect(loaded.api.usage);
+    try std.testing.expect(loaded.api.account);
 
     const registry_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "accounts", "registry.json" });
     defer gpa.free(registry_path);
     const saved = try fixtures.readFileAlloc(gpa, registry_path);
     defer gpa.free(saved);
-    try std.testing.expect(std.mem.indexOf(u8, saved, "\"usage\": false") != null);
-    try std.testing.expect(std.mem.indexOf(u8, saved, "\"account\": false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "\"api\"") == null);
 }
 
 test "legacy schema registry with legacy rollout attribution rewrites to normalized current schema" {

--- a/tests/workflows_core_test.zig
+++ b/tests/workflows_core_test.zig
@@ -286,8 +286,7 @@ fn mockAccountNameFetcherWithRegistryMutation(
         const codex_home = mutate_registry_codex_home orelse return error.TestExpectedEqual;
         var reg = try registry.loadRegistry(allocator, codex_home);
         defer reg.deinit(allocator);
-        reg.api.usage = false;
-        reg.api.account = false;
+        reg.live.interval_seconds = 45;
         try registry.saveRegistry(allocator, codex_home, &reg);
     }
 
@@ -347,7 +346,6 @@ test "Scenario: Given foreground commands when checking reconcile policy then co
         .threshold_5h_percent = 12,
         .threshold_weekly_percent = null,
     } } } }));
-    try std.testing.expect(main_mod.shouldReconcileManagedService(.{ .config = .{ .api = .enable } }));
     try std.testing.expect(main_mod.shouldReconcileManagedService(.{ .config = .{ .live = .{ .interval_seconds = 30 } } }));
     try std.testing.expect(!main_mod.shouldReconcileManagedService(.{ .help = .top_level }));
     try std.testing.expect(!main_mod.shouldReconcileManagedService(.{ .status = {} }));
@@ -1014,7 +1012,7 @@ test "Scenario: Given switched account with missing account names when refreshin
     try std.testing.expect(std.mem.eql(u8, reg.accounts.items[1].account_name.?, "Backup Workspace"));
 }
 
-test "Scenario: Given api disabled while background account-name refresh is in flight when it finishes then the latest api config is preserved" {
+test "Scenario: Given registry changes while background account-name refresh is in flight when it finishes then latest config is preserved" {
     const gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});
     defer tmp.cleanup();
@@ -1039,10 +1037,9 @@ test "Scenario: Given api disabled while background account-name refresh is in f
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
     try std.testing.expectEqual(@as(usize, 1), mock_account_name_fetch_count);
-    try std.testing.expect(!loaded.api.account);
-    try std.testing.expect(!loaded.api.usage);
-    try std.testing.expect(loaded.accounts.items[0].account_name == null);
-    try std.testing.expect(loaded.accounts.items[1].account_name == null);
+    try std.testing.expectEqual(@as(u16, 45), loaded.live.interval_seconds);
+    try std.testing.expectEqualStrings("Primary Workspace", loaded.accounts.items[0].account_name.?);
+    try std.testing.expectEqualStrings("Backup Workspace", loaded.accounts.items[1].account_name.?);
 }
 
 test "Scenario: Given grouped stored snapshots without active auth when running background account-name refresh then it updates the missing names" {
@@ -1421,5 +1418,4 @@ test "Scenario: Given newer registry schema when loading help config then defaul
 
     const help_cfg = main_mod.loadHelpConfig(gpa, codex_home);
     try std.testing.expectEqual(registry.defaultAutoSwitchConfig(), help_cfg.auto_switch);
-    try std.testing.expectEqual(registry.defaultApiConfig(), help_cfg.api);
 }

--- a/tests/workflows_live_test.zig
+++ b/tests/workflows_live_test.zig
@@ -76,7 +76,6 @@ test "handled cli errors include missing node" {
 fn saveLivePolicyTestRegistry(
     allocator: std.mem.Allocator,
     codex_home: []const u8,
-    api_config: registry.ApiConfig,
     live_config: registry.LiveConfig,
 ) !void {
     var reg: registry.Registry = .{
@@ -84,7 +83,7 @@ fn saveLivePolicyTestRegistry(
         .active_account_key = null,
         .active_account_activated_at_ms = null,
         .auto_switch = registry.defaultAutoSwitchConfig(),
-        .api = api_config,
+        .api = registry.defaultApiConfig(),
         .live = live_config,
         .accounts = std.ArrayList(registry.AccountRecord).empty,
     };
@@ -160,7 +159,7 @@ test "live refresh interval uses the shared live config cadence" {
     try std.testing.expectEqual(@as(i64, 60_000), switch_live_default_refresh_interval_ms);
 }
 
-test "initial live selection display uses stored api defaults for list, switch, and remove" {
+test "initial live selection display uses api defaults for list, switch, and remove" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -168,34 +167,11 @@ test "initial live selection display uses stored api defaults for list, switch, 
     const codex_home = try app_runtime.realPathFileAlloc(gpa, tmp.dir, ".");
     defer gpa.free(codex_home);
 
-    try saveLivePolicyTestRegistry(gpa, codex_home, registry.defaultApiConfig(), registry.defaultLiveConfig());
+    try saveLivePolicyTestRegistry(gpa, codex_home, registry.defaultLiveConfig());
 
     inline for ([_]ForegroundUsageRefreshTarget{ .list, .switch_account, .remove_account }) |target| {
         try expectInitialLiveSelectionPolicy(gpa, codex_home, target, .default, .{
             .usage_api_enabled = true,
-            .account_api_enabled = true,
-            .interval_ms = switch_live_default_refresh_interval_ms,
-            .label = "api",
-        });
-    }
-}
-
-test "initial live selection display preserves mixed stored api defaults for list, switch, and remove" {
-    const gpa = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    const codex_home = try app_runtime.realPathFileAlloc(gpa, tmp.dir, ".");
-    defer gpa.free(codex_home);
-
-    try saveLivePolicyTestRegistry(gpa, codex_home, .{
-        .usage = false,
-        .account = true,
-    }, registry.defaultLiveConfig());
-
-    inline for ([_]ForegroundUsageRefreshTarget{ .list, .switch_account, .remove_account }) |target| {
-        try expectInitialLiveSelectionPolicy(gpa, codex_home, target, .default, .{
-            .usage_api_enabled = false,
             .account_api_enabled = true,
             .interval_ms = switch_live_default_refresh_interval_ms,
             .label = "api",
@@ -211,10 +187,7 @@ test "initial live selection display honors explicit api mode overrides for list
     const codex_home = try app_runtime.realPathFileAlloc(gpa, tmp.dir, ".");
     defer gpa.free(codex_home);
 
-    try saveLivePolicyTestRegistry(gpa, codex_home, .{
-        .usage = false,
-        .account = false,
-    }, registry.defaultLiveConfig());
+    try saveLivePolicyTestRegistry(gpa, codex_home, registry.defaultLiveConfig());
 
     inline for ([_]ForegroundUsageRefreshTarget{ .list, .switch_account, .remove_account }) |target| {
         try expectInitialLiveSelectionPolicy(gpa, codex_home, target, .force_api, .{
@@ -225,7 +198,7 @@ test "initial live selection display honors explicit api mode overrides for list
         });
     }
 
-    try saveLivePolicyTestRegistry(gpa, codex_home, registry.defaultApiConfig(), registry.defaultLiveConfig());
+    try saveLivePolicyTestRegistry(gpa, codex_home, registry.defaultLiveConfig());
 
     inline for ([_]ForegroundUsageRefreshTarget{ .list, .switch_account, .remove_account }) |target| {
         try expectInitialLiveSelectionPolicy(gpa, codex_home, target, .skip_api, .{
@@ -245,7 +218,7 @@ test "initial live selection display uses configured live refresh interval for a
     const codex_home = try app_runtime.realPathFileAlloc(gpa, tmp.dir, ".");
     defer gpa.free(codex_home);
 
-    try saveLivePolicyTestRegistry(gpa, codex_home, registry.defaultApiConfig(), .{ .interval_seconds = 45 });
+    try saveLivePolicyTestRegistry(gpa, codex_home, .{ .interval_seconds = 45 });
     try expectInitialLiveSelectionPolicy(gpa, codex_home, .list, .default, .{
         .usage_api_enabled = true,
         .account_api_enabled = true,


### PR DESCRIPTION
This PR removes the persistent API refresh toggle and makes API-backed refresh the default behavior for supported commands.

- Remove the `config api enable` and `config api disable` command flow, including related help text and status output.
- Stop reading from or writing to the legacy `registry.json` `api` object while keeping `schema_version` at `4`.
- Ignore older persisted `api` fields and drop them the next time the registry is saved.
- Make refresh behavior API-backed by default for:
  - `list`
  - `switch`
  - `remove`
  - `daemon`
  - `account-name`
- Keep `--api` as an explicit equivalent to the default API-backed refresh path.
- Add `--skip-api` as the per-command local-only override.
- Update tests and documentation to cover the new default refresh behavior and local-only override.
