### PR TITLE
feat: add previous account switch

### DIFF
--- a/docs/brainstorm/2026-05-31-previous-account-switch-design.md
+++ b/docs/brainstorm/2026-05-31-previous-account-switch-design.md
@@ -1,0 +1,147 @@
+# Previous Account Switch Design
+
+## Goal
+
+Add a `cd -` style shortcut for returning to the previous active account.
+
+The shortcut must support both:
+
+```shell
+codex-auth -
+codex-auth switch -
+```
+
+Both commands must have the same behavior.
+
+## User-Facing Behavior
+
+`codex-auth -` and `codex-auth switch -` switch to the previous active account. On success, output stays consistent with the existing switch command:
+
+```text
+Switched to <label>
+```
+
+If there is no previous active account, the command fails with:
+
+```text
+error: no previous account to switch to.
+```
+
+If the recorded previous account no longer exists, the command fails with:
+
+```text
+error: previous account is no longer available.
+```
+
+No hint line is needed for these errors.
+
+`codex-auth switch - --api`, `codex-auth switch - --skip-api`, and `codex-auth switch - --live` keep the same usage-error style as query mode. Help and usage text should list `switch -` explicitly so the syntax is visible.
+
+## State Model
+
+Add a top-level field to `registry.json`:
+
+```json
+"previous_active_account_key": "..."
+```
+
+The in-memory registry gets a matching nullable field:
+
+```zig
+previous_active_account_key: ?[]u8
+```
+
+When loading an older registry without this field, treat it as `null`.
+
+## Update Rules
+
+Account activation should remain centralized in the registry layer.
+
+When the active account changes from A to B:
+
+```text
+previous_active_account_key = A
+active_account_key = B
+```
+
+This applies to successful switch paths and other existing paths that call the shared active-account setter.
+
+If there is no current active account, setting an active account does not create a previous account.
+
+If the target account is already active, keep the current behavior: the command succeeds and prints the standard switch success message, but the previous account is not changed.
+
+## Previous Switch Flow
+
+The previous-account switch should:
+
+1. Load and sync the registry the same way query switch does.
+2. Read `previous_active_account_key`.
+3. Fail if it is missing.
+4. Fail if it does not point to an account in the registry.
+5. Reuse the normal account activation path for the target previous account.
+6. Save the registry and print the normal switched-account message.
+
+Because normal activation updates the previous field, successful previous switches naturally alternate between two accounts.
+
+## Remove Behavior
+
+Removing an account must not leave `previous_active_account_key` pointing to a deleted account.
+
+Rules:
+
+- If the removed account is the recorded previous account, clear `previous_active_account_key`.
+- If the removed account is the active account and the existing remove flow automatically selects a replacement active account, keep the existing previous account if it still exists.
+- Do not record the deleted active account as previous during automatic replacement.
+- If neither the active nor previous account is removed, leave previous unchanged.
+
+The automatic active-account replacement after removal is treated as cleanup, not as a user-initiated switch.
+
+## Parsing And Help
+
+Top-level parsing should recognize:
+
+```shell
+codex-auth -
+```
+
+as the same command as:
+
+```shell
+codex-auth switch -
+```
+
+Switch parsing should treat a lone `-` as previous-account mode, not as a normal query selector. `switch -` with API or live flags should keep the existing query-mode usage error pattern.
+
+Help should show:
+
+```text
+codex-auth -
+codex-auth switch -
+```
+
+The switch command documentation should explain that `-` returns to the previous active account.
+
+## Testing
+
+Add focused tests for:
+
+- parsing `codex-auth -`;
+- parsing `codex-auth switch -`;
+- rejecting `switch -` combined with `--api`, `--skip-api`, or `--live`;
+- loading old registry data without `previous_active_account_key`;
+- writing the new registry field;
+- updating previous when active changes from A to B;
+- preserving previous on same-account activation;
+- switching back and forth with `switch -`;
+- failing when no previous account exists;
+- failing when the previous account no longer exists;
+- clearing previous when the previous account is removed;
+- preserving previous when active is removed and a replacement active account is selected.
+
+After changing Zig files, run:
+
+```shell
+zig build run -- list
+```
+
+Broader tests should cover the parser, registry behavior, and CLI integration paths touched by this change.

--- a/docs/commands/switch.md
+++ b/docs/commands/switch.md
@@ -3,10 +3,20 @@
 ## Usage
 
 ```shell
+codex-auth switch -
 codex-auth switch [--api|--skip-api]
 codex-auth switch --live [--api|--skip-api]
 codex-auth switch <query>
 ```
+
+## Previous Switch
+
+`codex-auth switch -` switches to the previous active account.
+
+- `codex-auth -` is a shortcut for the same behavior.
+- The command fails when no previous account has been recorded.
+- The command fails when the recorded previous account was removed.
+- `switch -` does not accept `--live`, `--api`, or `--skip-api`.
 
 ## Interactive Switch
 
@@ -46,4 +56,5 @@ When switching succeeds:
 1. `auth.json` is backed up when its contents would change.
 2. The selected account snapshot is copied to `~/.codex/auth.json`.
 3. `active_account_key` is updated in `registry.json`.
-4. The success message uses the same identity label as singleton rows, for example `Switched to me(test@example.com)`.
+4. `previous_active_account_key` records the account that was active before the switch, when one exists.
+5. The success message uses the same identity label as singleton rows, for example `Switched to me(test@example.com)`.

--- a/docs/implement.md
+++ b/docs/implement.md
@@ -33,10 +33,10 @@ Managed files:
 
 - `registry.json.schema_version` is the on-disk migration gate.
 - `version = 2` registries using `active_email` and email-keyed snapshots are migrated to the current schema.
-- Current-layout files that still use the top-level `version = 3` key are rewritten to `schema_version = 4`.
+- Current-layout files that still use the top-level `version = 3` key are rewritten to the current schema.
 - Loading a supported older schema performs the migration in memory and rewrites `registry.json` in the current format.
 - Loading a newer `schema_version` is rejected with `UnsupportedRegistryVersion`.
-- Saving always rewrites `registry.json` into the current schema `4` field set.
+- Saving always rewrites `registry.json` into the current schema field set.
 
 See [docs/schema-migration.md](./schema-migration.md) for versioning policy and migration rules.
 

--- a/docs/schema-migration.md
+++ b/docs/schema-migration.md
@@ -21,6 +21,7 @@ This document defines how `codex-auth` versions the on-disk `~/.codex/accounts/r
 - User-visible behavior is always “upgrade directly to the latest supported schema”.
 - Internally, migrations are implemented as a chain of `Vn -> Vn+1` steps.
 - In the current code, supported automatic migration is `version = 2 -> schema_version = 4`; older current-layout schema `3` files are rewritten once as schema `4`.
+- Current-layout schema `4` files are also rewritten once when they are missing normalized current fields such as `previous_active_account_key`.
 - Users are not expected to install intermediate `codex-auth` versions.
 
 ## Released Schemas
@@ -41,6 +42,7 @@ This document defines how `codex-auth` versions the on-disk `~/.codex/accounts/r
   - Same account layout as schema `3`
   - Live refresh interval stored as top-level `interval_seconds`
   - Older `live.interval_seconds` and removed `auto_switch` blocks are omitted on rewrite
+  - Adds top-level `previous_active_account_key` for `codex-auth -` and `codex-auth switch -`
 
 ## When To Bump `schema_version`
 

--- a/src/cli/commands/root.zig
+++ b/src/cli/commands/root.zig
@@ -39,6 +39,15 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !type
         return .{ .command = .{ .version = {} } };
     }
 
+    if (std.mem.eql(u8, cmd, "-")) {
+        if (args.len > 2) {
+            return common.usageErrorResult(allocator, .top_level, "unexpected argument after `-`: `{s}`.", .{
+                std.mem.sliceTo(args[2], 0),
+            });
+        }
+        return .{ .command = .{ .switch_account = .{ .target = .previous } } };
+    }
+
     if (std.mem.eql(u8, cmd, "list")) return list.parse(allocator, args[2..]);
     if (std.mem.eql(u8, cmd, "login")) return login.parse(allocator, args[2..]);
     if (std.mem.eql(u8, cmd, "import")) return import_auth.parse(allocator, args[2..]);
