### PR TITLE
fix(auth): relax CPA optional token metadata

### DIFF
--- a/src/auth/auth.zig
+++ b/src/auth/auth.zig
@@ -413,8 +413,9 @@ fn jsonStringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
 
 fn jsonNonEmptyStringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
     const value = jsonStringField(obj, key) orelse return null;
-    if (std.mem.trim(u8, value, &std.ascii.whitespace).len == 0) return null;
-    return value;
+    const trimmed = std.mem.trim(u8, value, &std.ascii.whitespace);
+    if (trimmed.len == 0) return null;
+    return trimmed;
 }
 
 fn jsonStringFieldOrDefault(obj: std.json.ObjectMap, key: []const u8) []const u8 {

--- a/src/auth/auth.zig
+++ b/src/auth/auth.zig
@@ -290,6 +290,8 @@ pub fn convertStandardAuthJsonToCpa(allocator: std.mem.Allocator, data: []const 
     };
     const id_token = jsonNonEmptyStringField(tokens, "id_token") orelse return error.MissingIdToken;
     const access_token = jsonNonEmptyStringField(tokens, "access_token") orelse return error.MissingAccessToken;
+    const account_id = try cpaAccountIdFromIdTokenAlloc(allocator, tokens) orelse return error.MissingAccountId;
+    defer allocator.free(account_id);
 
     var out: std.Io.Writer.Allocating = .init(allocator);
     errdefer out.deinit();
@@ -298,7 +300,7 @@ pub fn convertStandardAuthJsonToCpa(allocator: std.mem.Allocator, data: []const 
         .id_token = id_token,
         .access_token = access_token,
         .refresh_token = jsonNonEmptyStringField(tokens, "refresh_token"),
-        .account_id = jsonNonEmptyStringField(tokens, "account_id"),
+        .account_id = account_id,
         .last_refresh = jsonNonEmptyStringField(obj, "last_refresh"),
     }, .{ .whitespace = .indent_2, .emit_null_optional_fields = false }, &out.writer);
     try out.writer.writeAll("\n");

--- a/src/auth/auth.zig
+++ b/src/auth/auth.zig
@@ -26,22 +26,22 @@ pub const AuthInfo = struct {
 
 const StandardAuthJson = struct {
     auth_mode: []const u8,
-    OPENAI_API_KEY: ?[]const u8,
+    OPENAI_API_KEY: std.json.Value,
     tokens: struct {
         id_token: []const u8,
         access_token: []const u8,
-        refresh_token: []const u8,
+        refresh_token: ?[]const u8,
         account_id: []const u8,
     },
-    last_refresh: []const u8,
+    last_refresh: ?[]const u8,
 };
 
 const CpaAuthJson = struct {
     id_token: []const u8,
     access_token: []const u8,
-    refresh_token: []const u8,
-    account_id: []const u8,
-    last_refresh: []const u8,
+    refresh_token: ?[]const u8,
+    account_id: ?[]const u8,
+    last_refresh: ?[]const u8,
 };
 
 fn normalizeEmailAlloc(allocator: std.mem.Allocator, email: []const u8) ![]u8 {
@@ -252,23 +252,25 @@ pub fn convertCpaAuthJson(allocator: std.mem.Allocator, data: []const u8) ![]u8 
         else => return error.InvalidCPAFormat,
     };
 
-    const refresh_token = jsonStringField(obj, "refresh_token") orelse return error.MissingRefreshToken;
-    if (refresh_token.len == 0) return error.MissingRefreshToken;
+    const id_token = jsonNonEmptyStringField(obj, "id_token") orelse return error.MissingIdToken;
+    const access_token = jsonNonEmptyStringField(obj, "access_token") orelse return error.MissingAccessToken;
+    const account_id = try cpaAccountIdFromIdTokenAlloc(allocator, obj) orelse return error.MissingAccountId;
+    defer allocator.free(account_id);
 
     var out: std.Io.Writer.Allocating = .init(allocator);
     errdefer out.deinit();
 
     try std.json.Stringify.value(StandardAuthJson{
         .auth_mode = "chatgpt",
-        .OPENAI_API_KEY = null,
+        .OPENAI_API_KEY = .null,
         .tokens = .{
-            .id_token = jsonStringFieldOrDefault(obj, "id_token"),
-            .access_token = jsonStringFieldOrDefault(obj, "access_token"),
-            .refresh_token = refresh_token,
-            .account_id = jsonStringFieldOrDefault(obj, "account_id"),
+            .id_token = id_token,
+            .access_token = access_token,
+            .refresh_token = jsonNonEmptyStringField(obj, "refresh_token"),
+            .account_id = account_id,
         },
-        .last_refresh = jsonStringFieldOrDefault(obj, "last_refresh"),
-    }, .{ .whitespace = .indent_2 }, &out.writer);
+        .last_refresh = jsonNonEmptyStringField(obj, "last_refresh"),
+    }, .{ .whitespace = .indent_2, .emit_null_optional_fields = false }, &out.writer);
     try out.writer.writeAll("\n");
     return try out.toOwnedSlice();
 }
