### PR TITLE
Fix on Nix

### DIFF
--- a/src/workflows/login.zig
+++ b/src/workflows/login.zig
@@ -37,6 +37,8 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
         _ = try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg);
     }
 
+    try registry.ensureAccountsDir(allocator, codex_home);
+
     const auth_path = try registry.activeAuthPath(allocator, codex_home);
     defer allocator.free(auth_path);
     const original_auth = try loadActiveAuthState(allocator, auth_path);
@@ -48,7 +50,6 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
         );
     };
 
-    try registry.ensureAccountsDir(allocator, codex_home);
     try cli.login.runCodexLogin(opts, codex_home);
 
     const info = try auth.parseAuthInfo(allocator, auth_path);
@@ -64,6 +65,7 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
         const dest = try registry.accountAuthPath(allocator, codex_home, record_key);
         defer allocator.free(dest);
 
+        try registry.ensureAccountsDir(allocator, codex_home);
         try registry.copyManagedFile(auth_path, dest);
 
         const record = try registry.accountFromApiKeyMe(allocator, "", &info, &me);
@@ -79,6 +81,7 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
     const dest = try registry.accountAuthPath(allocator, codex_home, record_key);
     defer allocator.free(dest);
 
+    try registry.ensureAccountsDir(allocator, codex_home);
     try registry.copyManagedFile(auth_path, dest);
 
     const record = try registry.accountFromAuth(allocator, "", &info);

--- a/src/workflows/login.zig
+++ b/src/workflows/login.zig
@@ -41,7 +41,12 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
     defer allocator.free(auth_path);
     const original_auth = try loadActiveAuthState(allocator, auth_path);
     defer if (original_auth) |data| allocator.free(data);
-    errdefer restoreActiveAuthState(auth_path, original_auth) catch {};
+    errdefer |login_err| restoreActiveAuthState(auth_path, original_auth) catch |restore_err| {
+        std.log.err(
+            "failed to restore auth.json after login failure ({s}): {s}",
+            .{ @errorName(login_err), @errorName(restore_err) },
+        );
+    };
 
     try registry.ensureAccountsDir(allocator, codex_home);
     try cli.login.runCodexLogin(opts, codex_home);

--- a/src/workflows/login.zig
+++ b/src/workflows/login.zig
@@ -9,11 +9,25 @@ const app_runtime = @import("../core/runtime.zig");
 const defaultAccountFetcher = account_names.defaultAccountFetcher;
 const refreshAccountNamesAfterLogin = account_names.refreshAccountNamesAfterLogin;
 
-fn loginScratchCodexHomeAlloc(allocator: std.mem.Allocator, codex_home: []const u8) ![]u8 {
-    const stamp = std.Io.Timestamp.now(app_runtime.io(), .real).toMilliseconds();
-    const name = try std.fmt.allocPrint(allocator, "login-{d}", .{stamp});
-    defer allocator.free(name);
-    return try std.fs.path.join(allocator, &[_][]const u8{ codex_home, "accounts", name });
+fn loadActiveAuthState(allocator: std.mem.Allocator, auth_path: []const u8) !?[]u8 {
+    const file = std.Io.Dir.cwd().openFile(app_runtime.io(), auth_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer file.close(app_runtime.io());
+
+    return try registry.readFileAlloc(file, allocator, 10 * 1024 * 1024);
+}
+
+fn restoreActiveAuthState(auth_path: []const u8, state: ?[]const u8) !void {
+    if (state) |data| {
+        try registry.writeFile(auth_path, data);
+    } else {
+        std.Io.Dir.cwd().deleteFile(app_runtime.io(), auth_path) catch |err| switch (err) {
+            error.FileNotFound => {},
+            else => return err,
+        };
+    }
 }
 
 pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.types.LoginOptions) !void {
@@ -23,19 +37,15 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
         _ = try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg);
     }
 
-    try registry.ensureAccountsDir(allocator, codex_home);
-    const login_codex_home = try loginScratchCodexHomeAlloc(allocator, codex_home);
-    defer allocator.free(login_codex_home);
-    defer std.Io.Dir.cwd().deleteTree(app_runtime.io(), login_codex_home) catch {};
-    try registry.ensurePrivateDir(login_codex_home);
-
-    try cli.login.runCodexLogin(opts, login_codex_home);
-    const login_auth_path = try registry.activeAuthPath(allocator, login_codex_home);
-    defer allocator.free(login_auth_path);
-
     const auth_path = try registry.activeAuthPath(allocator, codex_home);
     defer allocator.free(auth_path);
