### PR TITLE
fix: create login temp root

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1573,7 +1573,7 @@ fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.L
 fn createTempLoginCodexHome(allocator: std.mem.Allocator) ![]u8 {
     const base = try tempBasePathAlloc(allocator);
     defer allocator.free(base);
-    try std.fs.cwd().makePath(base);
+    try ensureTempBasePath(base);
 
     var counter: usize = 0;
     while (counter < 100) : (counter += 1) {
@@ -1595,6 +1595,18 @@ fn createTempLoginCodexHome(allocator: std.mem.Allocator) ![]u8 {
         return path;
     }
     return error.PathAlreadyExists;
+}
+
+fn ensureTempBasePath(base: []const u8) !void {
+    std.fs.cwd().makePath(base) catch |err| switch (err) {
+        error.BadPathName => try std.fs.cwd().access(base, .{}),
+        else => return err,
+    };
+}
+
+test "temp base path accepts filesystem root" {
+    const root = if (builtin.os.tag == .windows) "C:\\" else "/";
+    try ensureTempBasePath(root);
 }
 
 fn tempBasePathAlloc(allocator: std.mem.Allocator) ![]u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1573,6 +1573,8 @@ fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.L
 fn createTempLoginCodexHome(allocator: std.mem.Allocator) ![]u8 {
     const base = try tempBasePathAlloc(allocator);
     defer allocator.free(base);
+    try std.fs.cwd().makePath(base);
+
     var counter: usize = 0;
     while (counter < 100) : (counter += 1) {
         const path = try std.fmt.allocPrint(

--- a/src/main.zig
+++ b/src/main.zig
@@ -1557,10 +1557,10 @@ fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.L
     const dest = try registry.accountAuthPath(allocator, codex_home, record_key);
     defer allocator.free(dest);
 
-    try registry.copyFile(auth_path, dest);
+    try registry.copyManagedFile(auth_path, dest);
     const active_auth_path = try registry.activeAuthPath(allocator, codex_home);
     defer allocator.free(active_auth_path);
-    try registry.copyFile(auth_path, active_auth_path);
+    try registry.copyManagedFile(auth_path, active_auth_path);
 
     const record = try registry.accountFromAuth(allocator, "", &info);
     try registry.upsertAccount(allocator, &reg, record);
@@ -1579,7 +1579,7 @@ fn createTempLoginCodexHome(allocator: std.mem.Allocator, codex_home: []const u8
             "{s}{c}accounts{c}login-{d}-{d}",
             .{ codex_home, std.fs.path.sep, std.fs.path.sep, std.time.nanoTimestamp(), counter },
         );
-        std.fs.cwd().makePath(path) catch |err| switch (err) {
+        registry.createPrivateDir(path) catch |err| switch (err) {
             error.PathAlreadyExists => {
                 allocator.free(path);
                 continue;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1557,7 +1557,6 @@ fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.L
     const dest = try registry.accountAuthPath(allocator, codex_home, record_key);
     defer allocator.free(dest);
 
-    try registry.ensureAccountsDir(allocator, codex_home);
     try registry.copyFile(auth_path, dest);
     const active_auth_path = try registry.activeAuthPath(allocator, codex_home);
     defer allocator.free(active_auth_path);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1531,7 +1531,7 @@ fn handleList(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.Li
 }
 
 fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.LoginOptions) !void {
-    const login_home = try createTempLoginCodexHome(allocator);
+    const login_home = try createTempLoginCodexHome(allocator, codex_home);
     defer {
         std.fs.cwd().deleteTree(login_home) catch |err| {
             std.log.warn("failed to remove temporary Codex login home `{s}`: {s}", .{ login_home, @errorName(err) });
@@ -1570,17 +1570,15 @@ fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.L
     try registry.saveRegistry(allocator, codex_home, &reg);
 }
 
-fn createTempLoginCodexHome(allocator: std.mem.Allocator) ![]u8 {
-    const base = try tempBasePathAlloc(allocator);
-    defer allocator.free(base);
-    try ensureTempBasePath(base);
+fn createTempLoginCodexHome(allocator: std.mem.Allocator, codex_home: []const u8) ![]u8 {
+    try registry.ensureAccountsDir(allocator, codex_home);
 
     var counter: usize = 0;
     while (counter < 100) : (counter += 1) {
         const path = try std.fmt.allocPrint(
             allocator,
-            "{s}{c}codex-auth-login-{d}-{d}",
-            .{ base, std.fs.path.sep, std.time.nanoTimestamp(), counter },
+            "{s}{c}accounts{c}login-{d}-{d}",
+            .{ codex_home, std.fs.path.sep, std.fs.path.sep, std.time.nanoTimestamp(), counter },
         );
         std.fs.cwd().makePath(path) catch |err| switch (err) {
             error.PathAlreadyExists => {
@@ -1595,43 +1593,6 @@ fn createTempLoginCodexHome(allocator: std.mem.Allocator) ![]u8 {
         return path;
     }
     return error.PathAlreadyExists;
-}
-
-fn ensureTempBasePath(base: []const u8) !void {
-    std.fs.cwd().makePath(base) catch |err| switch (err) {
-        error.BadPathName => try std.fs.cwd().access(base, .{}),
-        else => return err,
-    };
-}
-
-test "temp base path accepts filesystem root" {
-    const root = if (builtin.os.tag == .windows) "C:\\" else "/";
-    try ensureTempBasePath(root);
-}
-
-fn tempBasePathAlloc(allocator: std.mem.Allocator) ![]u8 {
-    if (builtin.os.tag == .windows) {
-        if (try getNonEmptyEnvVarOwned(allocator, "TEMP")) |path| return path;
-        if (try getNonEmptyEnvVarOwned(allocator, "TMP")) |path| return path;
-        if (try getNonEmptyEnvVarOwned(allocator, "TMPDIR")) |path| return path;
-        return allocator.dupe(u8, "C:\\Temp");
-    }
-    if (try getNonEmptyEnvVarOwned(allocator, "TMPDIR")) |path| return path;
-    if (try getNonEmptyEnvVarOwned(allocator, "TMP")) |path| return path;
-    if (try getNonEmptyEnvVarOwned(allocator, "TEMP")) |path| return path;
-    return allocator.dupe(u8, "/tmp");
-}
-
-fn getNonEmptyEnvVarOwned(allocator: std.mem.Allocator, name: []const u8) !?[]u8 {
-    const value = std.process.getEnvVarOwned(allocator, name) catch |err| switch (err) {
-        error.EnvironmentVariableNotFound => return null,
-        else => return err,
-    };
-    if (value.len == 0) {
-        allocator.free(value);
-        return null;
-    }
-    return value;
 }
 
 fn handleImport(allocator: std.mem.Allocator, codex_home: []const u8, opts: cli.ImportOptions) !void {

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -362,7 +362,22 @@ pub fn resolveUserHome(allocator: std.mem.Allocator) ![]u8 {
 pub fn ensureAccountsDir(allocator: std.mem.Allocator, codex_home: []const u8) !void {
     const accounts_dir = try std.fs.path.join(allocator, &[_][]const u8{ codex_home, "accounts" });
     defer allocator.free(accounts_dir);
-    try std.fs.cwd().makePath(accounts_dir);
+    try ensurePrivateDir(accounts_dir);
+}
+
+pub fn ensurePrivateDir(path: []const u8) !void {
+    try std.fs.cwd().makePath(path);
+    try hardenPrivateDir(path);
+}
+
+pub fn createPrivateDir(path: []const u8) !void {
+    try std.fs.cwd().makeDir(path);
+    try hardenPrivateDir(path);
+}
+
+fn hardenPrivateDir(path: []const u8) !void {
+    if (builtin.os.tag == .windows) return;
+    try std.posix.fchmodat(std.posix.AT.FDCWD, path, 0o700, 0);
 }
 
 pub fn registryPath(allocator: std.mem.Allocator, codex_home: []const u8) ![]u8 {
@@ -422,6 +437,14 @@ pub fn activeAuthPath(allocator: std.mem.Allocator, codex_home: []const u8) ![]u
 
 pub fn copyFile(src: []const u8, dest: []const u8) !void {
     try std.fs.cwd().copyFile(src, std.fs.cwd(), dest, .{});
+}
+
+pub fn copyManagedFile(src: []const u8, dest: []const u8) !void {
+    if (builtin.os.tag == .windows) {
+        try copyFile(src, dest);
+        return;
+    }
+    try std.fs.cwd().copyFile(src, std.fs.cwd(), dest, .{ .override_mode = 0o600 });
 }
 
 fn writeFile(path: []const u8, data: []const u8) !void {

--- a/src/registry.zig
+++ b/src/registry.zig
@@ -366,6 +366,8 @@ pub fn ensureAccountsDir(allocator: std.mem.Allocator, codex_home: []const u8) !
 }
 
 pub fn ensurePrivateDir(path: []const u8) !void {
+    // makePath can create the leaf with the process umask before chmod.
+    // Callers do not write sensitive data until hardenPrivateDir returns.
     try std.fs.cwd().makePath(path);
     try hardenPrivateDir(path);
 }

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -322,6 +322,8 @@ fn runCliWithIsolatedHomePathAndTmpDir(
     try env_map.put("USERPROFILE", home_root);
     env_map.remove("CODEX_HOME");
     try env_map.put("PATH", path_override);
+    try env_map.put("TEMP", tmpdir);
+    try env_map.put("TMP", tmpdir);
     try env_map.put("TMPDIR", tmpdir);
     try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
     try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -300,43 +300,6 @@ fn runCliWithIsolatedHomeAndPath(
     });
 }
 
-fn runCliWithIsolatedHomePathAndTmpDir(
-    allocator: std.mem.Allocator,
-    project_root: []const u8,
-    home_root: []const u8,
-    path_override: []const u8,
-    tmpdir: []const u8,
-    args: []const []const u8,
-) !std.process.Child.RunResult {
-    const exe_path = try builtCliPathAlloc(allocator, project_root);
-    defer allocator.free(exe_path);
-
-    var argv = std.ArrayList([]const u8).empty;
-    defer argv.deinit(allocator);
-    try argv.append(allocator, exe_path);
-    try argv.appendSlice(allocator, args);
-
-    var env_map = try std.process.getEnvMap(allocator);
-    defer env_map.deinit();
-    try env_map.put("HOME", home_root);
-    try env_map.put("USERPROFILE", home_root);
-    env_map.remove("CODEX_HOME");
-    try env_map.put("PATH", path_override);
-    try env_map.put("TEMP", tmpdir);
-    try env_map.put("TMP", tmpdir);
-    try env_map.put("TMPDIR", tmpdir);
-    try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
-    try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
-
-    return try std.process.Child.run(.{
-        .allocator = allocator,
-        .argv = argv.items,
-        .cwd = project_root,
-        .env_map = &env_map,
-        .max_output_bytes = 1024 * 1024,
-    });
-}
-
 fn runCliWithIsolatedHomeAndStdin(
     allocator: std.mem.Allocator,
     project_root: []const u8,
@@ -681,7 +644,7 @@ test "Scenario: Given existing active auth when login succeeds then upstream log
     try std.testing.expectEqualStrings(existing_auth, existing_snapshot_data);
 }
 
-test "Scenario: Given missing temp root when running login then it creates a temporary Codex home" {
+test "Scenario: Given login when running codex login then scratch home is under accounts cache" {
     const gpa = std.testing.allocator;
     const project_root = try projectRootAlloc(gpa);
     defer gpa.free(project_root);
@@ -694,9 +657,6 @@ test "Scenario: Given missing temp root when running login then it creates a tem
     defer gpa.free(home_root);
     try tmp.dir.makePath("fake-bin");
 
-    const missing_temp_root = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "missing-temp-root" });
-    defer gpa.free(missing_temp_root);
-
     const expected_email = "new-login@example.com";
     const fake_auth = try bdd.authJsonWithEmailPlan(gpa, expected_email, "pro");
     defer gpa.free(fake_auth);
@@ -708,12 +668,11 @@ test "Scenario: Given missing temp root when running login then it creates a tem
     const path_override = try prependPathEntryAlloc(gpa, fake_bin_path);
     defer gpa.free(path_override);
 
-    const result = try runCliWithIsolatedHomePathAndTmpDir(
+    const result = try runCliWithIsolatedHomeAndPath(
         gpa,
         project_root,
         home_root,
         path_override,
-        missing_temp_root,
         &[_][]const u8{ "login", "--device-auth" },
     );
     defer gpa.free(result.stdout);
@@ -726,12 +685,15 @@ test "Scenario: Given missing temp root when running login then it creates a tem
     const fake_codex_home_data = try bdd.readFileAlloc(gpa, fake_codex_home_path);
     defer gpa.free(fake_codex_home_data);
     const fake_codex_home = std.mem.trim(u8, fake_codex_home_data, " \r\n");
-    try std.testing.expect(std.mem.startsWith(u8, fake_codex_home, missing_temp_root));
-    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "codex-auth-login-") != null);
-    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(fake_codex_home, .{}));
 
     const codex_home = try codexHomeAlloc(gpa, home_root);
     defer gpa.free(codex_home);
+    const accounts_dir = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "accounts" });
+    defer gpa.free(accounts_dir);
+    try std.testing.expect(std.mem.startsWith(u8, fake_codex_home, accounts_dir));
+    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "login-") != null);
+    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(fake_codex_home, .{}));
+
     var loaded = try registry.loadRegistry(gpa, codex_home);
     defer loaded.deinit(gpa);
     try std.testing.expectEqual(@as(usize, 1), loaded.accounts.items.len);

--- a/src/tests/e2e_cli_test.zig
+++ b/src/tests/e2e_cli_test.zig
@@ -109,6 +109,7 @@ fn writeSuccessfulFakeCodex(dir: std.fs.Dir) !void {
         if (builtin.os.tag == .windows)
             "@echo off\r\n" ++
                 ">\"%HOME%\\fake-codex-argv.txt\" echo %*\r\n" ++
+                ">\"%HOME%\\fake-codex-home.txt\" echo %CODEX_HOME%\r\n" ++
                 "set \"CODEX_HOME_DIR=%CODEX_HOME%\"\r\n" ++
                 "if \"%CODEX_HOME_DIR%\"==\"\" set \"CODEX_HOME_DIR=%HOME%\\.codex\"\r\n" ++
                 "if not exist \"%CODEX_HOME_DIR%\" mkdir \"%CODEX_HOME_DIR%\"\r\n" ++
@@ -117,8 +118,38 @@ fn writeSuccessfulFakeCodex(dir: std.fs.Dir) !void {
         else
             "#!/bin/sh\n" ++
                 "printf '%s\\n' \"$*\" > \"$HOME/fake-codex-argv.txt\"\n" ++
+                "printf '%s\\n' \"$CODEX_HOME\" > \"$HOME/fake-codex-home.txt\"\n" ++
                 "CODEX_HOME_DIR=\"${CODEX_HOME:-$HOME/.codex}\"\n" ++
                 "mkdir -p \"$CODEX_HOME_DIR\"\n" ++
+                "cp \"$HOME/fake-auth.json\" \"$CODEX_HOME_DIR/auth.json\"\n" ++
+                "exit 0\n";
+    const sub_path = fakeCodexCommandPath();
+    try dir.writeFile(.{ .sub_path = sub_path, .data = script });
+
+    if (builtin.os.tag != .windows) {
+        var file = try dir.openFile(sub_path, .{ .mode = .read_write });
+        defer file.close();
+        try file.chmod(0o755);
+    }
+}
+
+fn writeStrictExistingCodexHomeFakeCodex(dir: std.fs.Dir) !void {
+    const script =
+        if (builtin.os.tag == .windows)
+            "@echo off\r\n" ++
+                ">\"%HOME%\\fake-codex-argv.txt\" echo %*\r\n" ++
+                ">\"%HOME%\\fake-codex-home.txt\" echo %CODEX_HOME%\r\n" ++
+                "set \"CODEX_HOME_DIR=%CODEX_HOME%\"\r\n" ++
+                "if \"%CODEX_HOME_DIR%\"==\"\" set \"CODEX_HOME_DIR=%HOME%\\.codex\"\r\n" ++
+                "if not exist \"%CODEX_HOME_DIR%\" exit /b 42\r\n" ++
+                "copy /Y \"%HOME%\\fake-auth.json\" \"%CODEX_HOME_DIR%\\auth.json\" >NUL\r\n" ++
+                "exit /b 0\r\n"
+        else
+            "#!/bin/sh\n" ++
+                "printf '%s\\n' \"$*\" > \"$HOME/fake-codex-argv.txt\"\n" ++
+                "printf '%s\\n' \"$CODEX_HOME\" > \"$HOME/fake-codex-home.txt\"\n" ++
+                "CODEX_HOME_DIR=\"${CODEX_HOME:-$HOME/.codex}\"\n" ++
+                "[ -d \"$CODEX_HOME_DIR\" ] || exit 42\n" ++
                 "cp \"$HOME/fake-auth.json\" \"$CODEX_HOME_DIR/auth.json\"\n" ++
                 "exit 0\n";
     const sub_path = fakeCodexCommandPath();
@@ -257,6 +288,41 @@ fn runCliWithIsolatedHomeAndPath(
     try env_map.put("USERPROFILE", home_root);
     env_map.remove("CODEX_HOME");
     try env_map.put("PATH", path_override);
+    try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
+    try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
+
+    return try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv.items,
+        .cwd = project_root,
+        .env_map = &env_map,
+        .max_output_bytes = 1024 * 1024,
+    });
+}
+
+fn runCliWithIsolatedHomePathAndTmpDir(
+    allocator: std.mem.Allocator,
+    project_root: []const u8,
+    home_root: []const u8,
+    path_override: []const u8,
+    tmpdir: []const u8,
+    args: []const []const u8,
+) !std.process.Child.RunResult {
+    const exe_path = try builtCliPathAlloc(allocator, project_root);
+    defer allocator.free(exe_path);
+
+    var argv = std.ArrayList([]const u8).empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, exe_path);
+    try argv.appendSlice(allocator, args);
+
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("HOME", home_root);
+    try env_map.put("USERPROFILE", home_root);
+    env_map.remove("CODEX_HOME");
+    try env_map.put("PATH", path_override);
+    try env_map.put("TMPDIR", tmpdir);
     try env_map.put("CODEX_AUTH_SKIP_SERVICE_RECONCILE", "1");
     try env_map.put("CODEX_AUTH_DISABLE_BACKGROUND_ACCOUNT_NAME_REFRESH", "1");
 
@@ -433,7 +499,7 @@ test "Scenario: Given device auth login when running login then it forwards the 
     const fake_auth = try bdd.authJsonWithEmailPlan(gpa, expected_email, "plus");
     defer gpa.free(fake_auth);
     try tmp.dir.writeFile(.{ .sub_path = "fake-auth.json", .data = fake_auth });
-    try writeSuccessfulFakeCodex(tmp.dir);
+    try writeStrictExistingCodexHomeFakeCodex(tmp.dir);
 
     const fake_bin_path = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "fake-bin" });
     defer gpa.free(fake_bin_path);
@@ -506,7 +572,7 @@ test "Scenario: Given CODEX_HOME override when running login then it stores auth
     const fake_auth = try bdd.authJsonWithEmailPlan(gpa, expected_email, "plus");
     defer gpa.free(fake_auth);
     try tmp.dir.writeFile(.{ .sub_path = "fake-auth.json", .data = fake_auth });
-    try writeSuccessfulFakeCodex(tmp.dir);
+    try writeStrictExistingCodexHomeFakeCodex(tmp.dir);
 
     const fake_bin_path = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "fake-bin" });
     defer gpa.free(fake_bin_path);
@@ -562,7 +628,7 @@ test "Scenario: Given existing active auth when login succeeds then upstream log
     const fake_auth = try bdd.authJsonWithEmailPlan(gpa, expected_email, "pro");
     defer gpa.free(fake_auth);
     try tmp.dir.writeFile(.{ .sub_path = "fake-auth.json", .data = fake_auth });
-    try writeSuccessfulFakeCodex(tmp.dir);
+    try writeStrictExistingCodexHomeFakeCodex(tmp.dir);
 
     const fake_bin_path = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "fake-bin" });
     defer gpa.free(fake_bin_path);
@@ -611,6 +677,63 @@ test "Scenario: Given existing active auth when login succeeds then upstream log
     const existing_snapshot_data = try bdd.readFileAlloc(gpa, existing_snapshot_path);
     defer gpa.free(existing_snapshot_data);
     try std.testing.expectEqualStrings(existing_auth, existing_snapshot_data);
+}
+
+test "Scenario: Given missing temp root when running login then it creates a temporary Codex home" {
+    const gpa = std.testing.allocator;
+    const project_root = try projectRootAlloc(gpa);
+    defer gpa.free(project_root);
+    try buildCliBinary(gpa, project_root);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const home_root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(home_root);
+    try tmp.dir.makePath("fake-bin");
+
+    const missing_temp_root = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "missing-temp-root" });
+    defer gpa.free(missing_temp_root);
+
+    const expected_email = "new-login@example.com";
+    const fake_auth = try bdd.authJsonWithEmailPlan(gpa, expected_email, "pro");
+    defer gpa.free(fake_auth);
+    try tmp.dir.writeFile(.{ .sub_path = "fake-auth.json", .data = fake_auth });
+    try writeStrictExistingCodexHomeFakeCodex(tmp.dir);
+
+    const fake_bin_path = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "fake-bin" });
+    defer gpa.free(fake_bin_path);
+    const path_override = try prependPathEntryAlloc(gpa, fake_bin_path);
+    defer gpa.free(path_override);
+
+    const result = try runCliWithIsolatedHomePathAndTmpDir(
+        gpa,
+        project_root,
+        home_root,
+        path_override,
+        missing_temp_root,
+        &[_][]const u8{ "login", "--device-auth" },
+    );
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try expectSuccess(result);
+
+    const fake_codex_home_path = try std.fs.path.join(gpa, &[_][]const u8{ home_root, "fake-codex-home.txt" });
+    defer gpa.free(fake_codex_home_path);
+    const fake_codex_home_data = try bdd.readFileAlloc(gpa, fake_codex_home_path);
+    defer gpa.free(fake_codex_home_data);
+    const fake_codex_home = std.mem.trim(u8, fake_codex_home_data, " \r\n");
+    try std.testing.expect(std.mem.startsWith(u8, fake_codex_home, missing_temp_root));
+    try std.testing.expect(std.mem.indexOf(u8, fake_codex_home, "codex-auth-login-") != null);
+    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(fake_codex_home, .{}));
+
+    const codex_home = try codexHomeAlloc(gpa, home_root);
+    defer gpa.free(codex_home);
+    var loaded = try registry.loadRegistry(gpa, codex_home);
+    defer loaded.deinit(gpa);
+    try std.testing.expectEqual(@as(usize, 1), loaded.accounts.items.len);
+    try std.testing.expectEqualStrings(expected_email, loaded.accounts.items[0].email);
 }
 
 test "Scenario: Given failed device auth login with existing auth json when running login then it forwards the flag and does not mutate the registry" {

--- a/src/tests/registry_test.zig
+++ b/src/tests/registry_test.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const account_api = @import("../account_api.zig");
 const registry = @import("../registry.zig");
 const bdd = @import("bdd_helpers.zig");
@@ -79,6 +80,12 @@ fn legacySnapshotRelPath(allocator: std.mem.Allocator, email: []const u8) ![]u8 
     const filename = try std.fmt.allocPrint(allocator, "{s}.auth.json", .{key});
     defer allocator.free(filename);
     return try std.fs.path.join(allocator, &[_][]const u8{ "accounts", filename });
+}
+
+fn expectPathMode(path: []const u8, expected: std.fs.File.Mode) !void {
+    if (builtin.os.tag == .windows) return;
+    const stat = try std.fs.cwd().statFile(path);
+    try std.testing.expectEqual(expected, stat.mode & 0o777);
 }
 
 fn makeEmptyRegistry() registry.Registry {
@@ -199,6 +206,44 @@ test "resolveCodexHomeFromEnv falls back to USERPROFILE when HOME is unset" {
     defer gpa.free(expected);
 
     try std.testing.expectEqualStrings(expected, resolved);
+}
+
+test "ensureAccountsDir creates private accounts directory" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+
+    try registry.ensureAccountsDir(gpa, codex_home);
+
+    const accounts_dir = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "accounts" });
+    defer gpa.free(accounts_dir);
+    try expectPathMode(accounts_dir, 0o700);
+}
+
+test "copyManagedFile writes private auth file" {
+    const gpa = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex_home = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(codex_home);
+    try registry.ensureAccountsDir(gpa, codex_home);
+
+    const src = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "source-auth.json" });
+    defer gpa.free(src);
+    try tmp.dir.writeFile(.{ .sub_path = "source-auth.json", .data = "{\"tokens\":{}}" });
+
+    const dest = try std.fs.path.join(gpa, &[_][]const u8{ codex_home, "accounts", "managed.auth.json" });
+    defer gpa.free(dest);
+    try registry.copyManagedFile(src, dest);
+
+    try expectPathMode(dest, 0o600);
+    const copied = try bdd.readFileAlloc(gpa, dest);
+    defer gpa.free(copied);
+    try std.testing.expectEqualStrings("{\"tokens\":{}}", copied);
 }
 
 fn setRecordIds(


### PR DESCRIPTION
## Summary
- create the isolated login CODEX_HOME under the target Codex home accounts cache
- create that scratch home before launching upstream codex login
- make login integration fakes fail when scratch CODEX_HOME is missing before launch

## Validation
- git diff --check

Closes #131 #132