@@ -286,19 +288,19 @@ pub fn convertStandardAuthJsonToCpa(allocator: std.mem.Allocator, data: []const 
         .object => |tokens| tokens,
         else => return error.MissingTokens,
     };
-    const refresh_token = jsonStringField(tokens, "refresh_token") orelse return error.MissingRefreshToken;
-    if (refresh_token.len == 0) return error.MissingRefreshToken;
+    const id_token = jsonNonEmptyStringField(tokens, "id_token") orelse return error.MissingIdToken;
+    const access_token = jsonNonEmptyStringField(tokens, "access_token") orelse return error.MissingAccessToken;
 
     var out: std.Io.Writer.Allocating = .init(allocator);
     errdefer out.deinit();
 
     try std.json.Stringify.value(CpaAuthJson{
-        .id_token = jsonStringFieldOrDefault(tokens, "id_token"),
-        .access_token = jsonStringFieldOrDefault(tokens, "access_token"),
-        .refresh_token = refresh_token,
-        .account_id = jsonStringFieldOrDefault(tokens, "account_id"),
-        .last_refresh = jsonStringFieldOrDefault(obj, "last_refresh"),
-    }, .{ .whitespace = .indent_2 }, &out.writer);
+        .id_token = id_token,
+        .access_token = access_token,
+        .refresh_token = jsonNonEmptyStringField(tokens, "refresh_token"),
+        .account_id = jsonNonEmptyStringField(tokens, "account_id"),
+        .last_refresh = jsonNonEmptyStringField(obj, "last_refresh"),
+    }, .{ .whitespace = .indent_2, .emit_null_optional_fields = false }, &out.writer);
     try out.writer.writeAll("\n");
     return try out.toOwnedSlice();
 }
@@ -362,6 +364,30 @@ fn organizationAccountIdAlloc(allocator: std.mem.Allocator, auth_obj: std.json.O
     return null;
 }
 
+fn cpaAccountIdFromIdTokenAlloc(allocator: std.mem.Allocator, obj: std.json.ObjectMap) !?[]u8 {
+    const id_token = jsonNonEmptyStringField(obj, "id_token") orelse return null;
+    const payload = try decodeJwtPayload(allocator, id_token);
+    defer allocator.free(payload);
+
+    var payload_json = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+    defer payload_json.deinit();
+
+    const claims = switch (payload_json.value) {
+        .object => |cobj| cobj,
+        else => return null,
+    };
+    const auth_val = claims.get("https://api.openai.com/auth") orelse return null;
+    const auth_obj = switch (auth_val) {
+        .object => |aobj| aobj,
+        else => return null,
+    };
+
+    if (jsonNonEmptyStringField(auth_obj, "chatgpt_account_id")) |account_id| {
+        return try allocator.dupe(u8, account_id);
+    }
+    return try organizationAccountIdAlloc(allocator, auth_obj);
+}
+
 fn resolveChatGptAccountId(
     token_chatgpt_account_id: ?[]u8,
     jwt_chatgpt_account_id: ?[]u8,
@@ -383,6 +409,12 @@ fn jsonStringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
         .string => |s| s,
         else => null,
     };