-    try registry.copyManagedFile(login_auth_path, auth_path);
+    const original_auth = try loadActiveAuthState(allocator, auth_path);
+    defer if (original_auth) |data| allocator.free(data);
+    var keep_updated_auth = false;
+    errdefer if (!keep_updated_auth) restoreActiveAuthState(auth_path, original_auth) catch {};
+
+    try registry.ensureAccountsDir(allocator, codex_home);
+    try cli.login.runCodexLogin(opts, codex_home);
 
     const info = try auth.parseAuthInfo(allocator, auth_path);
     defer info.deinit(allocator);
@@ -50,13 +60,13 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
         const dest = try registry.accountAuthPath(allocator, codex_home, record_key);
         defer allocator.free(dest);
 
-        try registry.ensureAccountsDir(allocator, codex_home);
         try registry.copyManagedFile(auth_path, dest);
 
         const record = try registry.accountFromApiKeyMe(allocator, "", &info, &me);
         try registry.upsertAccount(allocator, &reg, record);
         try registry.setActiveAccountKey(allocator, &reg, record_key);
         try registry.saveRegistry(allocator, codex_home, &reg);
+        keep_updated_auth = true;
         return;
     }
 
@@ -66,7 +76,6 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
     const dest = try registry.accountAuthPath(allocator, codex_home, record_key);
     defer allocator.free(dest);
 
-    try registry.ensureAccountsDir(allocator, codex_home);
     try registry.copyManagedFile(auth_path, dest);
 
     const record = try registry.accountFromAuth(allocator, "", &info);
@@ -74,4 +83,5 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
     try registry.setActiveAccountKey(allocator, &reg, record_key);
     _ = try refreshAccountNamesAfterLogin(allocator, &reg, &info, defaultAccountFetcher);
     try registry.saveRegistry(allocator, codex_home, &reg);
+    keep_updated_auth = true;
 }

--- a/src/workflows/login.zig
+++ b/src/workflows/login.zig
@@ -41,8 +41,7 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
     defer allocator.free(auth_path);
     const original_auth = try loadActiveAuthState(allocator, auth_path);
     defer if (original_auth) |data| allocator.free(data);
-    var keep_updated_auth = false;
-    errdefer if (!keep_updated_auth) restoreActiveAuthState(auth_path, original_auth) catch {};
+    errdefer restoreActiveAuthState(auth_path, original_auth) catch {};
 
     try registry.ensureAccountsDir(allocator, codex_home);
     try cli.login.runCodexLogin(opts, codex_home);
@@ -66,7 +65,6 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
         try registry.upsertAccount(allocator, &reg, record);
         try registry.setActiveAccountKey(allocator, &reg, record_key);
         try registry.saveRegistry(allocator, codex_home, &reg);
-        keep_updated_auth = true;
         return;
     }
 
@@ -83,5 +81,4 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
     try registry.setActiveAccountKey(allocator, &reg, record_key);
     _ = try refreshAccountNamesAfterLogin(allocator, &reg, &info, defaultAccountFetcher);
     try registry.saveRegistry(allocator, codex_home, &reg);
