### PR TITLE
Fix live TUI cursor fallback

### DIFF
--- a/src/cli/live_tui.zig
+++ b/src/cli/live_tui.zig
@@ -290,7 +290,7 @@ pub fn resolveSelectedIndex(
 ) !?usize {
     if (rows.selectable_row_indices.len == 0) return null;
     const selected_idx = if (selected_account_key.*) |key|
-        picker.selectableIndexForAccountKey(rows, reg, key) orelse picker.activeSelectableIndex(rows) orelse 0
+        picker.selectableIndexForAccountKey(rows, reg, key) orelse 0
     else
         picker.activeSelectableIndex(rows) orelse 0;
     try picker.replaceSelectedAccountKeyForSelectable(allocator, selected_account_key, rows, reg, selected_idx);

--- a/tests/cli_picker_test.zig
+++ b/tests/cli_picker_test.zig
@@ -919,6 +919,59 @@ test "Scenario: Given live switch navigation shortcuts when an account is unavai
     try std.testing.expectEqualStrings("user-1::acc-1", selected_account_key.?);
 }
 
+test "Scenario: Given a stale live cursor key when resolving then switch does not snap back to active" {
+    const gpa = std.testing.allocator;
+    var reg = makeTestRegistry();
+    defer reg.deinit(gpa);
+
+    try appendTestAccount(gpa, &reg, "user-1::acc-1", "active@example.com", "", .team);
+    try appendTestAccount(gpa, &reg, "user-1::acc-2", "second@example.com", "", .team);
+    try appendTestAccount(gpa, &reg, "user-1::acc-3", "third@example.com", "", .team);
+    reg.active_account_key = try gpa.dupe(u8, "user-1::acc-2");
+
+    var rows = try live_tui.buildSelectableRows(gpa, .{
+        .reg = &reg,
+        .usage_overrides = null,
+    });
+    defer rows.deinit(gpa);
+
+    var selected_account_key: ?[]u8 = try gpa.dupe(u8, "user-1::missing");
+    defer if (selected_account_key) |key| gpa.free(key);
+
+    const resolved_idx = try live_tui.resolveSelectedIndex(gpa, &selected_account_key, &rows, &reg);
+    try std.testing.expectEqual(@as(?usize, 0), resolved_idx);
+    try std.testing.expectEqualStrings("user-1::acc-1", selected_account_key.?);
+
+    try std.testing.expect(try live_tui.moveSelectedIndexForKey(gpa, &selected_account_key, &rows, &reg, TuiInputKey.move_down));
+    try std.testing.expectEqualStrings("user-1::acc-2", selected_account_key.?);
+}
+
+test "Scenario: Given active first account when navigating live switch then adjacent accounts are not skipped" {
+    const gpa = std.testing.allocator;
+    var reg = makeTestRegistry();
+    defer reg.deinit(gpa);
+
+    try appendTestAccount(gpa, &reg, "user-1::acc-1", "active@example.com", "", .team);
+    try appendTestAccount(gpa, &reg, "user-1::acc-2", "second@example.com", "", .team);
+    try appendTestAccount(gpa, &reg, "user-1::acc-3", "third@example.com", "", .team);
+    reg.active_account_key = try gpa.dupe(u8, "user-1::acc-1");
+
+    var rows = try live_tui.buildSelectableRows(gpa, .{
+        .reg = &reg,
+        .usage_overrides = null,
+    });
+    defer rows.deinit(gpa);
+
+    var selected_account_key: ?[]u8 = try gpa.dupe(u8, "user-1::acc-3");
+    defer if (selected_account_key) |key| gpa.free(key);
+
+    try std.testing.expect(try live_tui.moveSelectedIndexForKey(gpa, &selected_account_key, &rows, &reg, TuiInputKey.keyboard_up));
+    try std.testing.expectEqualStrings("user-1::acc-2", selected_account_key.?);
+
+    try std.testing.expect(try live_tui.moveSelectedIndexForKey(gpa, &selected_account_key, &rows, &reg, TuiInputKey.keyboard_up));
+    try std.testing.expectEqualStrings("user-1::acc-1", selected_account_key.?);
+}
+
 test "Scenario: Given live auto switch state when starting then the initial display triggers auto-switch once" {
     var enabled = live_tui.LiveAutoSwitchState.init(true);
     try std.testing.expect(enabled.takePending());


### PR DESCRIPTION
## Summary
- keep live switch/remove cursor recovery from snapping back to the active account after a cursor key becomes stale
- add coverage for stale cursor recovery and active-first adjacent keyboard navigation

## Tests
- HOME=/tmp/codex-auth-tui-fix-test CODEX_HOME=/tmp/codex-auth-tui-fix-test zig build test
- HOME=/tmp/codex-auth-tui-fix-run CODEX_HOME=/tmp/codex-auth-tui-fix-run zig build run -- list