### PR TITLE
fix: isolate codex login

### DIFF
--- a/src/cli/login.zig
+++ b/src/cli/login.zig
@@ -29,9 +29,14 @@ fn writeCodexLoginLaunchFailureHint(err_name: []const u8) !void {
     try out.flush();
 }
 
-pub fn runCodexLogin(opts: types.LoginOptions) !void {
+pub fn runCodexLogin(opts: types.LoginOptions, codex_home: []const u8) !void {
+    var env_map = try app_runtime.currentEnviron().createMap(std.heap.page_allocator);
+    defer env_map.deinit();
+    try env_map.put("CODEX_HOME", codex_home);
+
     var child = std.process.spawn(app_runtime.io(), .{
         .argv = codexLoginArgs(opts),
+        .environ_map = &env_map,
         .stdin = .inherit,
         .stdout = .inherit,
         .stderr = .inherit,

--- a/src/workflows/login.zig
+++ b/src/workflows/login.zig
@@ -4,9 +4,17 @@ const registry = @import("../registry/root.zig");
 const auth = @import("../auth/auth.zig");
 const me_api = @import("../api/me.zig");
 const account_names = @import("account_names.zig");
+const app_runtime = @import("../core/runtime.zig");
 
 const defaultAccountFetcher = account_names.defaultAccountFetcher;
 const refreshAccountNamesAfterLogin = account_names.refreshAccountNamesAfterLogin;
+
+fn loginScratchCodexHomeAlloc(allocator: std.mem.Allocator, codex_home: []const u8) ![]u8 {
+    const stamp = std.Io.Timestamp.now(app_runtime.io(), .real).toMilliseconds();
+    const name = try std.fmt.allocPrint(allocator, "login-{d}", .{stamp});
+    defer allocator.free(name);
+    return try std.fs.path.join(allocator, &[_][]const u8{ codex_home, "accounts", name });
+}
 
 pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.types.LoginOptions) !void {
     var reg = try registry.loadRegistry(allocator, codex_home);
@@ -15,9 +23,18 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
         _ = try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg);
     }
 
-    try cli.login.runCodexLogin(opts);
+    try registry.ensureAccountsDir(allocator, codex_home);
+    const login_codex_home = try loginScratchCodexHomeAlloc(allocator, codex_home);
+    defer allocator.free(login_codex_home);
+    defer std.Io.Dir.cwd().deleteTree(app_runtime.io(), login_codex_home) catch {};
+
+    try cli.login.runCodexLogin(opts, login_codex_home);
+    const login_auth_path = try registry.activeAuthPath(allocator, login_codex_home);
+    defer allocator.free(login_auth_path);
+
     const auth_path = try registry.activeAuthPath(allocator, codex_home);
     defer allocator.free(auth_path);
+    try registry.copyManagedFile(login_auth_path, auth_path);
 
     const info = try auth.parseAuthInfo(allocator, auth_path);
     defer info.deinit(allocator);

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -167,6 +167,7 @@ fn writeSuccessfulFakeCodex(dir: fs.Dir) !void {
         if (builtin.os.tag == .windows)
             "@echo off\r\n" ++
                 ">\"%HOME%\\fake-codex-argv.txt\" echo %*\r\n" ++
+                ">\"%HOME%\\fake-codex-home.txt\" echo %CODEX_HOME%\r\n" ++
                 "set \"CODEX_HOME_DIR=%CODEX_HOME%\"\r\n" ++
                 "if \"%CODEX_HOME_DIR%\"==\"\" set \"CODEX_HOME_DIR=%HOME%\\.codex\"\r\n" ++
                 "if not exist \"%CODEX_HOME_DIR%\" mkdir \"%CODEX_HOME_DIR%\"\r\n" ++
@@ -175,6 +176,7 @@ fn writeSuccessfulFakeCodex(dir: fs.Dir) !void {
         else
             "#!/bin/sh\n" ++
                 "printf '%s\\n' \"$*\" > \"$HOME/fake-codex-argv.txt\"\n" ++
+                "printf '%s\\n' \"$CODEX_HOME\" > \"$HOME/fake-codex-home.txt\"\n" ++
                 "CODEX_HOME_DIR=\"${CODEX_HOME:-$HOME/.codex}\"\n" ++
                 "mkdir -p \"$CODEX_HOME_DIR\"\n" ++
                 "cp \"$HOME/fake-auth.json\" \"$CODEX_HOME_DIR/auth.json\"\n" ++
@@ -756,6 +758,16 @@ test "Scenario: Given device auth login when running login then it forwards the 
 
     const codex_home = try codexHomeAlloc(gpa, home_root);
     defer gpa.free(codex_home);
+
+    const fake_codex_home_path = try fs.path.join(gpa, &[_][]const u8{ home_root, "fake-codex-home.txt" });
+    defer gpa.free(fake_codex_home_path);
+    const fake_codex_home_data = try fixtures.readFileAlloc(gpa, fake_codex_home_path);
+    defer gpa.free(fake_codex_home_data);
+    const fake_codex_home = std.mem.trim(u8, fake_codex_home_data, " \r\n");
+    try std.testing.expect(!std.mem.eql(u8, fake_codex_home, codex_home));
+    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "login-") != null);
+    try std.testing.expectError(error.FileNotFound, fs.cwd().access(fake_codex_home, .{}));
+
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
     try std.testing.expectEqual(@as(usize, 1), loaded.accounts.items.len);
@@ -888,6 +900,14 @@ test "Scenario: Given CODEX_HOME override when running login then it stores auth
     const custom_auth_path = try registry.activeAuthPath(gpa, custom_codex_home);
     defer gpa.free(custom_auth_path);
     try fs.cwd().access(custom_auth_path, .{});
+
+    const fake_codex_home_path = try fs.path.join(gpa, &[_][]const u8{ home_root, "fake-codex-home.txt" });
+    defer gpa.free(fake_codex_home_path);
+    const fake_codex_home_data = try fixtures.readFileAlloc(gpa, fake_codex_home_path);
+    defer gpa.free(fake_codex_home_data);
+    const fake_codex_home = std.mem.trim(u8, fake_codex_home_data, " \r\n");
+    try std.testing.expect(!std.mem.eql(u8, fake_codex_home, custom_codex_home));
+    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "login-") != null);
 
     const default_auth_path = try authJsonPathAlloc(gpa, home_root);
     defer gpa.free(default_auth_path);


### PR DESCRIPTION
## Summary
- run upstream `codex login` with a private temporary `CODEX_HOME`
- copy the successful login `auth.json` into the managed Codex home before importing it
- cover default and explicit `CODEX_HOME` login flows in integration tests

## Validation
- `HOME=/tmp/codex-auth-login-fix CODEX_HOME=/tmp/codex-auth-login-fix/codex-home ZIG_GLOBAL_CACHE_DIR=/tmp/codex-auth-login-fix/zig-global ZIG_LOCAL_CACHE_DIR=/tmp/codex-auth-login-fix/zig-local zig build --build-file /coding/codex-auth/build.zig run -- list`
- `HOME=/tmp/codex-auth-login-fix CODEX_HOME=/tmp/codex-auth-login-fix/codex-home ZIG_GLOBAL_CACHE_DIR=/tmp/codex-auth-login-fix/zig-global ZIG_LOCAL_CACHE_DIR=/tmp/codex-auth-login-fix/zig-local zig build --build-file /coding/codex-auth/build.zig test`
