### PR TITLE
fix(registry): create private dirs with restrictive mode

### DIFF
--- a/src/registry/common.zig
+++ b/src/registry/common.zig
@@ -402,7 +402,7 @@ pub fn hardenSensitiveDir(path: []const u8) !void {
 }
 
 pub fn ensurePrivateDir(path: []const u8) !void {
-    try std.Io.Dir.cwd().createDirPath(app_runtime.io(), path);
+    _ = try std.Io.Dir.cwd().createDirPathStatus(app_runtime.io(), path, private_dir_permissions);
     try hardenSensitiveDir(path);
 }
 

--- a/src/registry/common.zig
+++ b/src/registry/common.zig
@@ -402,6 +402,7 @@ pub fn hardenSensitiveDir(path: []const u8) !void {
 }
 
 pub fn ensurePrivateDir(path: []const u8) !void {
+    // Ignore created/existed status; existing dirs are hardened below too.
     _ = try std.Io.Dir.cwd().createDirPathStatus(app_runtime.io(), path, private_dir_permissions);
     try hardenSensitiveDir(path);
 }


### PR DESCRIPTION
## Summary
- create private directories with restrictive permissions at mkdir time
- keep the existing hardening pass for already-existing directories

## Tests
- zig build run -- list
- zig build test