+}
+
+fn jsonNonEmptyStringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = jsonStringField(obj, key) orelse return null;
+    if (std.mem.trim(u8, value, &std.ascii.whitespace).len == 0) return null;
+    return value;
 }
 
 fn jsonStringFieldOrDefault(obj: std.json.ObjectMap, key: []const u8) []const u8 {

--- a/src/registry/import_helpers.zig
+++ b/src/registry/import_helpers.zig
@@ -36,7 +36,6 @@ pub fn isImportValidationError(err: anyerror) bool {
         error.MissingAccountId,
         error.MissingAccessToken,
         error.MissingIdToken,
-        error.MissingRefreshToken,
         error.AccountIdMismatch,
         error.InvalidJwt,
         error.InvalidBase64,

--- a/src/registry/import_helpers.zig
+++ b/src/registry/import_helpers.zig
@@ -34,6 +34,8 @@ pub fn isImportValidationError(err: anyerror) bool {
         error.InvalidOpenAIMeResponse,
         error.OpenAIMeRequestFailed,
         error.MissingAccountId,
+        error.MissingAccessToken,
+        error.MissingIdToken,
         error.MissingRefreshToken,
         error.AccountIdMismatch,
         error.InvalidJwt,

--- a/tests/auth_test.zig
+++ b/tests/auth_test.zig
@@ -175,10 +175,166 @@ test "convert cpa auth json produces a parseable standard auth snapshot" {
     try std.testing.expect(info.auth_mode == .chatgpt);
 }
 
-test "convert cpa auth json requires refresh token" {
+test "convert cpa auth json omits empty last refresh" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "empty-refresh@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const empty_last_refresh = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        cpa_json,
+        "\"last_refresh\":\"2026-03-20T00:00:00Z\"",
+        "\"last_refresh\":\"\"",
+    );
+    defer gpa.free(empty_last_refresh);
+
+    const converted = try auth.convertCpaAuthJson(gpa, empty_last_refresh);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"last_refresh\"") == null);
+
+    const info = try auth.parseAuthInfoData(gpa, converted);
+    defer info.deinit(gpa);
+    try std.testing.expect(info.last_refresh == null);
+}
+
+test "convert cpa auth json omits missing last refresh" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "missing-last-refresh@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const without_last_refresh = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        cpa_json,
+        ",\"last_refresh\":\"2026-03-20T00:00:00Z\"",
+        "",
+    );
+    defer gpa.free(without_last_refresh);
+
+    const converted = try auth.convertCpaAuthJson(gpa, without_last_refresh);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"last_refresh\"") == null);
+
+    const info = try auth.parseAuthInfoData(gpa, converted);
+    defer info.deinit(gpa);
+    try std.testing.expect(info.last_refresh == null);
+}
+
+test "convert cpa auth json derives missing account id from id token" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "missing-account-id@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const without_account_id = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        cpa_json,
+        ",\"account_id\":\"",
+        ",\"removed_account_id\":\"",
+    );
+    defer gpa.free(without_account_id);
+
+    const expected_account_id = try fixtures.chatgptAccountIdForEmailAlloc(gpa, "missing-account-id@example.com");
+    defer gpa.free(expected_account_id);
+    const expected_json = try std.fmt.allocPrint(gpa, "\"account_id\": \"{s}\"", .{expected_account_id});
+    defer gpa.free(expected_json);
+
+    const converted = try auth.convertCpaAuthJson(gpa, without_account_id);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, expected_json) != null);
+
+    const info = try auth.parseAuthInfoData(gpa, converted);
+    defer info.deinit(gpa);
+    try std.testing.expect(info.chatgpt_account_id != null);
+    try std.testing.expect(std.mem.eql(u8, info.chatgpt_account_id.?, expected_account_id));
+}
+
+test "convert cpa auth json ignores top-level account id" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "mismatched-account-id@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const source_account_id = try fixtures.chatgptAccountIdForEmailAlloc(gpa, "mismatched-account-id@example.com");
+    defer gpa.free(source_account_id);
+    const source_json = try std.fmt.allocPrint(gpa, "\"account_id\":\"{s}\"", .{source_account_id});
+    defer gpa.free(source_json);
+    const mismatched = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        cpa_json,
+        source_json,
+        "\"account_id\":\"wrong-account-id\"",
+    );
+    defer gpa.free(mismatched);
+
+    const expected_json = try std.fmt.allocPrint(gpa, "\"account_id\": \"{s}\"", .{source_account_id});
+    defer gpa.free(expected_json);
+
+    const converted = try auth.convertCpaAuthJson(gpa, mismatched);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, expected_json) != null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "wrong-account-id") == null);
+}
+
+test "convert cpa auth json omits missing refresh token" {
     const gpa = std.testing.allocator;
     const cpa_json = try fixtures.cpaJsonWithoutRefreshToken(gpa, "missing-refresh@example.com", "plus");
     defer gpa.free(cpa_json);
 
-    try std.testing.expectError(error.MissingRefreshToken, auth.convertCpaAuthJson(gpa, cpa_json));
+    const converted = try auth.convertCpaAuthJson(gpa, cpa_json);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"refresh_token\"") == null);
+
+    const info = try auth.parseAuthInfoData(gpa, converted);
+    defer info.deinit(gpa);
+    try std.testing.expect(info.auth_mode == .chatgpt);
+    try std.testing.expect(info.access_token != null);
+}
+
+test "convert cpa auth json requires non-empty id token" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "missing-id-token@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const without_id_token = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        cpa_json,
+        ",\"id_token\":\"",
+        ",\"removed_id_token\":\"",
+    );
+    defer gpa.free(without_id_token);
+
+    try std.testing.expectError(error.MissingIdToken, auth.convertCpaAuthJson(gpa, without_id_token));
+}
+
+test "convert cpa auth json requires non-empty access token" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "missing-access-token@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const without_access_token = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        cpa_json,
+        ",\"access_token\":\"access-missing-access-token@example.com\"",
+        "",
+    );
+    defer gpa.free(without_access_token);
+
+    try std.testing.expectError(error.MissingAccessToken, auth.convertCpaAuthJson(gpa, without_access_token));
+}
+
+test "convert standard auth json to cpa omits optional empty fields" {
+    const gpa = std.testing.allocator;
+    const standard_json = try fixtures.authJsonWithEmailPlan(gpa, "standard-no-refresh@example.com", "plus");
+    defer gpa.free(standard_json);
+
+    const converted = try auth.convertStandardAuthJsonToCpa(gpa, standard_json);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"id_token\": \"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"access_token\": \"access-standard-no-refresh@example.com\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"refresh_token\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"last_refresh\"") == null);
 }

