### PR TITLE
feat: support JSON array imports

### DIFF
--- a/docs/commands/import.md
+++ b/docs/commands/import.md
@@ -42,5 +42,5 @@ Use `--purge` as a recovery tool when the registry index is out of sync with the
 
 - `stdout` receives scan lines, imported/updated rows, and summaries.
 - `stderr` receives skipped rows and warnings.
-- Parse failures render as `MalformedJson`.
+- Parse failures render as `InvalidJSON`.
 - Validation failures keep explicit names such as `MissingEmail` or `MissingChatgptUserId`.

--- a/src/api/me.zig
+++ b/src/api/me.zig
@@ -28,9 +28,9 @@ pub fn fetchMeForApiKeyFromEndpoint(
     defer allocator.free(http_result.body);
 
     if (http_result.status_code) |status| {
-        if (status < 200 or status > 299) return error.OpenAiMeRequestFailed;
+        if (status < 200 or status > 299) return error.OpenAIMeRequestFailed;
     }
-    if (http_result.body.len == 0) return error.OpenAiMeRequestFailed;
+    if (http_result.body.len == 0) return error.OpenAIMeRequestFailed;
 
     return try parseMeResponse(allocator, http_result.body);
 }
@@ -41,12 +41,12 @@ pub fn parseMeResponse(allocator: std.mem.Allocator, body: []const u8) !MeResult
 
     const obj = switch (parsed.value) {
         .object => |value| value,
-        else => return error.InvalidOpenAiMeResponse,
+        else => return error.InvalidOpenAIMeResponse,
     };
 
     const id = nonEmptyStringField(obj, "id") orelse
         nonEmptyStringField(obj, "user_id") orelse
-        return error.MissingOpenAiUserId;
+        return error.MissingOpenAIUserId;
     const email = nonEmptyStringField(obj, "email") orelse return error.MissingEmail;
     const name = nonEmptyStringField(obj, "name");
 

--- a/src/auth/auth.zig
+++ b/src/auth/auth.zig
@@ -249,7 +249,7 @@ pub fn convertCpaAuthJson(allocator: std.mem.Allocator, data: []const u8) ![]u8 
 
     const obj = switch (parsed.value) {
         .object => |obj| obj,
-        else => return error.InvalidCpaFormat,
+        else => return error.InvalidCPAFormat,
     };
 
     const refresh_token = jsonStringField(obj, "refresh_token") orelse return error.MissingRefreshToken;

--- a/src/cli/output.zig
+++ b/src/cli/output.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const display_rows = @import("../tui/display.zig");
 const registry = @import("../registry/root.zig");
 const io_util = @import("../core/io_util.zig");
@@ -11,11 +10,10 @@ const io = @import("io.zig");
 
 const UsageError = types.UsageError;
 