-    keep_updated_auth = true;
 }

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -164,7 +164,7 @@ fn writeSuccessfulFakeCodex(dir: fs.Dir) !void {
                 "if \"%CODEX_HOME_DIR%\"==\"\" set \"CODEX_HOME_DIR=%HOME%\\.codex\"\r\n" ++
                 "if not exist \"%CODEX_HOME_DIR%\" mkdir \"%CODEX_HOME_DIR%\"\r\n" ++
                 "copy /Y \"%HOME%\\fake-auth.json\" \"%CODEX_HOME_DIR%\\auth.json\" >NUL\r\n" ++
-                ">\"%CODEX_HOME_DIR%\\helper-state.txt\" echo installed\r\n" ++
+                "echo|set /p=\"installed\" >\"%CODEX_HOME_DIR%\\helper-state.txt\" & echo.>>\"%CODEX_HOME_DIR%\\helper-state.txt\"\r\n" ++
                 "exit /b 0\r\n"
         else
             "#!/bin/sh\n" ++

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -164,6 +164,7 @@ fn writeSuccessfulFakeCodex(dir: fs.Dir) !void {
                 "if \"%CODEX_HOME_DIR%\"==\"\" set \"CODEX_HOME_DIR=%HOME%\\.codex\"\r\n" ++
                 "if not exist \"%CODEX_HOME_DIR%\" mkdir \"%CODEX_HOME_DIR%\"\r\n" ++
                 "copy /Y \"%HOME%\\fake-auth.json\" \"%CODEX_HOME_DIR%\\auth.json\" >NUL\r\n" ++
+                ">\"%CODEX_HOME_DIR%\\helper-state.txt\" echo installed\r\n" ++
                 "exit /b 0\r\n"
         else
             "#!/bin/sh\n" ++
@@ -172,6 +173,7 @@ fn writeSuccessfulFakeCodex(dir: fs.Dir) !void {
                 "CODEX_HOME_DIR=\"${CODEX_HOME:-$HOME/.codex}\"\n" ++
                 "mkdir -p \"$CODEX_HOME_DIR\"\n" ++
                 "cp \"$HOME/fake-auth.json\" \"$CODEX_HOME_DIR/auth.json\"\n" ++
+                "printf 'installed\\n' > \"$CODEX_HOME_DIR/helper-state.txt\"\n" ++
                 "exit 0\n";
     const sub_path = fakeCodexCommandPath();
     try dir.writeFile(.{ .sub_path = sub_path, .data = script });
@@ -792,9 +794,7 @@ test "Scenario: Given device auth login when running login then it forwards the 
     const fake_codex_home_data = try fixtures.readFileAlloc(gpa, fake_codex_home_path);
     defer gpa.free(fake_codex_home_data);
     const fake_codex_home = std.mem.trim(u8, fake_codex_home_data, " \r\n");
-    try std.testing.expect(!std.mem.eql(u8, fake_codex_home, codex_home));
-    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "login-") != null);
-    try std.testing.expectError(error.FileNotFound, fs.cwd().access(fake_codex_home, .{}));
+    try std.testing.expectEqualStrings(codex_home, fake_codex_home);
 
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
@@ -817,9 +817,15 @@ test "Scenario: Given device auth login when running login then it forwards the 
     const active_auth = try fixtures.readFileAlloc(gpa, active_auth_path);
     defer gpa.free(active_auth);
     try std.testing.expectEqualStrings(fake_auth, active_auth);
+
+    const helper_state_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "helper-state.txt" });
+    defer gpa.free(helper_state_path);
+    const helper_state = try fixtures.readFileAlloc(gpa, helper_state_path);
+    defer gpa.free(helper_state);
+    try std.testing.expectEqualStrings("installed\n", helper_state);
 }
 
-test "Scenario: Given strict codex login when running login then scratch CODEX_HOME exists before launch" {
+test "Scenario: Given strict codex login when running login then the real CODEX_HOME exists before launch" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);
     defer gpa.free(project_root);
@@ -864,9 +870,7 @@ test "Scenario: Given strict codex login when running login then scratch CODEX_H
     const fake_codex_home_data = try fixtures.readFileAlloc(gpa, fake_codex_home_path);
     defer gpa.free(fake_codex_home_data);
     const fake_codex_home = std.mem.trim(u8, fake_codex_home_data, " \r\n");
-    try std.testing.expect(!std.mem.eql(u8, fake_codex_home, codex_home));
-    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "login-") != null);
-    try std.testing.expectError(error.FileNotFound, fs.cwd().access(fake_codex_home, .{}));
+    try std.testing.expectEqualStrings(codex_home, fake_codex_home);
 
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
@@ -989,8 +993,7 @@ test "Scenario: Given CODEX_HOME override when running login then it stores auth
     const fake_codex_home_data = try fixtures.readFileAlloc(gpa, fake_codex_home_path);
     defer gpa.free(fake_codex_home_data);
     const fake_codex_home = std.mem.trim(u8, fake_codex_home_data, " \r\n");
-    try std.testing.expect(!std.mem.eql(u8, fake_codex_home, custom_codex_home));
-    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "login-") != null);
+    try std.testing.expectEqualStrings(custom_codex_home, fake_codex_home);
 
     const default_auth_path = try authJsonPathAlloc(gpa, home_root);
     defer gpa.free(default_auth_path);


### PR DESCRIPTION
When I run `codex-auth login` on NixOS, I get:

```
WARNING: proceeding, even though we could not update PATH: Refusing to create helper binaries under temporary dir "/tmp" (codex_home: AbsolutePathBuf("/tmp/codex-auth-login-1780261072421214056-0"))
```

This PR is entirely generated by Codex, which also checked that these changes resolve the problem.