--- a/tests/auth_test.zig
+++ b/tests/auth_test.zig
@@ -366,3 +366,30 @@ test "convert standard auth json to cpa omits optional empty fields" {
     try std.testing.expect(std.mem.indexOf(u8, converted, "\"refresh_token\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, converted, "\"last_refresh\"") == null);
 }
+
+test "convert standard auth json to cpa derives account id from id token" {
+    const gpa = std.testing.allocator;
+    const standard_json = try fixtures.authJsonWithEmailPlan(gpa, "standard-mismatched-account@example.com", "plus");
+    defer gpa.free(standard_json);
+    const expected_account_id = try fixtures.chatgptAccountIdForEmailAlloc(gpa, "standard-mismatched-account@example.com");
+    defer gpa.free(expected_account_id);
+    const stale_account_id_json = try std.fmt.allocPrint(gpa, "\"account_id\":\"{s}\"", .{expected_account_id});
+    defer gpa.free(stale_account_id_json);
+    const mismatched = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        standard_json,
+        stale_account_id_json,
+        "\"account_id\":\"stale-account-id\"",
+    );
+    defer gpa.free(mismatched);
+
+    const expected_json = try std.fmt.allocPrint(gpa, "\"account_id\": \"{s}\"", .{expected_account_id});
+    defer gpa.free(expected_json);
+
+    const converted = try auth.convertStandardAuthJsonToCpa(gpa, mismatched);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, expected_json) != null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "stale-account-id") == null);
+}

--- a/tests/auth_test.zig
+++ b/tests/auth_test.zig
@@ -325,6 +325,34 @@ test "convert cpa auth json requires non-empty access token" {
     try std.testing.expectError(error.MissingAccessToken, auth.convertCpaAuthJson(gpa, without_access_token));
 }
 
+test "convert cpa auth json trims required token fields" {
+    const gpa = std.testing.allocator;
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "trimmed-tokens@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const spaced_id_token = try std.mem.replaceOwned(u8, gpa, cpa_json, "\"id_token\":\"", "\"id_token\":\"  ");
+    defer gpa.free(spaced_id_token);
+    const spaced_tokens = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        spaced_id_token,
+        "\",\"access_token\":\"access-trimmed-tokens@example.com\"",
+        "  \",\"access_token\":\" access-trimmed-tokens@example.com \"",
+    );
+    defer gpa.free(spaced_tokens);
+
+    const converted = try auth.convertCpaAuthJson(gpa, spaced_tokens);
+    defer gpa.free(converted);
+
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"id_token\": \"  ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, converted, "\"access_token\": \" access-trimmed-tokens@example.com \"") == null);
+
+    const info = try auth.parseAuthInfoData(gpa, converted);
+    defer info.deinit(gpa);
+    try std.testing.expect(info.auth_mode == .chatgpt);
+    try std.testing.expect(info.access_token != null);
+    try std.testing.expect(std.mem.eql(u8, info.access_token.?, "access-trimmed-tokens@example.com"));
+}
+
 test "convert standard auth json to cpa omits optional empty fields" {
     const gpa = std.testing.allocator;
     const standard_json = try fixtures.authJsonWithEmailPlan(gpa, "standard-no-refresh@example.com", "plus");

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -1758,21 +1758,20 @@ test "Scenario: Given cpa directory in default location when running import cpa 
         gpa,
         "Scanning ~/.cli-proxy-api...\n" ++
             "  imported  first.json\n" ++
+            "  imported  no-refresh.json\n" ++
             "  imported  second.json\n" ++
-            "Import Summary: 2 imported, 0 updated, 1 skipped (total 3 files)\n",
+            "Import Summary: 3 imported, 0 updated, 0 skipped (total 3 files)\n",
         .{},
     );
     defer gpa.free(expected_stdout);
     try std.testing.expectEqualStrings(expected_stdout, result.stdout);