-pub fn importReportMarker(outcome: registry.ImportOutcome, is_windows: bool) []const u8 {
+fn importReportStyle(outcome: registry.ImportOutcome) []const u8 {
     return switch (outcome) {
-        .imported => if (is_windows) "[+]" else "✓",
-        .updated => if (is_windows) "[~]" else "✓",
-        .skipped => if (is_windows) "[x]" else "✗",
+        .imported, .updated => style.ansi.green,
+        .skipped => style.ansi.red,
     };
 }
 
@@ -46,7 +44,7 @@ pub fn printImportReport(report: *const registry.ImportReport) !void {
     stdout.init();
     var stderr: io_util.Stderr = undefined;
     stderr.init();
-    try writeImportReport(stdout.out(), stderr.out(), report);
+    try writeImportReportWithColor(stdout.out(), stderr.out(), report, stdout.color_enabled, stderr.color_enabled);
 }
 
 pub fn writeImportReport(
@@ -54,7 +52,16 @@ pub fn writeImportReport(
     err_out: *std.Io.Writer,
     report: *const registry.ImportReport,
 ) !void {
-    const is_windows = builtin.os.tag == .windows;
+    try writeImportReportWithColor(out, err_out, report, false, false);
+}
+
+pub fn writeImportReportWithColor(
+    out: *std.Io.Writer,
+    err_out: *std.Io.Writer,
+    report: *const registry.ImportReport,
+    stdout_color: bool,
+    stderr_color: bool,
+) !void {
     if (report.render_kind == .scanned) {
         try out.print("Scanning {s}...\n", .{report.source_label.?});
         try out.flush();
@@ -63,15 +70,21 @@ pub fn writeImportReport(
     for (report.events.items) |event| {
         switch (event.outcome) {
             .imported => {
-                try out.print("  {s} imported  {s}\n", .{ importReportMarker(.imported, is_windows), event.label });
+                if (stdout_color) try out.writeAll(importReportStyle(.imported));
+                try out.print("  imported  {s}\n", .{event.label});
+                if (stdout_color) try out.writeAll(style.ansi.reset);
                 try out.flush();
             },
             .updated => {
-                try out.print("  {s} updated   {s}\n", .{ importReportMarker(.updated, is_windows), event.label });
+                if (stdout_color) try out.writeAll(importReportStyle(.updated));
+                try out.print("  updated   {s}\n", .{event.label});
+                if (stdout_color) try out.writeAll(style.ansi.reset);
                 try out.flush();
             },
             .skipped => {
-                try err_out.print("  {s} skipped   {s}: {s}\n", .{ importReportMarker(.skipped, is_windows), event.label, event.reason.? });
+                if (stderr_color) try err_out.writeAll(importReportStyle(.skipped));
+                try err_out.print("  skipped   {s}: {s}\n", .{ event.label, event.reason.? });
+                if (stderr_color) try err_out.writeAll(style.ansi.reset);
                 try err_out.flush();
             },
         }

--- a/src/cli/output.zig
+++ b/src/cli/output.zig
@@ -17,6 +17,14 @@ fn importReportStyle(outcome: registry.ImportOutcome) []const u8 {
     };
 }
 
+fn importOutcomeLabel(outcome: registry.ImportOutcome) []const u8 {
+    return switch (outcome) {
+        .imported => "imported",
+        .updated => "updated",
+        .skipped => "skipped",
+    };
+}
+
 pub fn printUsageError(usage_err: *const UsageError) !void {
     var stderr: io_util.Stderr = undefined;
     stderr.init();
@@ -67,17 +75,43 @@ pub fn writeImportReportWithColor(
         try out.flush();
     }
 
+    var current_item_label: ?[]const u8 = null;
     for (report.events.items) |event| {
-        switch (event.outcome) {
-            .imported => {
-                if (stdout_color) try out.writeAll(importReportStyle(.imported));
-                try out.print("  imported  {s}\n", .{event.label});
+        if (event.item_index) |item_index| {
+            if (current_item_label == null or !std.mem.eql(u8, current_item_label.?, event.label)) {
+                if (stdout_color) try out.writeAll(style.ansi.cyan);
+                try out.print("{s}:\n", .{event.label});
                 if (stdout_color) try out.writeAll(style.ansi.reset);
                 try out.flush();
-            },
-            .updated => {
-                if (stdout_color) try out.writeAll(importReportStyle(.updated));
-                try out.print("  updated   {s}\n", .{event.label});
+                current_item_label = event.label;
+            }
+            // Array item reports stay on stdout as one contiguous human-readable
+            // block. Splitting skipped items to stderr can reorder the file
+            // header and item rows when callers merge the two streams.
+            const item_out = out;
+            const item_color = stdout_color;
+            if (item_color) try item_out.writeAll(importReportStyle(event.outcome));
+            try item_out.print("  [{d}] {s}", .{ item_index, importOutcomeLabel(event.outcome) });
+            if (event.outcome == .skipped) {
+                try item_out.print("   {s}", .{event.reason.?});
+            } else if (event.detail) |detail| {
+                try item_out.print("  {s}", .{detail});
+            }
+            try item_out.writeAll("\n");
+            if (item_color) try item_out.writeAll(style.ansi.reset);
+            try item_out.flush();
+            continue;
+        }
+
+        current_item_label = null;
+        switch (event.outcome) {
+            .imported, .updated => {
+                if (stdout_color) try out.writeAll(importReportStyle(event.outcome));
+                switch (event.outcome) {
+                    .imported => try out.print("  imported  {s}\n", .{event.label}),
+                    .updated => try out.print("  updated   {s}\n", .{event.label}),
+                    .skipped => unreachable,
+                }
                 if (stdout_color) try out.writeAll(style.ansi.reset);
                 try out.flush();
             },

--- a/src/registry/account_ops.zig
+++ b/src/registry/account_ops.zig
@@ -547,7 +547,7 @@ pub fn accountFromApiKeyMe(
     info: *const @import("../auth/auth.zig").AuthInfo,
     me: *const me_api.MeResult,
 ) !AccountRecord {
-    const api_key = info.openai_api_key orelse return error.MissingOpenAiApiKey;
+    const api_key = info.openai_api_key orelse return error.MissingOpenAIAPIKey;
     const owned_record_key = try apiKeyAccountKeyAlloc(allocator, me.user_id, api_key);
     errdefer allocator.free(owned_record_key);
     const owned_user_id = try allocator.dupe(u8, me.user_id);

--- a/src/registry/import.zig
+++ b/src/registry/import.zig
@@ -51,10 +51,10 @@ pub const ImportRenderKind = import_types.ImportRenderKind;
 pub const ImportOutcome = import_types.ImportOutcome;
 pub const ImportEvent = import_types.ImportEvent;
 pub const ImportReport = import_types.ImportReport;
+pub const importReasonLabel = import_helpers.importReasonLabel;
 const loadPurgeCarryForwardConfig = import_carry.loadPurgeCarryForwardConfig;
 const importDisplayLabelFromName = import_helpers.importDisplayLabelFromName;
 const importDisplayLabel = import_helpers.importDisplayLabel;
-const importReasonLabel = import_helpers.importReasonLabel;
 const isImportValidationError = import_helpers.isImportValidationError;
 const isImportSourceFileError = import_helpers.isImportSourceFileError;
 const isImportSkippableBatchEntryError = import_helpers.isImportSkippableBatchEntryError;
@@ -186,7 +186,8 @@ pub fn importAuthPath(
     defer allocator.free(data);
 
     if (firstNonWhitespace(data) == '[') {
-        return try importAuthArrayData(allocator, codex_home, reg, auth_path, explicit_alias, data, &report);
+        try appendAuthArrayData(allocator, codex_home, reg, auth_path, explicit_alias, data, &report, true);
+        return report;
     }
 
     const outcome = importAuthData(allocator, codex_home, reg, data, explicit_alias) catch |err| {
@@ -217,7 +218,7 @@ fn readImportFileAlloc(allocator: std.mem.Allocator, auth_file: []const u8) ![]u
     return try readFileAlloc(file, allocator, 10 * 1024 * 1024);
 }
 
-fn importAuthArrayData(
+fn appendAuthArrayData(
     allocator: std.mem.Allocator,
     codex_home: []const u8,
     reg: *Registry,
@@ -225,14 +226,15 @@ fn importAuthArrayData(
     explicit_alias: ?[]const u8,
     data: []const u8,
     report: *ImportReport,
-) !ImportReport {
+    fail_report_on_malformed: bool,
+) !void {
     var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| {
         if (!isImportValidationError(err)) return err;
         const label = try importDisplayLabel(allocator, auth_path);
         defer allocator.free(label);
         try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
-        report.failure = err;
-        return report.*;
+        if (fail_report_on_malformed) report.failure = err;
+        return;
     };
     defer parsed.deinit();
 
@@ -243,21 +245,31 @@ fn importAuthArrayData(
     if (explicit_alias != null and items.items.len != 1) {
         std.log.warn("--alias is ignored when importing a JSON array with multiple items: {s}", .{auth_path});
     }
+    if (items.items.len == 0) {
+        report.addScannedFile();
+        return;
+    }
 
     const label = try importDisplayLabel(allocator, auth_path);
     defer allocator.free(label);
-    for (items.items) |item| {
+    for (items.items, 1..) |item, item_index| {
         const item_data = try jsonValueDataAlloc(allocator, item);
         defer allocator.free(item_data);
         const item_alias = if (items.items.len == 1) explicit_alias else null;
-        const outcome = importAuthData(allocator, codex_home, reg, item_data, item_alias) catch |err| {
+        const info = @import("../auth/auth.zig").parseAuthInfoData(allocator, item_data) catch |err| {
             if (!isImportValidationError(err)) return err;
-            try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+            try report.addItemEvent(allocator, label, item_index, .skipped, importReasonLabel(err), null);
             continue;
         };
-        try report.addEvent(allocator, label, outcome, null);
+        defer info.deinit(allocator);
+        const detail = info.email;
+        const outcome = importConvertedAuthInfo(allocator, codex_home, reg, item_alias, &info, item_data) catch |err| {
+            if (!isImportValidationError(err)) return err;
+            try report.addItemEvent(allocator, label, item_index, .skipped, importReasonLabel(err), detail);
+            continue;
+        };
+        try report.addItemEvent(allocator, label, item_index, outcome, null, detail);
     }
-    return report.*;
 }
 
 fn jsonValueDataAlloc(allocator: std.mem.Allocator, value: std.json.Value) ![]u8 {
@@ -385,7 +397,7 @@ fn importApiKeyAuthData(
     info: *const @import("../auth/auth.zig").AuthInfo,
     auth_data: []const u8,
 ) !ImportOutcome {
-    const api_key = info.openai_api_key orelse return error.MissingOpenAiApiKey;
+    const api_key = info.openai_api_key orelse return error.MissingOpenAIAPIKey;
     var me = try me_api.fetchMeForApiKey(allocator, api_key);
     defer me.deinit(allocator);
 
@@ -413,7 +425,7 @@ fn importApiKeyAuthFile(
     explicit_alias: ?[]const u8,
     info: *const @import("../auth/auth.zig").AuthInfo,
 ) !ImportOutcome {
-    const api_key = info.openai_api_key orelse return error.MissingOpenAiApiKey;
+    const api_key = info.openai_api_key orelse return error.MissingOpenAIAPIKey;
     var me = try me_api.fetchMeForApiKey(allocator, api_key);
     defer me.deinit(allocator);
 
@@ -514,13 +526,26 @@ fn importAuthDirectory(
         defer allocator.free(file_path);
         const label = try importDisplayLabelFromName(allocator, name);
         defer allocator.free(label);
-        const info = @import("../auth/auth.zig").parseAuthInfo(allocator, file_path) catch |err| {
+
+        const data = readImportFileAlloc(allocator, file_path) catch |err| {
+            if (!isImportSkippableBatchEntryError(err)) return err;
+            try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+            continue;
+        };
+        defer allocator.free(data);
+
+        if (firstNonWhitespace(data) == '[') {
+            try appendAuthArrayData(allocator, codex_home, reg, file_path, null, data, &report, false);
+            continue;
+        }
+
+        const info = @import("../auth/auth.zig").parseAuthInfoData(allocator, data) catch |err| {
             if (!isImportSkippableBatchEntryError(err)) return err;
             try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
             continue;
         };
         defer info.deinit(allocator);
-        const outcome = importAuthInfo(allocator, codex_home, reg, file_path, null, &info) catch |err| {
+        const outcome = importConvertedAuthInfo(allocator, codex_home, reg, null, &info, data) catch |err| {
             if (!isImportValidationError(err)) return err;
             try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
             continue;

--- a/src/registry/import.zig
+++ b/src/registry/import.zig
@@ -243,7 +243,11 @@ fn appendAuthArrayData(
         else => unreachable,
     };
     if (explicit_alias != null and items.items.len != 1) {
-        std.log.warn("--alias is ignored when importing a JSON array with multiple items: {s}", .{auth_path});
+        if (items.items.len == 0) {
+            std.log.warn("--alias is ignored when importing an empty JSON array: {s}", .{auth_path});
+        } else {
+            std.log.warn("--alias is ignored when importing a JSON array with multiple items: {s}", .{auth_path});
+        }
     }
     if (items.items.len == 0) {
         report.addScannedFile();

--- a/src/registry/import.zig
+++ b/src/registry/import.zig
@@ -182,6 +182,41 @@ pub fn importAuthPath(
     var report = ImportReport.init(.single_file);
     errdefer report.deinit(allocator);
 
+    const data = try readImportFileAlloc(allocator, auth_path);
+    defer allocator.free(data);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
+    defer parsed.deinit();
+
+    switch (parsed.value) {
+        .array => |items| {
+            if (explicit_alias != null and items.items.len != 1) {
+                std.log.warn("--alias is ignored when importing a JSON array with multiple items: {s}", .{auth_path});
+            }
+            const label = try importDisplayLabel(allocator, auth_path);
+            defer allocator.free(label);
+            for (items.items) |item| {
+                const item_data = try jsonValueDataAlloc(allocator, item);
+                defer allocator.free(item_data);
+                const info = @import("../auth/auth.zig").parseAuthInfoData(allocator, item_data) catch |err| {
+                    if (!isImportValidationError(err)) return err;
+                    try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+                    continue;
+                };
+                defer info.deinit(allocator);
+                const item_alias = if (items.items.len == 1) explicit_alias else null;
+                const outcome = importConvertedAuthInfo(allocator, codex_home, reg, item_alias, &info, item_data) catch |err| {
+                    if (!isImportValidationError(err)) return err;
+                    try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+                    continue;
+                };
+                try report.addEvent(allocator, label, outcome, null);
+            }
+            return report;
+        },
+        else => {},
+    }
+
     const outcome = importAuthFile(allocator, codex_home, reg, auth_path, explicit_alias) catch |err| {
         if (!isImportValidationError(err)) return err;
         const label = try importDisplayLabel(allocator, auth_path);
@@ -195,6 +230,19 @@ pub fn importAuthPath(
     defer allocator.free(label);
     try report.addEvent(allocator, label, outcome, null);
     return report;
+}
+
+fn readImportFileAlloc(allocator: std.mem.Allocator, auth_file: []const u8) ![]u8 {
+    var file = try std.Io.Dir.cwd().openFile(app_runtime.io(), auth_file, .{});
+    defer file.close(app_runtime.io());
+    return try readFileAlloc(file, allocator, 10 * 1024 * 1024);
+}
+
+fn jsonValueDataAlloc(allocator: std.mem.Allocator, value: std.json.Value) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    try std.json.Stringify.value(value, .{}, &out.writer);
+    return try out.toOwnedSlice();
 }
 
 fn defaultCpaImportPath(allocator: std.mem.Allocator) ![]u8 {

--- a/src/registry/import.zig
+++ b/src/registry/import.zig
@@ -185,39 +185,11 @@ pub fn importAuthPath(
     const data = try readImportFileAlloc(allocator, auth_path);
     defer allocator.free(data);
 
-    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
-    defer parsed.deinit();
-
-    switch (parsed.value) {
-        .array => |items| {
-            if (explicit_alias != null and items.items.len != 1) {
-                std.log.warn("--alias is ignored when importing a JSON array with multiple items: {s}", .{auth_path});
-            }
-            const label = try importDisplayLabel(allocator, auth_path);
-            defer allocator.free(label);
-            for (items.items) |item| {
-                const item_data = try jsonValueDataAlloc(allocator, item);
-                defer allocator.free(item_data);
-                const info = @import("../auth/auth.zig").parseAuthInfoData(allocator, item_data) catch |err| {
-                    if (!isImportValidationError(err)) return err;
-                    try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
-                    continue;
-                };
-                defer info.deinit(allocator);
-                const item_alias = if (items.items.len == 1) explicit_alias else null;
-                const outcome = importConvertedAuthInfo(allocator, codex_home, reg, item_alias, &info, item_data) catch |err| {
-                    if (!isImportValidationError(err)) return err;
-                    try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
-                    continue;
-                };
-                try report.addEvent(allocator, label, outcome, null);
-            }
-            return report;
-        },
-        else => {},
+    if (firstNonWhitespace(data) == '[') {
+        return try importAuthArrayData(allocator, codex_home, reg, auth_path, explicit_alias, data, &report);
     }
 
-    const outcome = importAuthFile(allocator, codex_home, reg, auth_path, explicit_alias) catch |err| {
+    const outcome = importAuthData(allocator, codex_home, reg, data, explicit_alias) catch |err| {
         if (!isImportValidationError(err)) return err;
         const label = try importDisplayLabel(allocator, auth_path);
         defer allocator.free(label);
@@ -232,10 +204,60 @@ pub fn importAuthPath(
     return report;
 }
 
+fn firstNonWhitespace(data: []const u8) ?u8 {
+    for (data) |ch| {
+        if (!std.ascii.isWhitespace(ch)) return ch;
+    }
+    return null;
+}
+
 fn readImportFileAlloc(allocator: std.mem.Allocator, auth_file: []const u8) ![]u8 {
     var file = try std.Io.Dir.cwd().openFile(app_runtime.io(), auth_file, .{});
     defer file.close(app_runtime.io());
     return try readFileAlloc(file, allocator, 10 * 1024 * 1024);
+}
+
+fn importAuthArrayData(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *Registry,
+    auth_path: []const u8,
+    explicit_alias: ?[]const u8,
+    data: []const u8,
+    report: *ImportReport,
+) !ImportReport {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| {
+        if (!isImportValidationError(err)) return err;
+        const label = try importDisplayLabel(allocator, auth_path);
+        defer allocator.free(label);
+        try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+        report.failure = err;
+        return report.*;
+    };
+    defer parsed.deinit();
+
+    const items = switch (parsed.value) {
+        .array => |items| items,
+        else => unreachable,
+    };
+    if (explicit_alias != null and items.items.len != 1) {
+        std.log.warn("--alias is ignored when importing a JSON array with multiple items: {s}", .{auth_path});
+    }
+
+    const label = try importDisplayLabel(allocator, auth_path);
+    defer allocator.free(label);
+    for (items.items) |item| {
+        const item_data = try jsonValueDataAlloc(allocator, item);
+        defer allocator.free(item_data);
+        const item_alias = if (items.items.len == 1) explicit_alias else null;
+        const outcome = importAuthData(allocator, codex_home, reg, item_data, item_alias) catch |err| {
+            if (!isImportValidationError(err)) return err;
+            try report.addEvent(allocator, label, .skipped, importReasonLabel(err));
+            continue;
+        };
+        try report.addEvent(allocator, label, outcome, null);
+    }
+    return report.*;
 }
 
 fn jsonValueDataAlloc(allocator: std.mem.Allocator, value: std.json.Value) ![]u8 {
@@ -312,6 +334,18 @@ fn importAuthFile(
     const info = try @import("../auth/auth.zig").parseAuthInfo(allocator, auth_file);
     defer info.deinit(allocator);
     return try importAuthInfo(allocator, codex_home, reg, auth_file, explicit_alias, &info);
+}
+
+fn importAuthData(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *Registry,
+    auth_data: []const u8,
+    explicit_alias: ?[]const u8,
+) !ImportOutcome {
+    const info = try @import("../auth/auth.zig").parseAuthInfoData(allocator, auth_data);
+    defer info.deinit(allocator);
+    return try importConvertedAuthInfo(allocator, codex_home, reg, explicit_alias, &info, auth_data);
 }
 
 fn importAuthInfo(

--- a/src/registry/import_helpers.zig
+++ b/src/registry/import_helpers.zig
@@ -5,12 +5,6 @@ const AccountRecord = common.AccountRecord;
 const Registry = common.Registry;
 
 pub fn importDisplayLabelFromName(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
-    if (std.mem.endsWith(u8, name, ".auth.json")) {
-        return allocator.dupe(u8, name[0 .. name.len - ".auth.json".len]);
-    }
-    if (std.mem.endsWith(u8, name, ".json")) {
-        return allocator.dupe(u8, name[0 .. name.len - ".json".len]);
-    }
     return allocator.dupe(u8, name);
 }
 

--- a/src/registry/import_helpers.zig
+++ b/src/registry/import_helpers.zig
@@ -13,26 +13,26 @@ pub fn importDisplayLabel(allocator: std.mem.Allocator, path: []const u8) ![]u8 
 }
 
 pub fn importReasonLabel(err: anyerror) []const u8 {
-    switch (err) {
+    return switch (err) {
         error.SyntaxError,
         error.UnexpectedEndOfInput,
-        => return "MalformedJson",
-        else => {},
-    }
-    return @errorName(err);
+        => "InvalidJSON",
+        error.StreamTooLong => "MaxFileSizeExceeded",
+        else => @errorName(err),
+    };
 }
 
 pub fn isImportValidationError(err: anyerror) bool {
     return switch (err) {
         error.SyntaxError,
         error.UnexpectedEndOfInput,
-        error.InvalidCpaFormat,
+        error.InvalidCPAFormat,
         error.MissingEmail,
         error.MissingChatgptUserId,
-        error.MissingOpenAiApiKey,
-        error.MissingOpenAiUserId,
-        error.InvalidOpenAiMeResponse,
-        error.OpenAiMeRequestFailed,
+        error.MissingOpenAIAPIKey,
+        error.MissingOpenAIUserId,
+        error.InvalidOpenAIMeResponse,
+        error.OpenAIMeRequestFailed,
         error.MissingAccountId,
         error.MissingRefreshToken,
         error.AccountIdMismatch,

--- a/src/registry/import_types.zig
+++ b/src/registry/import_types.zig
@@ -15,10 +15,13 @@ pub const ImportEvent = struct {
     label: []u8,
     outcome: ImportOutcome,
     reason: ?[]u8 = null,
+    item_index: ?usize = null,
+    detail: ?[]u8 = null,
 
     pub fn deinit(self: *ImportEvent, allocator: std.mem.Allocator) void {
         allocator.free(self.label);
         if (self.reason) |reason| allocator.free(reason);
+        if (self.detail) |detail| allocator.free(detail);
     }
 };
 
@@ -52,17 +55,49 @@ pub const ImportReport = struct {
         outcome: ImportOutcome,
         reason: ?[]const u8,
     ) !void {
+        try self.addEventDetail(allocator, label, outcome, reason, null, null);
+    }
+
+    pub fn addItemEvent(
+        self: *ImportReport,
+        allocator: std.mem.Allocator,
+        label: []const u8,
+        item_index: usize,
+        outcome: ImportOutcome,
+        reason: ?[]const u8,
+        detail: ?[]const u8,
+    ) !void {
+        try self.addEventDetail(allocator, label, outcome, reason, item_index, detail);
+    }
+
+    pub fn addScannedFile(self: *ImportReport) void {
+        self.total_files += 1;
+    }
+
+    fn addEventDetail(
+        self: *ImportReport,
+        allocator: std.mem.Allocator,
+        label: []const u8,
+        outcome: ImportOutcome,
+        reason: ?[]const u8,
+        item_index: ?usize,
+        detail: ?[]const u8,
+    ) !void {
         const owned_label = try allocator.dupe(u8, label);
         errdefer allocator.free(owned_label);
         const owned_reason = if (reason) |reason_text| try allocator.dupe(u8, reason_text) else null;
         errdefer if (owned_reason) |owned| allocator.free(owned);
+        const owned_detail = if (detail) |detail_text| try allocator.dupe(u8, detail_text) else null;
+        errdefer if (owned_detail) |owned| allocator.free(owned);
 
         try self.events.append(allocator, .{
             .label = owned_label,
             .outcome = outcome,
             .reason = owned_reason,
+            .item_index = item_index,
+            .detail = owned_detail,
         });
-        self.total_files += 1;
+        if (item_index == null or item_index.? == 1) self.total_files += 1;
         switch (outcome) {
             .imported => self.imported += 1,
             .updated => self.updated += 1,

--- a/src/registry/root.zig
+++ b/src/registry/root.zig
@@ -99,6 +99,7 @@ pub const ImportRenderKind = import_mod.ImportRenderKind;
 pub const ImportOutcome = import_mod.ImportOutcome;
 pub const ImportEvent = import_mod.ImportEvent;
 pub const ImportReport = import_mod.ImportReport;
+pub const importReasonLabel = import_mod.importReasonLabel;
 pub fn purgeRegistryFromImportSource(allocator: std.mem.Allocator, codex_home: []const u8, auth_path: ?[]const u8, alias: ?[]const u8) !ImportReport {
     return import_mod.purgeRegistryFromImportSourceWithSaver(allocator, codex_home, auth_path, alias, saveRegistry);
 }

--- a/src/workflows/import.zig
+++ b/src/workflows/import.zig
@@ -12,7 +12,7 @@ pub fn handleImport(allocator: std.mem.Allocator, codex_home: []const u8, opts: 
         var report = try registry.purgeRegistryFromImportSource(allocator, codex_home, opts.auth_path, opts.alias);
         defer report.deinit(allocator);
         try cli.output.printImportReport(&report);
-        if (report.failure) |err| return err;
+        if (report.failure != null) return error.ImportFailed;
         return;
     }
 
@@ -39,5 +39,5 @@ pub fn handleImport(allocator: std.mem.Allocator, codex_home: []const u8, opts: 
         try registry.saveRegistry(allocator, codex_home, &reg);
     }
     try cli.output.printImportReport(&report);
-    if (report.failure) |err| return err;
+    if (report.failure != null) return error.ImportFailed;
 }

--- a/src/workflows/login.zig
+++ b/src/workflows/login.zig
@@ -40,7 +40,7 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
     defer info.deinit(allocator);
 
     if (info.auth_mode == .apikey) {
-        const api_key = info.openai_api_key orelse return error.MissingOpenAiApiKey;
+        const api_key = info.openai_api_key orelse return error.MissingOpenAIAPIKey;
         var me = try me_api.fetchMeForApiKey(allocator, api_key);
         defer me.deinit(allocator);
 

--- a/src/workflows/preflight.zig
+++ b/src/workflows/preflight.zig
@@ -26,6 +26,7 @@ pub fn isHandledCliError(err: anyerror) bool {
         err == error.RemoveConfirmationUnavailable or
         err == error.RemoveSelectionRequiresTty or
         err == error.InvalidRemoveSelectionInput or
+        err == error.ImportFailed or
         err == error.AppLaunchConfigValidationFailed or
         err == error.AppIdRequired or
         err == error.AppIdNotFound or

--- a/tests/cli_behavior_test.zig
+++ b/tests/cli_behavior_test.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const cli = @import("codex_auth").cli;
 const registry = @import("codex_auth").registry;
 
 const ansi = struct {
     const reset = "\x1b[0m";
     const cyan = "\x1b[36m";
+    const green = "\x1b[32m";
+    const red = "\x1b[31m";
 };
 
 fn makeRegistry() registry.Registry {
@@ -152,14 +153,6 @@ test "Scenario: Given removed app unpatch subcommand when parsing then usage err
     defer cli.commands.freeParseResult(gpa, &result);
 
     try expectUsageError(result, .app, "unexpected argument `unpatch` for `app`.");
-}
-
-fn expectedImportMarker(outcome: registry.ImportOutcome) []const u8 {
-    return switch (outcome) {
-        .imported => if (builtin.os.tag == .windows) "[+]" else "✓",
-        .updated => if (builtin.os.tag == .windows) "[~]" else "✓",
-        .skipped => if (builtin.os.tag == .windows) "[x]" else "✗",
-    };
 }
 
 test "Scenario: Given import path and alias when parsing then import options are preserved" {
@@ -537,27 +530,27 @@ test "Scenario: Given scanned import report when rendering then stdout and stder
     var report = registry.ImportReport.init(.scanned);
     defer report.deinit(gpa);
     report.source_label = try gpa.dupe(u8, "./tokens/");
-    try report.addEvent(gpa, "token_ryan.taylor.alpha@email.com", .imported, null);
-    try report.addEvent(gpa, "token_jane.smith.alpha@email.com", .updated, null);
-    try report.addEvent(gpa, "token_invalid", .skipped, "MalformedJson");
+    try report.addEvent(gpa, "token_ryan.taylor.alpha@email.com.json", .imported, null);
+    try report.addEvent(gpa, "token_jane.smith.alpha@email.com.json", .updated, null);
+    try report.addEvent(gpa, "token_invalid.json", .skipped, "MalformedJson");
 
     try cli.output.writeImportReport(&stdout_aw.writer, &stderr_aw.writer, &report);
 
     const expected_stdout = try std.fmt.allocPrint(
         gpa,
         "Scanning ./tokens/...\n" ++
-            "  {s} imported  token_ryan.taylor.alpha@email.com\n" ++
-            "  {s} updated   token_jane.smith.alpha@email.com\n" ++
+            "  imported  token_ryan.taylor.alpha@email.com.json\n" ++
+            "  updated   token_jane.smith.alpha@email.com.json\n" ++
             "Import Summary: 1 imported, 1 updated, 1 skipped (total 3 files)\n",
-        .{ expectedImportMarker(.imported), expectedImportMarker(.updated) },
+        .{},
     );
     defer gpa.free(expected_stdout);
     try std.testing.expectEqualStrings(expected_stdout, stdout_aw.written());
 
     const expected_stderr = try std.fmt.allocPrint(
         gpa,
-        "  {s} skipped   token_invalid: MalformedJson\n",
-        .{expectedImportMarker(.skipped)},
+        "  skipped   token_invalid.json: MalformedJson\n",
+        .{},
     );
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, stderr_aw.written());
@@ -572,7 +565,7 @@ test "Scenario: Given single-file skipped import report when rendering then summ
 
     var report = registry.ImportReport.init(.single_file);
     defer report.deinit(gpa);
-    try report.addEvent(gpa, "token_bob.wilson.alpha@email.com", .skipped, "MissingEmail");
+    try report.addEvent(gpa, "token_bob.wilson.alpha@email.com.json", .skipped, "MissingEmail");
 
     try cli.output.writeImportReport(&stdout_aw.writer, &stderr_aw.writer, &report);
 
@@ -582,11 +575,32 @@ test "Scenario: Given single-file skipped import report when rendering then summ
     );
     const expected_stderr = try std.fmt.allocPrint(
         gpa,
-        "  {s} skipped   token_bob.wilson.alpha@email.com: MissingEmail\n",
-        .{expectedImportMarker(.skipped)},
+        "  skipped   token_bob.wilson.alpha@email.com.json: MissingEmail\n",
+        .{},
     );
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, stderr_aw.written());
+}
+
+test "Scenario: Given color import report when rendering then success and errors use ANSI colors without markers" {
+    const gpa = std.testing.allocator;
+    var stdout_aw: std.Io.Writer.Allocating = .init(gpa);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(gpa);
+    defer stderr_aw.deinit();
+
+    var report = registry.ImportReport.init(.scanned);
+    defer report.deinit(gpa);
+    report.source_label = try gpa.dupe(u8, "./tokens/");
+    try report.addEvent(gpa, "token_carol.three@example.com.json", .updated, null);
+    try report.addEvent(gpa, "token_invalid.json", .skipped, "MalformedJson");
+
+    try cli.output.writeImportReportWithColor(&stdout_aw.writer, &stderr_aw.writer, &report, true, true);
+
+    try std.testing.expect(std.mem.indexOf(u8, stdout_aw.written(), ansi.green ++ "  updated   token_carol.three@example.com.json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stderr_aw.written(), ansi.red ++ "  skipped   token_invalid.json: MalformedJson") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout_aw.written(), "✓") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stderr_aw.written(), "✗") == null);
 }
 
 test "Scenario: Given removed top-level auto command when parsing then usage error is returned" {

--- a/tests/cli_behavior_test.zig
+++ b/tests/cli_behavior_test.zig
@@ -532,7 +532,7 @@ test "Scenario: Given scanned import report when rendering then stdout and stder
     report.source_label = try gpa.dupe(u8, "./tokens/");
     try report.addEvent(gpa, "token_ryan.taylor.alpha@email.com.json", .imported, null);
     try report.addEvent(gpa, "token_jane.smith.alpha@email.com.json", .updated, null);
-    try report.addEvent(gpa, "token_invalid.json", .skipped, "MalformedJson");
+    try report.addEvent(gpa, "token_invalid.json", .skipped, "InvalidJSON");
 
     try cli.output.writeImportReport(&stdout_aw.writer, &stderr_aw.writer, &report);
 
@@ -549,7 +549,7 @@ test "Scenario: Given scanned import report when rendering then stdout and stder
 
     const expected_stderr = try std.fmt.allocPrint(
         gpa,
-        "  skipped   token_invalid.json: MalformedJson\n",
+        "  skipped   token_invalid.json: InvalidJSON\n",
         .{},
     );
     defer gpa.free(expected_stderr);
@@ -582,6 +582,36 @@ test "Scenario: Given single-file skipped import report when rendering then summ
     try std.testing.expectEqualStrings(expected_stderr, stderr_aw.written());
 }
 
+test "Scenario: Given array import report when rendering then items are grouped under the filename" {
+    const gpa = std.testing.allocator;
+    var stdout_aw: std.Io.Writer.Allocating = .init(gpa);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(gpa);
+    defer stderr_aw.deinit();
+
+    var report = registry.ImportReport.init(.scanned);
+    defer report.deinit(gpa);
+    report.source_label = try gpa.dupe(u8, "./tokens/");
+    try report.addEvent(gpa, "one_token_file.json", .imported, null);
+    try report.addItemEvent(gpa, "tokens_array.json", 1, .imported, null, "frank@example.com");
+    try report.addItemEvent(gpa, "tokens_array.json", 2, .skipped, "MissingEmail", null);
+    try report.addEvent(gpa, "another_token_file.json", .updated, null);
+
+    try cli.output.writeImportReport(&stdout_aw.writer, &stderr_aw.writer, &report);
+
+    try std.testing.expectEqualStrings(
+        "Scanning ./tokens/...\n" ++
+            "  imported  one_token_file.json\n" ++
+            "tokens_array.json:\n" ++
+            "  [1] imported  frank@example.com\n" ++
+            "  [2] skipped   MissingEmail\n" ++
+            "  updated   another_token_file.json\n" ++
+            "Import Summary: 2 imported, 1 updated, 1 skipped (total 3 files)\n",
+        stdout_aw.written(),
+    );
+    try std.testing.expectEqualStrings("", stderr_aw.written());
+}
+
 test "Scenario: Given color import report when rendering then success and errors use ANSI colors without markers" {
     const gpa = std.testing.allocator;
     var stdout_aw: std.Io.Writer.Allocating = .init(gpa);
@@ -593,12 +623,12 @@ test "Scenario: Given color import report when rendering then success and errors
     defer report.deinit(gpa);
     report.source_label = try gpa.dupe(u8, "./tokens/");
     try report.addEvent(gpa, "token_carol.three@example.com.json", .updated, null);
-    try report.addEvent(gpa, "token_invalid.json", .skipped, "MalformedJson");
+    try report.addEvent(gpa, "token_invalid.json", .skipped, "InvalidJSON");
 
     try cli.output.writeImportReportWithColor(&stdout_aw.writer, &stderr_aw.writer, &report, true, true);
 
     try std.testing.expect(std.mem.indexOf(u8, stdout_aw.written(), ansi.green ++ "  updated   token_carol.three@example.com.json") != null);
-    try std.testing.expect(std.mem.indexOf(u8, stderr_aw.written(), ansi.red ++ "  skipped   token_invalid.json: MalformedJson") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stderr_aw.written(), ansi.red ++ "  skipped   token_invalid.json: InvalidJSON") != null);
     try std.testing.expect(std.mem.indexOf(u8, stdout_aw.written(), "✓") == null);
     try std.testing.expect(std.mem.indexOf(u8, stderr_aw.written(), "✗") == null);
 }

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -441,8 +441,12 @@ fn runCliWithIsolatedHomeAndPathAndStdin(
     defer child.kill(fs.io());
 
     if (child.stdin) |stdin_pipe| {
-        try fs.wrapFile(stdin_pipe).writeAll(stdin_data);
-        fs.wrapFile(stdin_pipe).close();
+        const wrapped_stdin = fs.wrapFile(stdin_pipe);
+        wrapped_stdin.writeAll(stdin_data) catch |err| switch (err) {
+            error.BrokenPipe => {},
+            else => return err,
+        };
+        wrapped_stdin.close();
         child.stdin = null;
     }
 
@@ -508,8 +512,12 @@ fn runCliWithIsolatedHomeAndStdin(
     defer child.kill(fs.io());
 
     if (child.stdin) |stdin_pipe| {
-        try fs.wrapFile(stdin_pipe).writeAll(stdin_data);
-        fs.wrapFile(stdin_pipe).close();
+        const wrapped_stdin = fs.wrapFile(stdin_pipe);
+        wrapped_stdin.writeAll(stdin_data) catch |err| switch (err) {
+            error.BrokenPipe => {},
+            else => return err,
+        };
+        wrapped_stdin.close();
         child.stdin = null;
     }
 

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -31,14 +31,6 @@ const SeedAccount = struct {
 const future_primary_reset_at: i64 = 4_102_444_800;
 const future_secondary_reset_at: i64 = 4_103_049_600;
 
-fn expectedImportMarker(outcome: registry.ImportOutcome) []const u8 {
-    return switch (outcome) {
-        .imported => if (builtin.os.tag == .windows) "[+]" else "✓",
-        .updated => if (builtin.os.tag == .windows) "[~]" else "✓",
-        .skipped => if (builtin.os.tag == .windows) "[x]" else "✗",
-    };
-}
-
 fn projectRootAlloc(allocator: std.mem.Allocator) ![]u8 {
     const project_root = getEnvVarOwned(allocator, cli_integration_project_root_env) catch |err| switch (err) {
         error.EnvironmentVariableNotFound => null,
@@ -1136,18 +1128,14 @@ test "Scenario: Given repeated single-file import when running import then first
     defer gpa.free(first.stdout);
     defer gpa.free(first.stderr);
     try expectSuccess(first);
-    const expected_first_stdout = try std.fmt.allocPrint(gpa, "  {s} imported  token_ryan.taylor.alpha@email.com\n", .{expectedImportMarker(.imported)});
-    defer gpa.free(expected_first_stdout);
-    try std.testing.expectEqualStrings(expected_first_stdout, first.stdout);
+    try std.testing.expectEqualStrings("  imported  token_ryan.taylor.alpha@email.com.json\n", first.stdout);
     try std.testing.expectEqualStrings("", first.stderr);
 
     const second = try runCliWithIsolatedHome(gpa, project_root, home_root, &[_][]const u8{ "import", import_path });
     defer gpa.free(second.stdout);
     defer gpa.free(second.stderr);
     try expectSuccess(second);
-    const expected_second_stdout = try std.fmt.allocPrint(gpa, "  {s} updated   token_ryan.taylor.alpha@email.com\n", .{expectedImportMarker(.updated)});
-    defer gpa.free(expected_second_stdout);
-    try std.testing.expectEqualStrings(expected_second_stdout, second.stdout);
+    try std.testing.expectEqualStrings("  updated   token_ryan.taylor.alpha@email.com.json\n", second.stdout);
     try std.testing.expectEqualStrings("", second.stderr);
 }
 
@@ -1318,8 +1306,8 @@ test "Scenario: Given single-file import missing email when running import then 
     try std.testing.expectEqualStrings("Import Summary: 0 imported, 1 skipped\n", result.stdout);
     const expected_stderr = try std.fmt.allocPrint(
         gpa,
-        "  {s} skipped   token_bob.wilson.alpha@email.com: MissingEmail\n",
-        .{expectedImportMarker(.skipped)},
+        "  skipped   token_bob.wilson.alpha@email.com.json: MissingEmail\n",
+        .{},
     );
     defer gpa.free(expected_stderr);
     try std.testing.expect(std.mem.indexOf(u8, result.stderr, expected_stderr) != null);
@@ -1463,31 +1451,21 @@ test "Scenario: Given directory import with new updated and invalid files when r
     const expected_stdout = try std.fmt.allocPrint(
         gpa,
         "Scanning {s}...\n" ++
-            "  {s} updated   token_jane.smith.alpha@email.com\n" ++
-            "  {s} imported  token_john.doe.alpha@email.com\n" ++
-            "  {s} imported  token_mike.roe.alpha@email.com\n" ++
-            "  {s} imported  token_ryan.taylor.alpha@email.com\n" ++
+            "  updated   token_jane.smith.alpha@email.com.json\n" ++
+            "  imported  token_john.doe.alpha@email.com.json\n" ++
+            "  imported  token_mike.roe.alpha@email.com.json\n" ++
+            "  imported  token_ryan.taylor.alpha@email.com.json\n" ++
             "Import Summary: 3 imported, 1 updated, 3 skipped (total 7 files)\n",
-        .{
-            imports_path,
-            expectedImportMarker(.updated),
-            expectedImportMarker(.imported),
-            expectedImportMarker(.imported),
-            expectedImportMarker(.imported),
-        },
+        .{imports_path},
     );
     defer gpa.free(expected_stdout);
     try std.testing.expectEqualStrings(expected_stdout, result.stdout);
     const expected_stderr = try std.fmt.allocPrint(
         gpa,
-        "  {s} skipped   token_alice.brown.alpha@email.com: MissingChatgptUserId\n" ++
-            "  {s} skipped   token_bob.wilson.alpha@email.com: MissingEmail\n" ++
-            "  {s} skipped   token_invalid: MalformedJson\n",
-        .{
-            expectedImportMarker(.skipped),
-            expectedImportMarker(.skipped),
-            expectedImportMarker(.skipped),
-        },
+        "  skipped   token_alice.brown.alpha@email.com.json: MissingChatgptUserId\n" ++
+            "  skipped   token_bob.wilson.alpha@email.com.json: MissingEmail\n" ++
+            "  skipped   token_invalid.json: MalformedJson\n",
+        .{},
     );
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, result.stderr);
@@ -1522,13 +1500,13 @@ test "Scenario: Given directory import with an empty json file when running impo
     const expected_stdout = try std.fmt.allocPrint(
         gpa,
         "Scanning {s}...\n" ++
-            "  {s} imported  valid\n" ++
+            "  imported  valid.json\n" ++
             "Import Summary: 1 imported, 0 updated, 1 skipped (total 2 files)\n",
-        .{ imports_path, expectedImportMarker(.imported) },
+        .{imports_path},
     );
     defer gpa.free(expected_stdout);
     try std.testing.expectEqualStrings(expected_stdout, result.stdout);
-    const expected_stderr = try std.fmt.allocPrint(gpa, "  {s} skipped   empty: MalformedJson\n", .{expectedImportMarker(.skipped)});
+    const expected_stderr = try std.fmt.allocPrint(gpa, "  skipped   empty.json: MalformedJson\n", .{});
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, result.stderr);
 
@@ -1571,13 +1549,13 @@ test "Scenario: Given directory import with a broken symlink when running import
     const expected_stdout = try std.fmt.allocPrint(
         gpa,
         "Scanning {s}...\n" ++
-            "  {s} imported  valid\n" ++
+            "  imported  valid.json\n" ++
             "Import Summary: 1 imported, 0 updated, 1 skipped (total 2 files)\n",
-        .{ imports_path, expectedImportMarker(.imported) },
+        .{imports_path},
     );
     defer gpa.free(expected_stdout);
     try std.testing.expectEqualStrings(expected_stdout, result.stdout);
-    const expected_stderr = try std.fmt.allocPrint(gpa, "  {s} skipped   broken: FileNotFound\n", .{expectedImportMarker(.skipped)});
+    const expected_stderr = try std.fmt.allocPrint(gpa, "  skipped   broken.json: FileNotFound\n", .{});
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, result.stderr);
 
@@ -1620,14 +1598,14 @@ test "Scenario: Given cpa directory in default location when running import cpa 
     const expected_stdout = try std.fmt.allocPrint(
         gpa,
         "Scanning ~/.cli-proxy-api...\n" ++
-            "  {s} imported  first\n" ++
-            "  {s} imported  second\n" ++
+            "  imported  first.json\n" ++
+            "  imported  second.json\n" ++
             "Import Summary: 2 imported, 0 updated, 1 skipped (total 3 files)\n",
-        .{ expectedImportMarker(.imported), expectedImportMarker(.imported) },
+        .{},
     );
     defer gpa.free(expected_stdout);
     try std.testing.expectEqualStrings(expected_stdout, result.stdout);
-    const expected_stderr = try std.fmt.allocPrint(gpa, "  {s} skipped   no-refresh: MissingRefreshToken\n", .{expectedImportMarker(.skipped)});
+    const expected_stderr = try std.fmt.allocPrint(gpa, "  skipped   no-refresh.json: MissingRefreshToken\n", .{});
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, result.stderr);
 
@@ -1682,9 +1660,7 @@ test "Scenario: Given cpa file import when running import cpa then it stores a s
     defer gpa.free(result.stderr);
 
     try expectSuccess(result);
-    const expected_stdout = try std.fmt.allocPrint(gpa, "  {s} imported  cpa\n", .{expectedImportMarker(.imported)});
-    defer gpa.free(expected_stdout);
-    try std.testing.expectEqualStrings(expected_stdout, result.stdout);
+    try std.testing.expectEqualStrings("  imported  cpa.json\n", result.stdout);
     try std.testing.expectEqualStrings("", result.stderr);
 
     const codex_home = try codexHomeAlloc(gpa, home_root);

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -1464,11 +1464,82 @@ test "Scenario: Given directory import with new updated and invalid files when r
         gpa,
         "  skipped   token_alice.brown.alpha@email.com.json: MissingChatgptUserId\n" ++
             "  skipped   token_bob.wilson.alpha@email.com.json: MissingEmail\n" ++
-            "  skipped   token_invalid.json: MalformedJson\n",
+            "  skipped   token_invalid.json: InvalidJSON\n",
         .{},
     );
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, result.stderr);
+}
+
+test "Scenario: Given directory import with regular files and array files when running import then array items are grouped" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+    try tmp.dir.makePath("imports");
+
+    const another_auth = try fixtures.authJsonWithEmailPlan(gpa, "another@example.com", "plus");
+    defer gpa.free(another_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/another_token_file.json", .data = another_auth });
+
+    const one_auth = try fixtures.authJsonWithEmailPlan(gpa, "one@example.com", "team");
+    defer gpa.free(one_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/one_token_file.json", .data = one_auth });
+
+    try tmp.dir.writeFile(.{ .sub_path = "imports/token_malformed.json", .data = "{not-json}" });
+
+    const first_array_auth = try fixtures.authJsonWithEmailPlan(gpa, "erin.array@example.com", "plus");
+    defer gpa.free(first_array_auth);
+    const second_array_auth = try fixtures.authJsonWithEmailPlan(gpa, "frank.array@example.com", "team");
+    defer gpa.free(second_array_auth);
+    const array_auth = try std.fmt.allocPrint(gpa, "[{s},{s}]", .{ first_array_auth, second_array_auth });
+    defer gpa.free(array_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/tokens_array.json", .data = array_auth });
+
+    const mixed_valid_auth = try fixtures.authJsonWithEmailPlan(gpa, "grace.array@example.com", "pro");
+    defer gpa.free(mixed_valid_auth);
+    const mixed_invalid_auth = try fixtures.authJsonWithoutEmail(gpa);
+    defer gpa.free(mixed_invalid_auth);
+    const mixed_array_auth = try std.fmt.allocPrint(gpa, "[{s},{s}]", .{ mixed_valid_auth, mixed_invalid_auth });
+    defer gpa.free(mixed_array_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/tokens_array_mixed.json", .data = mixed_array_auth });
+
+    try tmp.dir.writeFile(.{ .sub_path = "imports/tokens_empty_array.json", .data = "[]" });
+
+    const imports_path = try fs.path.join(gpa, &[_][]const u8{ home_root, "imports" });
+    defer gpa.free(imports_path);
+
+    const result = try runCliWithIsolatedHome(gpa, project_root, home_root, &[_][]const u8{ "import", imports_path });
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectSuccess(result);
+    const expected_stdout = try std.fmt.allocPrint(
+        gpa,
+        "Scanning {s}...\n" ++
+            "  imported  another_token_file.json\n" ++
+            "  imported  one_token_file.json\n" ++
+            "tokens_array.json:\n" ++
+            "  [1] imported  erin.array@example.com\n" ++
+            "  [2] imported  frank.array@example.com\n" ++
+            "tokens_array_mixed.json:\n" ++
+            "  [1] imported  grace.array@example.com\n" ++
+            "  [2] skipped   MissingEmail\n" ++
+            "Import Summary: 5 imported, 0 updated, 2 skipped (total 6 files)\n",
+        .{imports_path},
+    );
+    defer gpa.free(expected_stdout);
+    try std.testing.expectEqualStrings(expected_stdout, result.stdout);
+    try std.testing.expectEqualStrings(
+        "  skipped   token_malformed.json: InvalidJSON\n",
+        result.stderr,
+    );
 }
 
 test "Scenario: Given directory import with an empty json file when running import then it is skipped as malformed and valid imports still persist" {
@@ -1506,7 +1577,7 @@ test "Scenario: Given directory import with an empty json file when running impo
     );
     defer gpa.free(expected_stdout);
     try std.testing.expectEqualStrings(expected_stdout, result.stdout);
-    const expected_stderr = try std.fmt.allocPrint(gpa, "  skipped   empty.json: MalformedJson\n", .{});
+    const expected_stderr = try std.fmt.allocPrint(gpa, "  skipped   empty.json: InvalidJSON\n", .{});
     defer gpa.free(expected_stderr);
     try std.testing.expectEqualStrings(expected_stderr, result.stderr);
 

--- a/tests/cli_picker_test.zig
+++ b/tests/cli_picker_test.zig
@@ -27,7 +27,6 @@ const removeTuiFooterText = cli.tui.removeTuiFooterText;
 const listTuiFooterText = cli.tui.listTuiFooterText;
 const writeTuiFrameTo = cli.tui.writeTuiFrameTo;
 const TuiInputKey = cli.tui.TuiInputKey;
-const importReportMarker = cli.output.importReportMarker;
 const mapTuiOutputError = cli.tui.mapTuiOutputError;
 const indexWidth = cli.render.indexWidth;
 const LiveListViewport = cli.render.LiveListViewport;
@@ -1482,9 +1481,6 @@ test "Scenario: Given Windows console labels when rendering unicode-prone output
         "Keys: Up/Down scroll, PgUp/PgDn page, Home/End jump, Esc or q quit\n",
         listTuiFooterText(true),
     );
-    try std.testing.expectEqualStrings("[+]", importReportMarker(.imported, true));
-    try std.testing.expectEqualStrings("[~]", importReportMarker(.updated, true));
-    try std.testing.expectEqualStrings("[x]", importReportMarker(.skipped, true));
 }
 
 test "Scenario: Given non-Windows console labels when rendering unicode-prone output then the richer glyphs remain" {
@@ -1500,9 +1496,6 @@ test "Scenario: Given non-Windows console labels when rendering unicode-prone ou
         "Keys: ↑/↓ scroll, PgUp/PgDn page, Home/End jump, Esc or q quit\n",
         listTuiFooterText(false),
     );
-    try std.testing.expectEqualStrings("✓", importReportMarker(.imported, false));
-    try std.testing.expectEqualStrings("✓", importReportMarker(.updated, false));
-    try std.testing.expectEqualStrings("✗", importReportMarker(.skipped, false));
 }
 
 test "Scenario: Given a live TUI write failure when mapping output errors then it becomes a handled TUI error" {

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -1383,6 +1383,35 @@ test "import auth path with json array imports each top-level item" {
     try std.testing.expect(reg.accounts.items.len == 2);
 }
 
+test "import auth path with malformed single file reports skipped" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+    try tmp.dir.writeFile(.{ .sub_path = "imports/bad.json", .data = "{not-json}" });
+
+    const import_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "imports", "bad.json" });
+    defer gpa.free(import_path);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+
+    var summary = try registry.importAuthPath(gpa, codex_home, &reg, import_path, null);
+    defer summary.deinit(gpa);
+
+    try std.testing.expect(summary.render_kind == .single_file);
+    try std.testing.expect(summary.imported == 0);
+    try std.testing.expect(summary.updated == 0);
+    try std.testing.expect(summary.skipped == 1);
+    try std.testing.expect(summary.failure != null);
+    try std.testing.expectEqual(error.SyntaxError, summary.failure.?);
+    try std.testing.expectEqualStrings("bad.json", summary.events.items[0].label);
+    try std.testing.expectEqualStrings("MalformedJson", summary.events.items[0].reason.?);
+}
+
 test "import auth path with directory imports multiple json files and skips bad files" {
     const gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -1376,10 +1376,14 @@ test "import auth path with json array imports each top-level item" {
     try std.testing.expect(summary.imported == 2);
     try std.testing.expect(summary.updated == 0);
     try std.testing.expect(summary.skipped == 0);
-    try std.testing.expect(summary.total_files == 2);
+    try std.testing.expect(summary.total_files == 1);
     try std.testing.expectEqual(@as(usize, 2), summary.events.items.len);
     try std.testing.expectEqualStrings("token_array.json", summary.events.items[0].label);
     try std.testing.expectEqualStrings("token_array.json", summary.events.items[1].label);
+    try std.testing.expectEqual(@as(?usize, 1), summary.events.items[0].item_index);
+    try std.testing.expectEqual(@as(?usize, 2), summary.events.items[1].item_index);
+    try std.testing.expectEqualStrings("array-one@example.com", summary.events.items[0].detail.?);
+    try std.testing.expectEqualStrings("array-two@example.com", summary.events.items[1].detail.?);
     try std.testing.expect(reg.accounts.items.len == 2);
 }
 
@@ -1409,7 +1413,13 @@ test "import auth path with malformed single file reports skipped" {
     try std.testing.expect(summary.failure != null);
     try std.testing.expectEqual(error.SyntaxError, summary.failure.?);
     try std.testing.expectEqualStrings("bad.json", summary.events.items[0].label);
-    try std.testing.expectEqualStrings("MalformedJson", summary.events.items[0].reason.?);
+    try std.testing.expectEqualStrings("InvalidJSON", summary.events.items[0].reason.?);
+}
+
+test "import reason labels override only public names that differ from internal errors" {
+    try std.testing.expectEqualStrings("InvalidJSON", registry.importReasonLabel(error.SyntaxError));
+    try std.testing.expectEqualStrings("InvalidCPAFormat", registry.importReasonLabel(error.InvalidCPAFormat));
+    try std.testing.expectEqualStrings("MaxFileSizeExceeded", registry.importReasonLabel(error.StreamTooLong));
 }
 
 test "import auth path with directory imports multiple json files and skips bad files" {

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -1346,6 +1346,43 @@ test "import auth path with single file keeps explicit alias" {
     try std.testing.expect(std.mem.eql(u8, reg.accounts.items[0].alias, "personal"));
 }
 
+test "import auth path with json array imports each top-level item" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+
+    const first_auth = try authJsonWithEmailPlan(gpa, "array-one@example.com", "plus");
+    defer gpa.free(first_auth);
+    const second_auth = try authJsonWithEmailPlan(gpa, "array-two@example.com", "team");
+    defer gpa.free(second_auth);
+    const array_auth = try std.fmt.allocPrint(gpa, "[{s},{s}]", .{ first_auth, second_auth });
+    defer gpa.free(array_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/token_array.json", .data = array_auth });
+
+    const import_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "imports", "token_array.json" });
+    defer gpa.free(import_path);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+
+    var summary = try registry.importAuthPath(gpa, codex_home, &reg, import_path, null);
+    defer summary.deinit(gpa);
+
+    try std.testing.expect(summary.render_kind == .single_file);
+    try std.testing.expect(summary.imported == 2);
+    try std.testing.expect(summary.updated == 0);
+    try std.testing.expect(summary.skipped == 0);
+    try std.testing.expect(summary.total_files == 2);
+    try std.testing.expectEqual(@as(usize, 2), summary.events.items.len);
+    try std.testing.expectEqualStrings("token_array.json", summary.events.items[0].label);
+    try std.testing.expectEqualStrings("token_array.json", summary.events.items[1].label);
+    try std.testing.expect(reg.accounts.items.len == 2);
+}
+
 test "import auth path with directory imports multiple json files and skips bad files" {
     const gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});


### PR DESCRIPTION
### What changed

- Support importing a single `.json` file whose top-level value is an array
- Keep full filenames in import reports.
  - Before: `updated   token_carol.three@example.com`
  - After: `updated   token_carol.three@example.com.json`
- Remove status glyph prefixes like `✓` / `✗`, ANSI colors instead

fix #115 