@@ -67,8 +76,9 @@ fn freeCommand(allocator: std.mem.Allocator, cmd: *types.Command) void {
         .export_auth => |opts| {
             if (opts.dest_path) |path| allocator.free(path);
         },
-        .switch_account => |opts| {
-            if (opts.query) |query| allocator.free(query);
+        .switch_account => |opts| switch (opts.target) {
+            .query => |query| allocator.free(query),
+            else => {},
         },
         .remove_account => |opts| {
             common.freeOwnedStringList(allocator, opts.selectors);

--- a/src/cli/commands/switch.zig
+++ b/src/cli/commands/switch.zig
@@ -7,12 +7,12 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.Pa
         return .{ .command = .{ .help = .switch_account } };
     }
 
-    var opts: types.SwitchOptions = .{ .query = null };
+    var opts: types.SwitchOptions = .{};
     for (args) |raw_arg| {
         const arg = std.mem.sliceTo(raw_arg, 0);
         if (std.mem.eql(u8, arg, "--live")) {
             if (opts.live) {
-                if (opts.query) |query| allocator.free(query);
+                freeTarget(allocator, opts.target);
                 return common.usageErrorResult(allocator, .switch_account, "duplicate `--live` for `switch`.", .{});
             }
             opts.live = true;
@@ -22,11 +22,11 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.Pa
             switch (opts.api_mode) {
                 .default => opts.api_mode = .force_api,
                 .force_api => {
-                    if (opts.query) |query| allocator.free(query);
+                    freeTarget(allocator, opts.target);
                     return common.usageErrorResult(allocator, .switch_account, "duplicate `--api` for `switch`.", .{});
                 },
                 .skip_api => {
-                    if (opts.query) |query| allocator.free(query);
+                    freeTarget(allocator, opts.target);
                     return common.usageErrorResult(allocator, .switch_account, "`--api` cannot be combined with `--skip-api` for `switch`.", .{});
                 },
             }
@@ -36,34 +36,44 @@ pub fn parse(allocator: std.mem.Allocator, args: []const [:0]const u8) !types.Pa
             switch (opts.api_mode) {
                 .default => opts.api_mode = .skip_api,
                 .skip_api => {
-                    if (opts.query) |query| allocator.free(query);
+                    freeTarget(allocator, opts.target);
                     return common.usageErrorResult(allocator, .switch_account, "duplicate `--skip-api` for `switch`.", .{});
                 },
                 .force_api => {
-                    if (opts.query) |query| allocator.free(query);
+                    freeTarget(allocator, opts.target);
                     return common.usageErrorResult(allocator, .switch_account, "`--skip-api` cannot be combined with `--api` for `switch`.", .{});
                 },
             }
             continue;
         }
-        if (std.mem.startsWith(u8, arg, "-")) {
-            if (opts.query) |query| allocator.free(query);
+        if (std.mem.startsWith(u8, arg, "-") and !std.mem.eql(u8, arg, "-")) {
+            freeTarget(allocator, opts.target);
             return common.usageErrorResult(allocator, .switch_account, "unknown flag `{s}` for `switch`.", .{arg});
         }
-        if (opts.query != null) {
-            if (opts.query) |query| allocator.free(query);
+        if (opts.target != .picker) {
+            freeTarget(allocator, opts.target);
             return common.usageErrorResult(allocator, .switch_account, "unexpected extra query `{s}` for `switch`.", .{arg});
         }
-        opts.query = try allocator.dupe(u8, arg);
+        opts.target = if (std.mem.eql(u8, arg, "-"))
+            .previous
+        else
+            .{ .query = try allocator.dupe(u8, arg) };
     }
-    if (opts.query != null and (opts.api_mode != .default or opts.live)) {
-        if (opts.query) |query| allocator.free(query);
+    if (opts.target != .picker and (opts.api_mode != .default or opts.live)) {
+        freeTarget(allocator, opts.target);
         return common.usageErrorResult(
             allocator,
             .switch_account,
-            "`switch <alias|email|display-number|query>` does not support `--live`, `--api`, or `--skip-api`.",
+            "`switch -|<alias|email|display-number|query>` does not support `--live`, `--api`, or `--skip-api`.",
             .{},
         );
     }
     return .{ .command = .{ .switch_account = opts } };
+}
+
+fn freeTarget(allocator: std.mem.Allocator, target: types.SwitchTarget) void {
+    switch (target) {
+        .query => |query| allocator.free(query),
+        else => {},
+    }
 }

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -36,6 +36,7 @@ pub fn writeHelp(
     try writeCommandSummary(out, use_color, "--help, -h", "Show this help");
     try writeCommandSummary(out, use_color, "help <command>", "Show command-specific help");
     try writeCommandSummary(out, use_color, "--version, -V", "Show version");
+    try writeCommandSummary(out, use_color, "-", "Switch to the previous active account");
     try writeCommandSummary(out, use_color, "list [--live] [--active] [--api|--skip-api]", "List available accounts");
     try writeCommandSummary(out, use_color, "login [--device-auth]", "Login and add the current account");
     try writeCommandSummary(out, use_color, "import", "Import auth files or rebuild registry");
@@ -44,6 +45,7 @@ pub fn writeHelp(
     try writeCommandDetail(out, use_color, "import --purge [<path>]");
     try writeCommandSummary(out, use_color, "export [<dir>] [--cpa]", "Export stored account auth files");
     try writeCommandSummary(out, use_color, "switch", "Switch the active account");
+    try writeCommandDetail(out, use_color, "switch -");
     try writeCommandDetail(out, use_color, "switch [--live] [--api|--skip-api]");
     try writeCommandDetail(out, use_color, "switch <alias|email|display-number|query>");
     try writeCommandSummary(out, use_color, "remove", "Remove one or more accounts");
@@ -187,6 +189,7 @@ fn writeUsageLines(out: *std.Io.Writer, topic: HelpTopic) !void {
     switch (topic) {
         .top_level => {
             try out.writeAll("  codex-auth <command>\n");
+            try out.writeAll("  codex-auth -\n");
             try out.writeAll("  codex-auth --help\n");
             try out.writeAll("  codex-auth help <command>\n");
         },
@@ -205,6 +208,7 @@ fn writeUsageLines(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  codex-auth export --cpa [<dir>]\n");
         },
         .switch_account => {
+            try out.writeAll("  codex-auth switch -\n");
             try out.writeAll("  codex-auth switch [--live] [--api|--skip-api]\n");
             try out.writeAll("  codex-auth switch <alias|email|display-number|query>\n");
         },
@@ -279,6 +283,7 @@ fn writeOptionLines(out: *std.Io.Writer, topic: HelpTopic) !void {
             try out.writeAll("  --skip-api   Load usage and account data from local data only (may be inaccurate).\n");
             try out.writeAll("  <alias|email|display-number|query>\n");
             try out.writeAll("               Switch directly when the target resolves to one account.\n");
+            try out.writeAll("  -            Switch to the previous active account.\n");
         },
         .remove_account => {
             try out.writeAll("  --live       Open the live remove UI.\n");
@@ -348,6 +353,7 @@ fn writeExampleLines(out: *std.Io.Writer, topic: HelpTopic) !void {
         },
         .switch_account => {
             try out.writeAll("  codex-auth switch\n");
+            try out.writeAll("  codex-auth switch -\n");
             try out.writeAll("  codex-auth switch --live\n");
             try out.writeAll("  codex-auth switch --api\n");
             try out.writeAll("  codex-auth switch --skip-api\n");
@@ -391,7 +397,7 @@ fn writeNotesSectionStyled(out: *std.Io.Writer, use_color: bool, topic: HelpTopi
     try out.writeAll("\n");
     switch (topic) {
         .switch_account => {
-            try out.writeAll("  Targets can be aliases, emails, display numbers, or partial queries.\n");
+            try out.writeAll("  Targets can be `-`, aliases, emails, display numbers, or partial queries.\n");
         },
         .alias => {
             try out.writeAll("  Alias targets can be aliases, emails, display numbers, or partial queries.\n");

--- a/src/cli/output.zig
+++ b/src/cli/output.zig
@@ -184,6 +184,26 @@ pub fn printSwitchAccountNotFoundError(query: []const u8) !void {
     try out.flush();
 }
 
+pub fn printNoPreviousAccountError() !void {
+    var stderr: io_util.Stderr = undefined;
+    stderr.init();
+    const out = stderr.out();
+    const use_color = stderr.color_enabled;
+    try writeErrorPrefixTo(out, use_color);
+    try out.writeAll(" no previous account to switch to.\n");
+    try out.flush();
+}
+
+pub fn printPreviousAccountUnavailableError() !void {
+    var stderr: io_util.Stderr = undefined;
+    stderr.init();
+    const out = stderr.out();
+    const use_color = stderr.color_enabled;
+    try writeErrorPrefixTo(out, use_color);
+    try out.writeAll(" previous account is no longer available.\n");
+    try out.flush();
+}
+
 pub fn printAliasAccountNotFoundError(query: []const u8) !void {
     var stderr: io_util.Stderr = undefined;
     stderr.init();

--- a/src/cli/types.zig
+++ b/src/cli/types.zig
@@ -24,8 +24,13 @@ pub const ExportOptions = struct {
     dest_path: ?[]u8,
     format: ExportFormat,
 };
+pub const SwitchTarget = union(enum) {
+    picker,
+    query: []u8,
+    previous,
+};
 pub const SwitchOptions = struct {
-    query: ?[]u8,
+    target: SwitchTarget = .picker,
     live: bool = false,
     api_mode: ApiMode = .default,
 };

--- a/src/registry/account_ops.zig
+++ b/src/registry/account_ops.zig
@@ -167,7 +167,7 @@ pub fn syncActiveAccountFromAuthWithImporter(allocator: std.mem.Allocator, codex
         errdefer if (record_owned) freeAccountRecord(allocator, &record);
         try upsertAccount(allocator, reg, record);
         record_owned = false;
-        try setActiveAccountKey(allocator, reg, record_key);
+        try setActiveAccountKeyPreservingPrevious(allocator, reg, record_key);
         return true;
     }
 
@@ -204,7 +204,7 @@ pub fn syncActiveAccountFromAuthWithImporter(allocator: std.mem.Allocator, codex
         try hardenSensitiveFile(dest);
     }
 
-    try setActiveAccountKey(allocator, reg, rec_account_key);
+    try setActiveAccountKeyPreservingPrevious(allocator, reg, rec_account_key);
     return changed;
 }
 
@@ -245,7 +245,7 @@ fn syncActiveApiKeyAccountFromAuth(
         errdefer if (record_owned) freeAccountRecord(allocator, &record);
         try upsertAccount(allocator, reg, record);
         record_owned = false;
-        try setActiveAccountKey(allocator, reg, record_key);
+        try setActiveAccountKeyPreservingPrevious(allocator, reg, record_key);
         return true;
     }
 
@@ -285,7 +285,7 @@ fn syncActiveApiKeyAccountFromAuth(
         try hardenSensitiveFile(dest);
     }
 
-    try setActiveAccountKey(allocator, reg, rec_account_key);
+    try setActiveAccountKeyPreservingPrevious(allocator, reg, rec_account_key);
     return changed;
 }
 

--- a/src/registry/account_ops.zig
+++ b/src/registry/account_ops.zig
@@ -52,6 +52,35 @@ pub fn setActiveAccountKey(allocator: std.mem.Allocator, reg: *Registry, account
     if (reg.active_account_key) |k| {
         if (std.mem.eql(u8, k, account_key)) return;
     }
+    const previous_active_account_key = if (reg.active_account_key) |k| blk: {
+        if (findAccountIndexByAccountKey(reg, k) == null) break :blk null;
+        break :blk try allocator.dupe(u8, k);
+    } else null;
+    errdefer if (previous_active_account_key) |k| allocator.free(k);
+    const new_active_account_key = try allocator.dupe(u8, account_key);
+    errdefer allocator.free(new_active_account_key);
+    if (reg.previous_active_account_key) |k| {
+        allocator.free(k);
+    }
+    reg.previous_active_account_key = previous_active_account_key;
+    if (reg.active_account_key) |k| {
+        allocator.free(k);
+    }
+    reg.active_account_key = new_active_account_key;
+    reg.active_account_activated_at_ms = std.Io.Timestamp.now(app_runtime.io(), .real).toMilliseconds();
+    const now = std.Io.Timestamp.now(app_runtime.io(), .real).toSeconds();
+    for (reg.accounts.items) |*rec| {
+        if (std.mem.eql(u8, rec.account_key, account_key)) {
+            rec.last_used_at = now;
+            break;
+        }
+    }
+}
+
+pub fn setActiveAccountKeyPreservingPrevious(allocator: std.mem.Allocator, reg: *Registry, account_key: []const u8) !void {
+    if (reg.active_account_key) |k| {
+        if (std.mem.eql(u8, k, account_key)) return;
+    }
     const new_active_account_key = try allocator.dupe(u8, account_key);
     if (reg.active_account_key) |k| {
         allocator.free(k);
@@ -64,6 +93,13 @@ pub fn setActiveAccountKey(allocator: std.mem.Allocator, reg: *Registry, account
             rec.last_used_at = now;
             break;
         }
+    }
+}
+
+fn clearPreviousActiveAccountKey(allocator: std.mem.Allocator, reg: *Registry) void {
+    if (reg.previous_active_account_key) |key| {
+        allocator.free(key);
+        reg.previous_active_account_key = null;
     }
 }
 
@@ -277,6 +313,19 @@ pub fn removeAccounts(allocator: std.mem.Allocator, codex_home: []const u8, reg:
             allocator.free(key);
             reg.active_account_key = null;
             reg.active_account_activated_at_ms = null;
+        }
+    }
+
+    if (reg.previous_active_account_key) |key| {
+        var previous_removed = false;
+        for (reg.accounts.items, 0..) |rec, i| {
+            if (removed[i] and std.mem.eql(u8, rec.account_key, key)) {
+                previous_removed = true;
+                break;
+            }
+        }
+        if (previous_removed) {
+            clearPreviousActiveAccountKey(allocator, reg);
         }
     }
 
@@ -503,6 +552,24 @@ pub fn replaceActiveAuthWithAccountByKey(
     try ensureAccountsDir(allocator, codex_home);
     try replaceFilePreservingPermissions(src, dest);
     try setActiveAccountKey(allocator, reg, account_key);
+}
+
+pub fn replaceActiveAuthWithAccountByKeyPreservingPrevious(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    reg: *Registry,
+    account_key: []const u8,
+) !void {
+    _ = findAccountIndexByAccountKey(reg, account_key) orelse return error.AccountNotFound;
+    const src = try resolveStrictAccountAuthPath(allocator, codex_home, account_key);
+    defer allocator.free(src);
+
+    const dest = try activeAuthPath(allocator, codex_home);
+    defer allocator.free(dest);
+
+    try ensureAccountsDir(allocator, codex_home);
+    try replaceFilePreservingPermissions(src, dest);
+    try setActiveAccountKeyPreservingPrevious(allocator, reg, account_key);
 }
 
 pub fn accountFromAuth(

--- a/src/registry/common.zig
+++ b/src/registry/common.zig
@@ -135,6 +135,7 @@ pub fn planLabel(plan: PlanType) []const u8 {
 pub const Registry = struct {
     schema_version: u32,
     active_account_key: ?[]u8,
+    previous_active_account_key: ?[]u8 = null,
     active_account_activated_at_ms: ?i64,
     api: ApiConfig,
     live: LiveConfig = defaultLiveConfig(),
@@ -145,6 +146,7 @@ pub const Registry = struct {
             freeAccountRecord(allocator, rec);
         }
         if (self.active_account_key) |k| allocator.free(k);
+        if (self.previous_active_account_key) |k| allocator.free(k);
         self.accounts.deinit(allocator);
     }
 };

--- a/src/registry/root.zig
+++ b/src/registry/root.zig
@@ -119,6 +119,7 @@ pub const exportAccounts = export_mod.exportAccounts;
 
 pub const findAccountIndexByAccountKey = account_ops.findAccountIndexByAccountKey;
 pub const setActiveAccountKey = account_ops.setActiveAccountKey;
+pub const setActiveAccountKeyPreservingPrevious = account_ops.setActiveAccountKeyPreservingPrevious;
 pub const updateUsage = account_ops.updateUsage;
 pub fn syncActiveAccountFromAuth(allocator: std.mem.Allocator, codex_home: []const u8, reg: *Registry) !bool {
     return account_ops.syncActiveAccountFromAuthWithImporter(allocator, codex_home, reg, autoImportActiveAuth);
@@ -134,6 +135,7 @@ pub const activeChatgptUserId = account_ops.activeChatgptUserId;
 pub const applyAccountNamesForUser = account_ops.applyAccountNamesForUser;
 pub const activateAccountByKey = account_ops.activateAccountByKey;
 pub const replaceActiveAuthWithAccountByKey = account_ops.replaceActiveAuthWithAccountByKey;
+pub const replaceActiveAuthWithAccountByKeyPreservingPrevious = account_ops.replaceActiveAuthWithAccountByKeyPreservingPrevious;
 pub const accountFromAuth = account_ops.accountFromAuth;
 pub const accountFromApiKeyMe = account_ops.accountFromApiKeyMe;
 pub const apiKeyAccountKeyAlloc = account_ops.apiKeyAccountKeyAlloc;

--- a/src/registry/storage.zig
+++ b/src/registry/storage.zig
@@ -75,6 +75,7 @@ pub fn defaultRegistry() Registry {
     return Registry{
         .schema_version = current_schema_version,
         .active_account_key = null,
+        .previous_active_account_key = null,
         .active_account_activated_at_ms = null,
         .api = defaultApiConfig(),
         .live = defaultLiveConfig(),
@@ -267,6 +268,12 @@ fn loadLegacyRegistryV2(
             else => {},
         }
     }
+    if (root_obj.get("previous_active_account_key")) |v| {
+        switch (v) {
+            .string => |s| reg.previous_active_account_key = try allocator.dupe(u8, s),
+            else => {},
+        }
+    }
     if (reg.active_account_key != null) {
         reg.active_account_activated_at_ms = 0;
     }
@@ -314,6 +321,12 @@ fn loadCurrentRegistry(allocator: std.mem.Allocator, root_obj: std.json.ObjectMa
     if (root_obj.get("active_account_key")) |v| {
         switch (v) {
             .string => |s| reg.active_account_key = try allocator.dupe(u8, s),
+            else => {},
+        }
+    }
+    if (root_obj.get("previous_active_account_key")) |v| {
+        switch (v) {
+            .string => |s| reg.previous_active_account_key = try allocator.dupe(u8, s),
             else => {},
         }
     }
@@ -369,6 +382,7 @@ fn currentLayoutNeedsRewrite(root_obj: std.json.ObjectMap) bool {
     } else {
         return true;
     }
+    if (root_obj.get("previous_active_account_key") == null) return true;
     return root_obj.get("active_account_key") != null and root_obj.get("active_account_activated_at_ms") == null;
 }
 

--- a/src/registry/storage_write.zig
+++ b/src/registry/storage_write.zig
@@ -23,6 +23,7 @@ pub fn saveRegistry(allocator: std.mem.Allocator, codex_home: []const u8, reg: *
     const out = RegistryOut{
         .schema_version = current_schema_version,
         .active_account_key = reg.active_account_key,
+        .previous_active_account_key = reg.previous_active_account_key,
         .active_account_activated_at_ms = reg.active_account_activated_at_ms,
         .interval_seconds = reg.live.interval_seconds,
         .accounts = reg.accounts.items,
@@ -102,6 +103,7 @@ fn writeRegistryFileAtomic(path: []const u8, data: []const u8) !void {
 const RegistryOut = struct {
     schema_version: u32,
     active_account_key: ?[]const u8,
+    previous_active_account_key: ?[]const u8,
     active_account_activated_at_ms: ?i64,
     interval_seconds: u16,
     accounts: []const AccountRecord,

--- a/src/workflows/active_auth.zig
+++ b/src/workflows/active_auth.zig
@@ -30,9 +30,9 @@ pub fn reconcileActiveAuthAfterRemove(
         const best_idx = registry.selectBestAccountIndexByUsage(reg) orelse 0;
         const account_key = reg.accounts.items[best_idx].account_key;
         if (allow_auth_file_update) {
-            try registry.replaceActiveAuthWithAccountByKey(allocator, codex_home, reg, account_key);
+            try registry.replaceActiveAuthWithAccountByKeyPreservingPrevious(allocator, codex_home, reg, account_key);
         } else {
-            try registry.setActiveAccountKey(allocator, reg, account_key);
+            try registry.setActiveAccountKeyPreservingPrevious(allocator, reg, account_key);
         }
         return;
     }

--- a/src/workflows/live_runtime.zig
+++ b/src/workflows/live_runtime.zig
@@ -373,9 +373,9 @@ pub fn removeSelectedAccountsAndPersist(
 
     if (replacement_account_key) |key| {
         if (allow_auth_file_update) {
-            try registry.replaceActiveAuthWithAccountByKey(allocator, codex_home, reg, key);
+            try registry.replaceActiveAuthWithAccountByKeyPreservingPrevious(allocator, codex_home, reg, key);
         } else {
-            try registry.setActiveAccountKey(allocator, reg, key);
+            try registry.setActiveAccountKeyPreservingPrevious(allocator, reg, key);
         }
     }
 

--- a/src/workflows/preflight.zig
+++ b/src/workflows/preflight.zig
@@ -16,6 +16,8 @@ const loadActiveAuthInfoForAccountRefresh = account_names.loadActiveAuthInfoForA
 
 pub fn isHandledCliError(err: anyerror) bool {
     return err == error.AccountNotFound or
+        err == error.NoPreviousAccount or
+        err == error.PreviousAccountUnavailable or
         err == error.CodexLoginFailed or
         err == error.ListLiveRequiresTty or
         err == error.TuiOutputUnavailable or

--- a/src/workflows/switch.zig
+++ b/src/workflows/switch.zig
@@ -176,6 +176,13 @@ fn handleSwitchPrevious(
         return error.PreviousAccountUnavailable;
     }
 
+    if (reg.active_account_key) |active_account_key| {
+        if (std.mem.eql(u8, active_account_key, previous_account_key)) {
+            try cli.output.printNoPreviousAccountError();
+            return error.NoPreviousAccount;
+        }
+    }
+
     try registry.activateAccountByKey(allocator, codex_home, &reg, previous_account_key);
     try registry.saveRegistry(allocator, codex_home, &reg);
     try cli.output.printSwitchedAccount(allocator, &reg, previous_account_key);

--- a/src/workflows/switch.zig
+++ b/src/workflows/switch.zig
@@ -23,10 +23,6 @@ pub fn handleSwitch(allocator: std.mem.Allocator, codex_home: []const u8, opts: 
         .picker => {},
     }
 
-    if (opts.target == .picker) {
-        std.debug.assert(opts.api_mode == .default or opts.api_mode == .force_api or opts.api_mode == .skip_api);
-    }
-
     {
         if (!opts.live) {
             var loaded = if (opts.api_mode == .skip_api)

--- a/src/workflows/switch.zig
+++ b/src/workflows/switch.zig
@@ -17,122 +17,170 @@ const switchLiveRuntimeBuildStatusLine = live_flow.switchLiveRuntimeBuildStatusL
 const switchLiveRuntimeApplySelection = live_flow.switchLiveRuntimeApplySelection;
 
 pub fn handleSwitch(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.types.SwitchOptions) !void {
-    if (opts.query) |query| {
-        var reg = try registry.loadRegistry(allocator, codex_home);
-        defer reg.deinit(allocator);
-        if (try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg)) {
-            try registry.saveRegistry(allocator, codex_home, &reg);
-        }
-        std.debug.assert(opts.api_mode == .default);
-        std.debug.assert(!opts.live);
+    switch (opts.target) {
+        .query => |query| return handleSwitchQuery(allocator, codex_home, opts, query),
+        .previous => return handleSwitchPrevious(allocator, codex_home, opts),
+        .picker => {},
+    }
 
-        var resolution = try resolveSwitchQueryLocally(allocator, &reg, query);
-        defer resolution.deinit(allocator);
+    if (opts.target == .picker) {
+        std.debug.assert(opts.api_mode == .default or opts.api_mode == .force_api or opts.api_mode == .skip_api);
+    }
 
-        const selected_account_key = switch (resolution) {
-            .not_found => {
-                try cli.output.printSwitchAccountNotFoundError(query);
-                return error.AccountNotFound;
-            },
-            .direct => |account_key| account_key,
-            .multiple => |matches| cli.picker.selectAccountFromIndicesWithUsageOverrides(
+    {
+        if (!opts.live) {
+            var loaded = if (opts.api_mode == .skip_api)
+                try loadStoredSwitchSelectionDisplay(
+                    allocator,
+                    codex_home,
+                    .switch_account,
+                    opts.api_mode,
+                )
+            else
+                try loadSwitchSelectionDisplay(
+                    allocator,
+                    codex_home,
+                    opts.api_mode,
+                    .switch_account,
+                    true,
+                );
+            defer loaded.display.deinit(allocator);
+            defer if (loaded.refresh_error_name) |name| allocator.free(name);
+
+            const selected_account_key = cli.picker.selectAccountWithUsageOverrides(
                 allocator,
-                &reg,
-                matches.items,
-                null,
+                &loaded.display.reg,
+                loaded.display.usage_overrides,
             ) catch |err| {
                 if (err == error.TuiRequiresTty) {
                     try cli.output.printSwitchRequiresTtyError();
                     return error.SwitchSelectionRequiresTty;
                 }
                 return err;
+            };
+            if (selected_account_key == null) return;
+            try registry.activateAccountByKey(allocator, codex_home, &loaded.display.reg, selected_account_key.?);
+            try registry.saveRegistry(allocator, codex_home, &loaded.display.reg);
+            try cli.output.printSwitchedAccount(allocator, &loaded.display.reg, selected_account_key.?);
+            return;
+        }
+
+        try ensureLiveTty(.switch_account);
+        const live_allocator = std.heap.smp_allocator;
+        const strict_refresh = opts.api_mode == .force_api;
+        const loaded = try loadInitialLiveSelectionDisplay(
+            live_allocator,
+            codex_home,
+            .switch_account,
+            opts.api_mode,
+        );
+        var initial_display: ?cli.live.OwnedSwitchSelectionDisplay = loaded.display;
+        errdefer if (initial_display) |*display| display.deinit(live_allocator);
+
+        var runtime = SwitchLiveRuntime.init(
+            live_allocator,
+            codex_home,
+            .switch_account,
+            opts.api_mode,
+            strict_refresh,
+            loaded.policy,
+            loaded.refresh_error_name,
+        );
+        defer runtime.deinit();
+
+        const controller: cli.live.SwitchLiveActionController = .{
+            .refresh = .{
+                .context = @ptrCast(&runtime),
+                .maybe_start_refresh = switchLiveRuntimeMaybeStartRefresh,
+                .maybe_take_updated_display = switchLiveRuntimeMaybeTakeUpdatedDisplay,
+                .build_status_line = switchLiveRuntimeBuildStatusLine,
             },
+            .apply_selection = switchLiveRuntimeApplySelection,
+            .auto_switch = true,
         };
-        if (selected_account_key == null) return;
-        try registry.activateAccountByKey(allocator, codex_home, &reg, selected_account_key.?);
-        try registry.saveRegistry(allocator, codex_home, &reg);
-        try cli.output.printSwitchedAccount(allocator, &reg, selected_account_key.?);
-        return;
-    }
 
-    if (!opts.live) {
-        var loaded = if (opts.api_mode == .skip_api)
-            try loadStoredSwitchSelectionDisplay(
-                allocator,
-                codex_home,
-                .switch_account,
-                opts.api_mode,
-            )
-        else
-            try loadSwitchSelectionDisplay(
-                allocator,
-                codex_home,
-                opts.api_mode,
-                .switch_account,
-                true,
-            );
-        defer loaded.display.deinit(allocator);
-        defer if (loaded.refresh_error_name) |name| allocator.free(name);
-
-        const selected_account_key = cli.picker.selectAccountWithUsageOverrides(
-            allocator,
-            &loaded.display.reg,
-            loaded.display.usage_overrides,
-        ) catch |err| {
+        const transferred_display = initial_display.?;
+        initial_display = null;
+        cli.live.runSwitchLiveActions(live_allocator, transferred_display, controller) catch |err| {
             if (err == error.TuiRequiresTty) {
                 try cli.output.printSwitchRequiresTtyError();
                 return error.SwitchSelectionRequiresTty;
             }
             return err;
         };
-        if (selected_account_key == null) return;
-        try registry.activateAccountByKey(allocator, codex_home, &loaded.display.reg, selected_account_key.?);
-        try registry.saveRegistry(allocator, codex_home, &loaded.display.reg);
-        try cli.output.printSwitchedAccount(allocator, &loaded.display.reg, selected_account_key.?);
-        return;
+    }
+}
+
+fn handleSwitchQuery(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    opts: cli.types.SwitchOptions,
+    query: []const u8,
+) !void {
+    var reg = try registry.loadRegistry(allocator, codex_home);
+    defer reg.deinit(allocator);
+    if (try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg)) {
+        try registry.saveRegistry(allocator, codex_home, &reg);
+    }
+    std.debug.assert(opts.api_mode == .default);
+    std.debug.assert(!opts.live);
+
+    var resolution = try resolveSwitchQueryLocally(allocator, &reg, query);
+    defer resolution.deinit(allocator);
+
+    const selected_account_key = switch (resolution) {
+        .not_found => {
+            try cli.output.printSwitchAccountNotFoundError(query);
+            return error.AccountNotFound;
+        },
+        .direct => |account_key| account_key,
+        .multiple => |matches| cli.picker.selectAccountFromIndicesWithUsageOverrides(
+            allocator,
+            &reg,
+            matches.items,
+            null,
+        ) catch |err| {
+            if (err == error.TuiRequiresTty) {
+                try cli.output.printSwitchRequiresTtyError();
+                return error.SwitchSelectionRequiresTty;
+            }
+            return err;
+        },
+    };
+    if (selected_account_key == null) return;
+    try registry.activateAccountByKey(allocator, codex_home, &reg, selected_account_key.?);
+    try registry.saveRegistry(allocator, codex_home, &reg);
+    try cli.output.printSwitchedAccount(allocator, &reg, selected_account_key.?);
+    return;
+}
+
+fn handleSwitchPrevious(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    opts: cli.types.SwitchOptions,
+) !void {
+    std.debug.assert(opts.api_mode == .default);
+    std.debug.assert(!opts.live);
+
+    var reg = try registry.loadRegistry(allocator, codex_home);
+    defer reg.deinit(allocator);
+    if (try registry.syncActiveAccountFromAuth(allocator, codex_home, &reg)) {
+        try registry.saveRegistry(allocator, codex_home, &reg);
     }
 
-    try ensureLiveTty(.switch_account);
-    const live_allocator = std.heap.smp_allocator;
-    const strict_refresh = opts.api_mode == .force_api;
-    const loaded = try loadInitialLiveSelectionDisplay(
-        live_allocator,
-        codex_home,
-        .switch_account,
-        opts.api_mode,
-    );
-    var initial_display: ?cli.live.OwnedSwitchSelectionDisplay = loaded.display;
-    errdefer if (initial_display) |*display| display.deinit(live_allocator);
-
-    var runtime = SwitchLiveRuntime.init(
-        live_allocator,
-        codex_home,
-        .switch_account,
-        opts.api_mode,
-        strict_refresh,
-        loaded.policy,
-        loaded.refresh_error_name,
-    );
-    defer runtime.deinit();
-
-    const controller: cli.live.SwitchLiveActionController = .{
-        .refresh = .{
-            .context = @ptrCast(&runtime),
-            .maybe_start_refresh = switchLiveRuntimeMaybeStartRefresh,
-            .maybe_take_updated_display = switchLiveRuntimeMaybeTakeUpdatedDisplay,
-            .build_status_line = switchLiveRuntimeBuildStatusLine,
-        },
-        .apply_selection = switchLiveRuntimeApplySelection,
-        .auto_switch = true,
+    const previous_account_key_value = reg.previous_active_account_key orelse {
+        try cli.output.printNoPreviousAccountError();
+        return error.NoPreviousAccount;
     };
+    const previous_account_key = try allocator.dupe(u8, previous_account_key_value);
+    defer allocator.free(previous_account_key);
 
-    const transferred_display = initial_display.?;
-    initial_display = null;
-    cli.live.runSwitchLiveActions(live_allocator, transferred_display, controller) catch |err| {
-        if (err == error.TuiRequiresTty) {
-            try cli.output.printSwitchRequiresTtyError();
-            return error.SwitchSelectionRequiresTty;
-        }
-        return err;
-    };
+    if (registry.findAccountIndexByAccountKey(&reg, previous_account_key) == null) {
+        try cli.output.printPreviousAccountUnavailableError();
+        return error.PreviousAccountUnavailable;
+    }
+
+    try registry.activateAccountByKey(allocator, codex_home, &reg, previous_account_key);
+    try registry.saveRegistry(allocator, codex_home, &reg);
+    try cli.output.printSwitchedAccount(allocator, &reg, previous_account_key);
 }

--- a/tests/cli_behavior_test.zig
+++ b/tests/cli_behavior_test.zig
@@ -833,9 +833,49 @@ test "Scenario: Given switch with positional query when parsing then non-interac
     switch (result) {
         .command => |cmd| switch (cmd) {
             .switch_account => |opts| {
-                try std.testing.expect(opts.query != null);
-                try std.testing.expect(std.mem.eql(u8, opts.query.?, "user@example.com"));
+                switch (opts.target) {
+                    .query => |query| try std.testing.expectEqualStrings("user@example.com", query),
+                    else => return error.TestExpectedEqual,
+                }
                 try std.testing.expectEqual(cli.types.ApiMode.default, opts.api_mode);
+            },
+            else => return error.TestExpectedEqual,
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "Scenario: Given top-level dash when parsing then previous switch is selected" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "-" };
+    var result = try cli.commands.parseArgs(gpa, &args);
+    defer cli.commands.freeParseResult(gpa, &result);
+
+    switch (result) {
+        .command => |cmd| switch (cmd) {
+            .switch_account => |opts| {
+                try std.testing.expectEqual(cli.types.SwitchTarget.previous, opts.target);
+                try std.testing.expectEqual(cli.types.ApiMode.default, opts.api_mode);
+                try std.testing.expect(!opts.live);
+            },
+            else => return error.TestExpectedEqual,
+        },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "Scenario: Given switch dash when parsing then previous switch is selected" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "switch", "-" };
+    var result = try cli.commands.parseArgs(gpa, &args);
+    defer cli.commands.freeParseResult(gpa, &result);
+
+    switch (result) {
+        .command => |cmd| switch (cmd) {
+            .switch_account => |opts| {
+                try std.testing.expectEqual(cli.types.SwitchTarget.previous, opts.target);
+                try std.testing.expectEqual(cli.types.ApiMode.default, opts.api_mode);
+                try std.testing.expect(!opts.live);
             },
             else => return error.TestExpectedEqual,
         },
@@ -862,7 +902,7 @@ test "Scenario: Given switch interactive with live flag when parsing then live m
         .command => |cmd| switch (cmd) {
             .switch_account => |opts| {
                 try std.testing.expect(opts.live);
-                try std.testing.expect(opts.query == null);
+                try std.testing.expectEqual(cli.types.SwitchTarget.picker, opts.target);
             },
             else => return error.TestExpectedEqual,
         },
@@ -906,7 +946,7 @@ test "Scenario: Given switch interactive with skip-api flag when parsing then sk
     switch (result) {
         .command => |cmd| switch (cmd) {
             .switch_account => |opts| {
-                try std.testing.expect(opts.query == null);
+                try std.testing.expectEqual(cli.types.SwitchTarget.picker, opts.target);
                 try std.testing.expectEqual(cli.types.ApiMode.skip_api, opts.api_mode);
             },
             else => return error.TestExpectedEqual,
@@ -924,7 +964,7 @@ test "Scenario: Given switch interactive with api flag when parsing then api mod
     switch (result) {
         .command => |cmd| switch (cmd) {
             .switch_account => |opts| {
-                try std.testing.expect(opts.query == null);
+                try std.testing.expectEqual(cli.types.SwitchTarget.picker, opts.target);
                 try std.testing.expectEqual(cli.types.ApiMode.force_api, opts.api_mode);
             },
             else => return error.TestExpectedEqual,
@@ -940,6 +980,33 @@ test "Scenario: Given switch query with api flag when parsing then usage error i
     defer cli.commands.freeParseResult(gpa, &result);
 
     try expectUsageError(result, .switch_account, "does not support");
+}
+
+test "Scenario: Given switch dash with api flag when parsing then usage error is returned" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "switch", "--api", "-" };
+    var result = try cli.commands.parseArgs(gpa, &args);
+    defer cli.commands.freeParseResult(gpa, &result);
+
+    try expectUsageError(result, .switch_account, "switch -|<alias|email|display-number|query>");
+}
+
+test "Scenario: Given switch dash with live flag when parsing then usage error is returned" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "switch", "--live", "-" };
+    var result = try cli.commands.parseArgs(gpa, &args);
+    defer cli.commands.freeParseResult(gpa, &result);
+
+    try expectUsageError(result, .switch_account, "switch -|<alias|email|display-number|query>");
+}
+
+test "Scenario: Given switch dash with skip-api flag when parsing then usage error is returned" {
+    const gpa = std.testing.allocator;
+    const args = [_][:0]const u8{ "codex-auth", "switch", "--skip-api", "-" };
+    var result = try cli.commands.parseArgs(gpa, &args);
+    defer cli.commands.freeParseResult(gpa, &result);
+
+    try expectUsageError(result, .switch_account, "switch -|<alias|email|display-number|query>");
 }
 
 test "Scenario: Given switch query with removed auto flag when parsing then usage error is returned" {

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -2059,6 +2059,75 @@ test "Scenario: Given no previous account when running dash then it fails cleanl
     try std.testing.expectEqualStrings("error: no previous account to switch to.\n", result.stderr);
 }
 
+test "Scenario: Given previous is active after remove when running dash then it fails cleanly" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+
+    try seedRegistryWithAccounts(gpa, home_root, "active@example.com", &[_]SeedAccount{
+        .{ .email = "previous@example.com", .alias = "previous" },
+        .{ .email = "active@example.com", .alias = "active" },
+    });
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+    const active_auth_path = try authJsonPathAlloc(gpa, home_root);
+    defer gpa.free(active_auth_path);
+
+    const previous_key = try fixtures.accountKeyForEmailAlloc(gpa, "previous@example.com");
+    defer gpa.free(previous_key);
+    const active_key = try fixtures.accountKeyForEmailAlloc(gpa, "active@example.com");
+    defer gpa.free(active_key);
+    const previous_snapshot_path = try registry.accountAuthPath(gpa, codex_home, previous_key);
+    defer gpa.free(previous_snapshot_path);
+    const active_snapshot_path = try registry.accountAuthPath(gpa, codex_home, active_key);
+    defer gpa.free(active_snapshot_path);
+
+    const previous_auth = try fixtures.authJsonWithEmailPlan(gpa, "previous@example.com", "plus");
+    defer gpa.free(previous_auth);
+    const active_auth = try fixtures.authJsonWithEmailPlan(gpa, "active@example.com", "pro");
+    defer gpa.free(active_auth);
+    try tmp.dir.writeFile(.{ .sub_path = ".codex/auth.json", .data = active_auth });
+    try fs.cwd().writeFile(.{ .sub_path = previous_snapshot_path, .data = previous_auth });
+    try fs.cwd().writeFile(.{ .sub_path = active_snapshot_path, .data = active_auth });
+
+    var seeded = try registry.loadRegistry(gpa, codex_home);
+    defer seeded.deinit(gpa);
+    try registry.setActiveAccountKey(gpa, &seeded, previous_key);
+    try registry.setActiveAccountKey(gpa, &seeded, active_key);
+    try registry.saveRegistry(gpa, codex_home, &seeded);
+
+    const remove_result = try runCliWithIsolatedHomeAndStdin(gpa, project_root, home_root, &[_][]const u8{ "remove", "active@" }, "");
+    defer gpa.free(remove_result.stdout);
+    defer gpa.free(remove_result.stderr);
+    try expectSuccess(remove_result);
+
+    const dash_result = try runCliWithIsolatedHome(gpa, project_root, home_root, &[_][]const u8{"-"});
+    defer gpa.free(dash_result.stdout);
+    defer gpa.free(dash_result.stderr);
+    try expectFailure(dash_result);
+    try std.testing.expectEqualStrings("", dash_result.stdout);
+    try std.testing.expectEqualStrings("error: no previous account to switch to.\n", dash_result.stderr);
+
+    const active_auth_after = try fixtures.readFileAlloc(gpa, active_auth_path);
+    defer gpa.free(active_auth_after);
+    try std.testing.expectEqualStrings(previous_auth, active_auth_after);
+
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expect(loaded.active_account_key != null);
+    try std.testing.expect(loaded.previous_active_account_key != null);
+    try std.testing.expectEqualStrings(previous_key, loaded.active_account_key.?);
+    try std.testing.expectEqualStrings(previous_key, loaded.previous_active_account_key.?);
+}
+
 test "Scenario: Given missing previous account when running switch dash then it fails cleanly" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -1927,7 +1927,173 @@ test "Scenario: Given switch query with a direct local match when running switch
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
     try std.testing.expect(loaded.active_account_key != null);
+    try std.testing.expect(loaded.previous_active_account_key != null);
     try std.testing.expect(std.mem.eql(u8, loaded.active_account_key.?, backup_key));
+    try std.testing.expect(std.mem.eql(u8, loaded.previous_active_account_key.?, active_key));
+}
+
+test "Scenario: Given previous account exists when running top-level dash then it switches back and forth" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+
+    try seedRegistryWithAccounts(gpa, home_root, "active@example.com", &[_]SeedAccount{
+        .{ .email = "active@example.com", .alias = "active" },
+        .{ .email = "backup@example.com", .alias = "backup" },
+    });
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+    const active_auth_path = try authJsonPathAlloc(gpa, home_root);
+    defer gpa.free(active_auth_path);
+
+    const active_key = try fixtures.accountKeyForEmailAlloc(gpa, "active@example.com");
+    defer gpa.free(active_key);
+    const backup_key = try fixtures.accountKeyForEmailAlloc(gpa, "backup@example.com");
+    defer gpa.free(backup_key);
+    const active_snapshot_path = try registry.accountAuthPath(gpa, codex_home, active_key);
+    defer gpa.free(active_snapshot_path);
+    const backup_snapshot_path = try registry.accountAuthPath(gpa, codex_home, backup_key);
+    defer gpa.free(backup_snapshot_path);
+
+    const active_auth = try fixtures.authJsonWithEmailPlan(gpa, "active@example.com", "team");
+    defer gpa.free(active_auth);
+    const backup_auth = try fixtures.authJsonWithEmailPlan(gpa, "backup@example.com", "plus");
+    defer gpa.free(backup_auth);
+
+    try tmp.dir.writeFile(.{ .sub_path = ".codex/auth.json", .data = active_auth });
+    try fs.cwd().writeFile(.{ .sub_path = active_snapshot_path, .data = active_auth });
+    try fs.cwd().writeFile(.{ .sub_path = backup_snapshot_path, .data = backup_auth });
+
+    try tmp.dir.makePath("empty-bin");
+    const empty_path = try tmp.dir.realpathAlloc(gpa, "empty-bin");
+    defer gpa.free(empty_path);
+
+    const switch_result = try runCliWithIsolatedHomeAndPath(
+        gpa,
+        project_root,
+        home_root,
+        empty_path,
+        &[_][]const u8{ "switch", "backup@" },
+    );
+    defer gpa.free(switch_result.stdout);
+    defer gpa.free(switch_result.stderr);
+    try expectSuccess(switch_result);
+
+    const dash_result = try runCliWithIsolatedHomeAndPath(
+        gpa,
+        project_root,
+        home_root,
+        empty_path,
+        &[_][]const u8{"-"},
+    );
+    defer gpa.free(dash_result.stdout);
+    defer gpa.free(dash_result.stderr);
+    try expectSuccess(dash_result);
+    try std.testing.expectEqualStrings("Switched to active(active@example.com)\n", dash_result.stdout);
+    try std.testing.expectEqualStrings("", dash_result.stderr);
+
+    const auth_after_dash = try fixtures.readFileAlloc(gpa, active_auth_path);
+    defer gpa.free(auth_after_dash);
+    try std.testing.expectEqualStrings(active_auth, auth_after_dash);
+
+    var loaded_after_dash = try registry.loadRegistry(gpa, codex_home);
+    defer loaded_after_dash.deinit(gpa);
+    try std.testing.expect(loaded_after_dash.active_account_key != null);
+    try std.testing.expect(loaded_after_dash.previous_active_account_key != null);
+    try std.testing.expectEqualStrings(active_key, loaded_after_dash.active_account_key.?);
+    try std.testing.expectEqualStrings(backup_key, loaded_after_dash.previous_active_account_key.?);
+
+    const switch_dash_result = try runCliWithIsolatedHomeAndPath(
+        gpa,
+        project_root,
+        home_root,
+        empty_path,
+        &[_][]const u8{ "switch", "-" },
+    );
+    defer gpa.free(switch_dash_result.stdout);
+    defer gpa.free(switch_dash_result.stderr);
+    try expectSuccess(switch_dash_result);
+    try std.testing.expectEqualStrings("Switched to backup(backup@example.com)\n", switch_dash_result.stdout);
+    try std.testing.expectEqualStrings("", switch_dash_result.stderr);
+
+    const auth_after_switch_dash = try fixtures.readFileAlloc(gpa, active_auth_path);
+    defer gpa.free(auth_after_switch_dash);
+    try std.testing.expectEqualStrings(backup_auth, auth_after_switch_dash);
+}
+
+test "Scenario: Given no previous account when running dash then it fails cleanly" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+
+    try seedRegistryWithAccounts(gpa, home_root, "active@example.com", &[_]SeedAccount{
+        .{ .email = "active@example.com", .alias = "active" },
+    });
+
+    const result = try runCliWithIsolatedHome(
+        gpa,
+        project_root,
+        home_root,
+        &[_][]const u8{"-"},
+    );
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectFailure(result);
+    try std.testing.expectEqualStrings("", result.stdout);
+    try std.testing.expectEqualStrings("error: no previous account to switch to.\n", result.stderr);
+}
+
+test "Scenario: Given missing previous account when running switch dash then it fails cleanly" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+
+    try seedRegistryWithAccounts(gpa, home_root, "active@example.com", &[_]SeedAccount{
+        .{ .email = "active@example.com", .alias = "active" },
+    });
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+    var reg = try registry.loadRegistry(gpa, codex_home);
+    defer reg.deinit(gpa);
+    reg.previous_active_account_key = try fixtures.accountKeyForEmailAlloc(gpa, "removed@example.com");
+    try registry.saveRegistry(gpa, codex_home, &reg);
+
+    const result = try runCliWithIsolatedHome(
+        gpa,
+        project_root,
+        home_root,
+        &[_][]const u8{ "switch", "-" },
+    );
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectFailure(result);
+    try std.testing.expectEqualStrings("", result.stdout);
+    try std.testing.expectEqualStrings("error: previous account is no longer available.\n", result.stderr);
 }
 
 test "Scenario: Given alias set with a direct local match when running alias then registry alias is updated" {
@@ -2847,6 +3013,81 @@ test "Scenario: Given active account removal with a replacement when running rem
     try std.testing.expectEqualStrings(backup_auth, replaced_auth);
     try std.testing.expectError(error.FileNotFound, fs.cwd().openFile(active_snapshot_path, .{}));
     try std.testing.expectEqual(@as(usize, 0), try countAuthBackups(tmp.dir, ".codex/accounts"));
+}
+
+test "Scenario: Given active account removal with a replacement when running remove then previous account is preserved" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+
+    try seedRegistryWithAccounts(gpa, home_root, "active@example.com", &[_]SeedAccount{
+        .{ .email = "previous@example.com", .alias = "previous" },
+        .{ .email = "active@example.com", .alias = "active" },
+        .{ .email = "backup@example.com", .alias = "backup" },
+    });
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+    const active_auth_path = try authJsonPathAlloc(gpa, home_root);
+    defer gpa.free(active_auth_path);
+
+    const previous_key = try fixtures.accountKeyForEmailAlloc(gpa, "previous@example.com");
+    defer gpa.free(previous_key);
+    const active_key = try fixtures.accountKeyForEmailAlloc(gpa, "active@example.com");
+    defer gpa.free(active_key);
+    const backup_key = try fixtures.accountKeyForEmailAlloc(gpa, "backup@example.com");
+    defer gpa.free(backup_key);
+
+    const previous_snapshot_path = try registry.accountAuthPath(gpa, codex_home, previous_key);
+    defer gpa.free(previous_snapshot_path);
+    const active_snapshot_path = try registry.accountAuthPath(gpa, codex_home, active_key);
+    defer gpa.free(active_snapshot_path);
+    const backup_snapshot_path = try registry.accountAuthPath(gpa, codex_home, backup_key);
+    defer gpa.free(backup_snapshot_path);
+
+    const previous_auth = try fixtures.authJsonWithEmailPlan(gpa, "previous@example.com", "pro");
+    defer gpa.free(previous_auth);
+    const active_auth = try fixtures.authJsonWithEmailPlan(gpa, "active@example.com", "plus");
+    defer gpa.free(active_auth);
+    const backup_auth = try fixtures.authJsonWithEmailPlan(gpa, "backup@example.com", "team");
+    defer gpa.free(backup_auth);
+    try tmp.dir.writeFile(.{ .sub_path = ".codex/auth.json", .data = active_auth });
+    try fs.cwd().writeFile(.{ .sub_path = previous_snapshot_path, .data = previous_auth });
+    try fs.cwd().writeFile(.{ .sub_path = active_snapshot_path, .data = active_auth });
+    try fs.cwd().writeFile(.{ .sub_path = backup_snapshot_path, .data = backup_auth });
+
+    var seeded = try registry.loadRegistry(gpa, codex_home);
+    defer seeded.deinit(gpa);
+    try registry.setActiveAccountKey(gpa, &seeded, previous_key);
+    try registry.setActiveAccountKey(gpa, &seeded, active_key);
+    registry.updateUsage(gpa, &seeded, backup_key, makeUsageSnapshot(10.0, 10.0));
+    try registry.saveRegistry(gpa, codex_home, &seeded);
+
+    const result = try runCliWithIsolatedHomeAndStdin(gpa, project_root, home_root, &[_][]const u8{ "remove", "active@" }, "");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectSuccess(result);
+    try std.testing.expectEqualStrings("Removed 1 account(s): active(active@example.com)\n", result.stdout);
+    try std.testing.expectEqualStrings("", result.stderr);
+
+    const replaced_auth = try fixtures.readFileAlloc(gpa, active_auth_path);
+    defer gpa.free(replaced_auth);
+    try std.testing.expectEqualStrings(backup_auth, replaced_auth);
+
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expect(loaded.active_account_key != null);
+    try std.testing.expect(loaded.previous_active_account_key != null);
+    try std.testing.expectEqualStrings(backup_key, loaded.active_account_key.?);
+    try std.testing.expectEqualStrings(previous_key, loaded.previous_active_account_key.?);
 }
 
 test "Scenario: Given active account removal with missing auth json when running remove then replacement auth is recreated" {

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -297,6 +297,7 @@ test "registry save/load" {
     const saved = try fixtures.readFileAlloc(gpa, registry_path);
     defer gpa.free(saved);
     try std.testing.expect(std.mem.indexOf(u8, saved, "\"api\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "\"previous_active_account_key\": null") != null);
 
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
@@ -304,10 +305,65 @@ test "registry save/load" {
     try std.testing.expect(loaded.api.usage);
     try std.testing.expect(loaded.api.account);
     try std.testing.expect(loaded.active_account_activated_at_ms != null);
+    try std.testing.expect(loaded.previous_active_account_key == null);
     try std.testing.expect(loaded.accounts.items[0].last_local_rollout != null);
     try std.testing.expectEqual(@as(i64, 1735689600000), loaded.accounts.items[0].last_local_rollout.?.event_timestamp_ms);
     try std.testing.expect(std.mem.eql(u8, loaded.accounts.items[0].last_local_rollout.?.path, "/tmp/sessions/run-1/rollout-a.jsonl"));
     try std.testing.expect(loaded.accounts.items[0].account_name == null);
+}
+
+test "registry save/load round-trips previous active account key" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("accounts");
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "alpha@example.com", "alpha", .plus, .chatgpt, 1));
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "beta@example.com", "beta", .pro, .chatgpt, 2));
+
+    const alpha_key = try accountKeyForEmailAlloc(gpa, "alpha@example.com");
+    defer gpa.free(alpha_key);
+    const beta_key = try accountKeyForEmailAlloc(gpa, "beta@example.com");
+    defer gpa.free(beta_key);
+
+    try registry.setActiveAccountKey(gpa, &reg, alpha_key);
+    try registry.setActiveAccountKey(gpa, &reg, beta_key);
+    try std.testing.expect(reg.previous_active_account_key != null);
+    try std.testing.expectEqualStrings(alpha_key, reg.previous_active_account_key.?);
+
+    try registry.saveRegistry(gpa, codex_home, &reg);
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+
+    try std.testing.expect(loaded.active_account_key != null);
+    try std.testing.expect(loaded.previous_active_account_key != null);
+    try std.testing.expectEqualStrings(beta_key, loaded.active_account_key.?);
+    try std.testing.expectEqualStrings(alpha_key, loaded.previous_active_account_key.?);
+}
+
+test "setting same active account preserves previous active account key" {
+    const gpa = std.testing.allocator;
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "alpha@example.com", "alpha", .plus, .chatgpt, 1));
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "beta@example.com", "beta", .pro, .chatgpt, 2));
+
+    const alpha_key = try accountKeyForEmailAlloc(gpa, "alpha@example.com");
+    defer gpa.free(alpha_key);
+    const beta_key = try accountKeyForEmailAlloc(gpa, "beta@example.com");
+    defer gpa.free(beta_key);
+
+    try registry.setActiveAccountKey(gpa, &reg, alpha_key);
+    try registry.setActiveAccountKey(gpa, &reg, beta_key);
+    try registry.setActiveAccountKey(gpa, &reg, beta_key);
+
+    try std.testing.expect(reg.previous_active_account_key != null);
+    try std.testing.expectEqualStrings(alpha_key, reg.previous_active_account_key.?);
 }
 
 test "plan labels are human-readable while registry stores raw plan values" {
@@ -420,6 +476,39 @@ test "registry save/load round-trips account_name null" {
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
     try std.testing.expect(loaded.accounts.items[0].account_name == null);
+}
+
+test "registry load normalizes schema four without previous active account key" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("accounts");
+    try tmp.dir.writeFile(.{
+        .sub_path = "accounts/registry.json",
+        .data =
+        \\{
+        \\  "schema_version": 4,
+        \\  "active_account_key": null,
+        \\  "active_account_activated_at_ms": null,
+        \\  "interval_seconds": 60,
+        \\  "accounts": []
+        \\}
+        ,
+    });
+
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expect(loaded.previous_active_account_key == null);
+
+    var file = try tmp.dir.openFile("accounts/registry.json", .{});
+    defer file.close();
+    const contents = try file.readToEndAlloc(gpa, 10 * 1024 * 1024);
+    defer gpa.free(contents);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\"schema_version\": 4") != null);
+    try std.testing.expect(std.mem.indexOf(u8, contents, "\"previous_active_account_key\": null") != null);
 }
 
 test "registry save/load round-trips account_name string" {
@@ -1314,6 +1403,34 @@ test "remove accounts deletes matching snapshots and auth backups only for remov
     keep_backup.close();
     var malformed_backup = try tmp.dir.openFile("accounts/auth.json.bak.20260320-030303", .{});
     malformed_backup.close();
+}
+
+test "remove accounts clears previous active account when previous is removed" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("accounts");
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "previous@example.com", "", .plus, .chatgpt, 1));
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "active@example.com", "", .team, .chatgpt, 2));
+
+    const previous_key = try accountKeyForEmailAlloc(gpa, "previous@example.com");
+    defer gpa.free(previous_key);
+    const active_key = try accountKeyForEmailAlloc(gpa, "active@example.com");
+    defer gpa.free(active_key);
+    try registry.setActiveAccountKey(gpa, &reg, previous_key);
+    try registry.setActiveAccountKey(gpa, &reg, active_key);
+
+    try registry.removeAccounts(gpa, codex_home, &reg, &[_]usize{0});
+
+    try std.testing.expect(reg.active_account_key != null);
+    try std.testing.expectEqualStrings(active_key, reg.active_account_key.?);
+    try std.testing.expect(reg.previous_active_account_key == null);
 }
 
 test "import auth path with single file keeps explicit alias" {

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -1207,6 +1207,42 @@ test "sync active auth matches by email and updates account auth" {
     try std.testing.expect(std.mem.eql(u8, data, active_auth));
 }
 
+test "sync active auth preserves previous account on external drift" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("accounts");
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "previous@example.com", "previous", .plus, .chatgpt, 1));
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "active@example.com", "active", .pro, .chatgpt, 2));
+    try reg.accounts.append(gpa, try makeAccountRecord(gpa, "external@example.com", "external", .free, .chatgpt, 3));
+
+    const previous_key = try accountKeyForEmailAlloc(gpa, "previous@example.com");
+    defer gpa.free(previous_key);
+    const active_key = try accountKeyForEmailAlloc(gpa, "active@example.com");
+    defer gpa.free(active_key);
+    const external_key = try accountKeyForEmailAlloc(gpa, "external@example.com");
+    defer gpa.free(external_key);
+    try registry.setActiveAccountKey(gpa, &reg, previous_key);
+    try registry.setActiveAccountKey(gpa, &reg, active_key);
+
+    const active_auth = try authJsonWithEmailPlan(gpa, "external@example.com", "team");
+    defer gpa.free(active_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "auth.json", .data = active_auth });
+
+    const changed = try registry.syncActiveAccountFromAuth(gpa, codex_home, &reg);
+    try std.testing.expect(changed);
+    try std.testing.expect(reg.active_account_key != null);
+    try std.testing.expectEqualStrings(external_key, reg.active_account_key.?);
+    try std.testing.expect(reg.previous_active_account_key != null);
+    try std.testing.expectEqualStrings(previous_key, reg.previous_active_account_key.?);
+}
+
 test "registry backup only on change" {
     var gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});


### PR DESCRIPTION
## Summary

- Add cd - style previous-account switching via `codex-auth -` and `codex-auth switch -`.
- Persist `previous_active_account_key` in registry schema 4 and normalize schema 4 files missing it.
- Preserve previous-account state during same-account switches and active-account removal replacement; clear it only when the recorded previous account is removed.

## Validation

- `HOME=/tmp/previous-account-switch zig build run -- list`
- `HOME=/tmp/previous-account-switch zig build test`
- `git diff --check`

## Risks

- Registry persistence now writes `previous_active_account_key` while staying on `schema_version = 4` because this schema has not shipped yet.
- Previous switch depends on recorded account keys; it fails without mutation when the recorded previous account is missing.

## PR Loop Status

- Latest push creates the feature branch and initial PR.
- CI status pending.
- No review comments have been addressed yet.
- No comments intentionally left unresolved.