-    const expected_stderr = try std.fmt.allocPrint(gpa, "  skipped   no-refresh.json: MissingRefreshToken\n", .{});
-    defer gpa.free(expected_stderr);
-    try std.testing.expectEqualStrings(expected_stderr, result.stderr);
+    try std.testing.expectEqualStrings("", result.stderr);
 
     const codex_home = try codexHomeAlloc(gpa, home_root);
     defer gpa.free(codex_home);
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
-    try std.testing.expectEqual(@as(usize, 2), loaded.accounts.items.len);
+    try std.testing.expectEqual(@as(usize, 3), loaded.accounts.items.len);
 }
 
 test "Scenario: Given missing default cpa directory when running import cpa then it fails" {

--- a/tests/registry_test.zig
+++ b/tests/registry_test.zig
@@ -1573,6 +1573,46 @@ test "import cpa path with single file converts to standard auth and keeps expli
     try expectModeUnix(snapshot_path, 0o600);
 }
 
+test "import cpa path with empty last refresh omits refresh metadata" {
+    const gpa = std.testing.allocator;
+    var tmp = fs.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try tmp.dir.makePath("imports");
+
+    const cpa_json = try fixtures.cpaJsonWithEmailPlan(gpa, "empty-cpa-refresh@example.com", "plus");
+    defer gpa.free(cpa_json);
+    const empty_last_refresh = try std.mem.replaceOwned(
+        u8,
+        gpa,
+        cpa_json,
+        "\"last_refresh\":\"2026-03-20T00:00:00Z\"",
+        "\"last_refresh\":\"\"",
+    );
+    defer gpa.free(empty_last_refresh);
+    try tmp.dir.writeFile(.{ .sub_path = "imports/empty-refresh.json", .data = empty_last_refresh });
+
+    const import_path = try fs.path.join(gpa, &[_][]const u8{ codex_home, "imports", "empty-refresh.json" });
+    defer gpa.free(import_path);
+
+    var reg = makeEmptyRegistry();
+    defer reg.deinit(gpa);
+
+    var report = try registry.importCpaPath(gpa, codex_home, &reg, import_path, null);
+    defer report.deinit(gpa);
+    try std.testing.expect(report.imported == 1);
+
+    const account_key = try fixtures.accountKeyForEmailAlloc(gpa, "empty-cpa-refresh@example.com");
+    defer gpa.free(account_key);
+    const snapshot_path = try registry.accountAuthPath(gpa, codex_home, account_key);
+    defer gpa.free(snapshot_path);
+    const snapshot_data = try fixtures.readFileAlloc(gpa, snapshot_path);
+    defer gpa.free(snapshot_data);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot_data, "\"last_refresh\"") == null);
+}
+
 test "import cpa path with repeated single file reports updated on second import" {
     const gpa = std.testing.allocator;
     var tmp = fs.tmpDir(.{});
@@ -1635,11 +1675,11 @@ test "import cpa path with directory imports multiple json files and skips bad f
     var report = try registry.importCpaPath(gpa, codex_home, &reg, imports_dir, null);
     defer report.deinit(gpa);
     try std.testing.expect(report.render_kind == .scanned);
-    try std.testing.expect(report.imported == 2);
+    try std.testing.expect(report.imported == 3);
     try std.testing.expect(report.updated == 0);
-    try std.testing.expect(report.skipped == 2);
+    try std.testing.expect(report.skipped == 1);
     try std.testing.expect(report.total_files == 4);
-    try std.testing.expectEqual(@as(usize, 2), reg.accounts.items.len);
+    try std.testing.expectEqual(@as(usize, 3), reg.accounts.items.len);
 }
 
 test "export accounts writes standard auth snapshots to explicit directory" {


### PR DESCRIPTION
Fixes #129

Changes:
- Require non-empty `id_token` and `access_token` for CPA import/export conversion.
- Derive `account_id` from `id_token` and ignore CPA top-level `account_id`.
- Ignore CPA `type` and top-level `email`.
- Omit missing or empty `refresh_token` and `last_refresh` instead of emitting empty fields.