### PR TITLE
feat: support MiniMax API key accounts

### DIFF
--- a/docs/implement.md
+++ b/docs/implement.md
@@ -68,6 +68,12 @@ For OpenAI API-key auth:
 - The raw API key is stored only in the managed auth snapshot, never in `registry.json`, snapshot filenames, or display labels.
 - API-key rows use a local `API key <fingerprint>` account label so multiple keys under the same email remain distinguishable.
 
+For MiniMax API-key auth:
+
+- `auth.json` includes `OPENAI_BASE_URL` set to `https://api.minimax.io/v1` or `https://api.minimaxi.com/v1`.
+- The key is verified with `GET <OPENAI_BASE_URL>/models` because MiniMax does not provide `/v1/me`.
+- The service host is used as the display/grouping label, while the key fingerprint remains the local account discriminator.
+
 ## Auth Parsing
 
 If `OPENAI_API_KEY` is present, the account is treated as API-key auth. Otherwise, ChatGPT auth requires:

--- a/src/api/me.zig
+++ b/src/api/me.zig
@@ -2,6 +2,26 @@ const std = @import("std");
 const http = @import("http.zig");
 
 pub const default_me_endpoint = "https://api.openai.com/v1/me";
+pub const mini_max_global_base_url = "https://api.minimax.io/v1";
+pub const mini_max_china_base_url = "https://api.minimaxi.com/v1";
+
+const MiniMaxProfile = struct {
+    models_endpoint: []const u8,
+    user_id: []const u8,
+    account_label: []const u8,
+};
+
+const mini_max_global_profile = MiniMaxProfile{
+    .models_endpoint = "https://api.minimax.io/v1/models",
+    .user_id = "minimax-global",
+    .account_label = "api.minimax.io",
+};
+
+const mini_max_china_profile = MiniMaxProfile{
+    .models_endpoint = "https://api.minimaxi.com/v1/models",
+    .user_id = "minimax-china",
+    .account_label = "api.minimaxi.com",
+};
 
 pub const MeResult = struct {
     user_id: []u8,
@@ -17,6 +37,63 @@ pub const MeResult = struct {
 
 pub fn fetchMeForApiKey(allocator: std.mem.Allocator, api_key: []const u8) !MeResult {
     return fetchMeForApiKeyFromEndpoint(allocator, default_me_endpoint, api_key);
+}
+
+pub fn fetchMeForApiKeyWithBaseUrl(
+    allocator: std.mem.Allocator,
+    api_key: []const u8,
+    base_url: ?[]const u8,
+) !MeResult {
+    const profile = miniMaxProfile(base_url orelse return fetchMeForApiKey(allocator, api_key)) orelse
+        return fetchMeForApiKey(allocator, api_key);
+    const http_result = try http.runBearerGetJsonCommand(allocator, profile.models_endpoint, api_key);
+    defer allocator.free(http_result.body);
+
+    if (http_result.status_code) |status| {
+        if (status < 200 or status > 299) return error.MiniMaxModelsRequestFailed;
+    }
+    if (http_result.body.len == 0) return error.MiniMaxModelsRequestFailed;
+    try parseMiniMaxModelsResponse(allocator, http_result.body);
+
+    const owned_user_id = try allocator.dupe(u8, profile.user_id);
+    errdefer allocator.free(owned_user_id);
+    const owned_account_label = try allocator.dupe(u8, profile.account_label);
+    errdefer allocator.free(owned_account_label);
+    const owned_name = try allocator.dupe(u8, "MiniMax");
+    errdefer allocator.free(owned_name);
+
+    return .{
+        .user_id = owned_user_id,
+        .email = owned_account_label,
+        .name = owned_name,
+    };
+}
+
+pub fn miniMaxModelsEndpoint(base_url: []const u8) ?[]const u8 {
+    const profile = miniMaxProfile(base_url) orelse return null;
+    return profile.models_endpoint;
+}
+
+pub fn parseMiniMaxModelsResponse(allocator: std.mem.Allocator, body: []const u8) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |value| value,
+        else => return error.InvalidMiniMaxModelsResponse,
+    };
+    const models = switch (obj.get("data") orelse return error.InvalidMiniMaxModelsResponse) {
+        .array => |value| value,
+        else => return error.InvalidMiniMaxModelsResponse,
+    };
+    for (models.items) |model| {
+        const model_obj = switch (model) {
+            .object => |value| value,
+            else => continue,
+        };
+        if (nonEmptyStringField(model_obj, "id") != null) return;
+    }
+    return error.InvalidMiniMaxModelsResponse;
 }
 
 pub fn fetchMeForApiKeyFromEndpoint(
@@ -78,4 +155,12 @@ fn normalizeEmailAlloc(allocator: std.mem.Allocator, email: []const u8) ![]u8 {
         buf[i] = std.ascii.toLower(ch);
     }
     return buf;
+}
+
+fn miniMaxProfile(base_url: []const u8) ?MiniMaxProfile {
+    const trimmed = std.mem.trim(u8, base_url, &std.ascii.whitespace);
+    const normalized = std.mem.trimEnd(u8, trimmed, "/");
+    if (std.mem.eql(u8, normalized, mini_max_global_base_url)) return mini_max_global_profile;
+    if (std.mem.eql(u8, normalized, mini_max_china_base_url)) return mini_max_china_profile;
+    return null;
 }

--- a/src/auth/auth.zig
+++ b/src/auth/auth.zig
@@ -9,6 +9,7 @@ pub const AuthInfo = struct {
     record_key: ?[]u8,
     access_token: ?[]u8,
     openai_api_key: ?[]u8 = null,
+    openai_base_url: ?[]u8 = null,
     last_refresh: ?[]u8,
     plan: ?registry.PlanType,
     auth_mode: registry.AuthMode,
@@ -20,6 +21,7 @@ pub const AuthInfo = struct {
         if (self.record_key) |key| allocator.free(key);
         if (self.access_token) |token| allocator.free(token);
         if (self.openai_api_key) |key| allocator.free(key);
+        if (self.openai_base_url) |url| allocator.free(url);
         if (self.last_refresh) |value| allocator.free(value);
     }
 };
@@ -82,17 +84,29 @@ pub fn parseAuthInfoData(allocator: std.mem.Allocator, data: []const u8) !AuthIn
                 switch (key_val) {
                     .string => |s| {
                         const trimmed = std.mem.trim(u8, s, &std.ascii.whitespace);
-                        if (trimmed.len > 0) return AuthInfo{
-                            .email = null,
-                            .chatgpt_account_id = null,
-                            .chatgpt_user_id = null,
-                            .record_key = null,
-                            .access_token = null,
-                            .openai_api_key = try allocator.dupe(u8, trimmed),
-                            .last_refresh = null,
-                            .plan = null,
-                            .auth_mode = .apikey,
-                        };
+                        if (trimmed.len > 0) {
+                            const base_url = if (obj.get("OPENAI_BASE_URL")) |url_val| switch (url_val) {
+                                .string => |url| blk: {
+                                    const trimmed_url = std.mem.trim(u8, url, &std.ascii.whitespace);
+                                    break :blk if (trimmed_url.len > 0) try allocator.dupe(u8, trimmed_url) else null;
+                                },
+                                else => null,
+                            } else null;
+                            errdefer if (base_url) |url| allocator.free(url);
+
+                            return AuthInfo{
+                                .email = null,
+                                .chatgpt_account_id = null,
+                                .chatgpt_user_id = null,
+                                .record_key = null,
+                                .access_token = null,
+                                .openai_api_key = try allocator.dupe(u8, trimmed),
+                                .openai_base_url = base_url,
+                                .last_refresh = null,
+                                .plan = null,
+                                .auth_mode = .apikey,
+                            };
+                        }
                     },
                     else => {},
                 }

--- a/src/registry/account_ops.zig
+++ b/src/registry/account_ops.zig
@@ -220,7 +220,7 @@ fn syncActiveApiKeyAccountFromAuth(
         std.log.warn("auth.json missing OPENAI_API_KEY; skipping sync", .{});
         return false;
     };
-    var me = me_api.fetchMeForApiKey(allocator, api_key) catch |err| switch (err) {
+    var me = me_api.fetchMeForApiKeyWithBaseUrl(allocator, api_key, info.openai_base_url) catch |err| switch (err) {
         error.OutOfMemory => return err,
         else => {
             std.log.warn("auth.json API key sync skipped: {s}", .{@errorName(err)});

--- a/src/registry/import.zig
+++ b/src/registry/import.zig
@@ -402,7 +402,7 @@ fn importApiKeyAuthData(
     auth_data: []const u8,
 ) !ImportOutcome {
     const api_key = info.openai_api_key orelse return error.MissingOpenAIAPIKey;
-    var me = try me_api.fetchMeForApiKey(allocator, api_key);
+    var me = try me_api.fetchMeForApiKeyWithBaseUrl(allocator, api_key, info.openai_base_url);
     defer me.deinit(allocator);
 
     const record_key = try account_ops.apiKeyAccountKeyAlloc(allocator, me.user_id, api_key);
@@ -430,7 +430,7 @@ fn importApiKeyAuthFile(
     info: *const @import("../auth/auth.zig").AuthInfo,
 ) !ImportOutcome {
     const api_key = info.openai_api_key orelse return error.MissingOpenAIAPIKey;
-    var me = try me_api.fetchMeForApiKey(allocator, api_key);
+    var me = try me_api.fetchMeForApiKeyWithBaseUrl(allocator, api_key, info.openai_base_url);
     defer me.deinit(allocator);
 
     const record_key = try account_ops.apiKeyAccountKeyAlloc(allocator, me.user_id, api_key);
@@ -628,7 +628,7 @@ fn syncCurrentApiKeyAuthBestEffort(
     info: *const @import("../auth/auth.zig").AuthInfo,
 ) !?ImportOutcome {
     const api_key = info.openai_api_key orelse return null;
-    var me = me_api.fetchMeForApiKey(allocator, api_key) catch return null;
+    var me = me_api.fetchMeForApiKeyWithBaseUrl(allocator, api_key, info.openai_base_url) catch return null;
     defer me.deinit(allocator);
 
     const record_key = try account_ops.apiKeyAccountKeyAlloc(allocator, me.user_id, api_key);

--- a/src/registry/import_helpers.zig
+++ b/src/registry/import_helpers.zig
@@ -33,6 +33,8 @@ pub fn isImportValidationError(err: anyerror) bool {
         error.MissingOpenAIUserId,
         error.InvalidOpenAIMeResponse,
         error.OpenAIMeRequestFailed,
+        error.InvalidMiniMaxModelsResponse,
+        error.MiniMaxModelsRequestFailed,
         error.MissingAccountId,
         error.MissingAccessToken,
         error.MissingIdToken,

--- a/src/registry/root.zig
+++ b/src/registry/root.zig
@@ -165,7 +165,7 @@ pub fn autoImportActiveAuth(allocator: std.mem.Allocator, codex_home: []const u8
     defer info.deinit(allocator);
     if (info.auth_mode == .apikey) {
         const api_key = info.openai_api_key orelse return false;
-        var me = me_api.fetchMeForApiKey(allocator, api_key) catch |err| switch (err) {
+        var me = me_api.fetchMeForApiKeyWithBaseUrl(allocator, api_key, info.openai_base_url) catch |err| switch (err) {
             error.OutOfMemory => return err,
             else => {
                 std.log.warn("auth.json API key import skipped: {s}", .{@errorName(err)});

--- a/src/workflows/login.zig
+++ b/src/workflows/login.zig
@@ -42,7 +42,7 @@ pub fn handleLogin(allocator: std.mem.Allocator, codex_home: []const u8, opts: c
 
     if (info.auth_mode == .apikey) {
         const api_key = info.openai_api_key orelse return error.MissingOpenAIAPIKey;
-        var me = try me_api.fetchMeForApiKey(allocator, api_key);
+        var me = try me_api.fetchMeForApiKeyWithBaseUrl(allocator, api_key, info.openai_base_url);
         defer me.deinit(allocator);
 
         const record_key = try registry.apiKeyAccountKeyAlloc(allocator, me.user_id, api_key);

--- a/tests/api_me_test.zig
+++ b/tests/api_me_test.zig
@@ -23,6 +23,30 @@ test "parse OpenAI me response normalizes identity metadata" {
     try std.testing.expectEqualStrings("User Example", me.name.?);
 }
 
+test "MiniMax API key base URLs use the models endpoint" {
+    try std.testing.expectEqualStrings(
+        "https://api.minimax.io/v1/models",
+        me_api.miniMaxModelsEndpoint("https://api.minimax.io/v1").?,
+    );
+    try std.testing.expectEqualStrings(
+        "https://api.minimaxi.com/v1/models",
+        me_api.miniMaxModelsEndpoint(" https://api.minimaxi.com/v1/ ").?,
+    );
+    try std.testing.expect(me_api.miniMaxModelsEndpoint("https://example.com/v1") == null);
+}
+
+test "parse MiniMax models response accepts an OpenAI-compatible model list" {
+    const gpa = std.testing.allocator;
+    try me_api.parseMiniMaxModelsResponse(
+        gpa,
+        "{\"object\":\"list\",\"data\":[{\"id\":\"MiniMax-M3\",\"object\":\"model\"}]}",
+    );
+    try std.testing.expectError(
+        error.InvalidMiniMaxModelsResponse,
+        me_api.parseMiniMaxModelsResponse(gpa, "{\"object\":\"list\",\"data\":{}}"),
+    );
+}
+
 test "API key account key includes user id and stable key fingerprint" {
     const gpa = std.testing.allocator;
 

--- a/tests/auth_test.zig
+++ b/tests/auth_test.zig
@@ -105,6 +105,17 @@ test "api key auth" {
     try std.testing.expect(info.auth_mode == .apikey);
 }
 
+test "API key auth preserves an explicit MiniMax base URL" {
+    const gpa = std.testing.allocator;
+    const info = try auth.parseAuthInfoData(
+        gpa,
+        "{\"OPENAI_API_KEY\":\"sk-test\",\"OPENAI_BASE_URL\":\"  https://api.minimax.io/v1/  \"}",
+    );
+    defer info.deinit(gpa);
+
+    try std.testing.expectEqualStrings("https://api.minimax.io/v1/", info.openai_base_url.?);
+}
+
 test "parse auth info does not leak duplicated tokens when id token is missing" {
     const gpa = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
Reason: MiniMax API-key accounts always call the `/v1/me` endpoint, so their keys cannot use the configured MiniMax base URL.

- Preserve an explicit MiniMax `OPENAI_BASE_URL` from API-key auth snapshots.
- Validate global and China MiniMax keys through their OpenAI-compatible `/models` endpoints.
- Use region-stable account identity metadata without persisting raw API keys.
- Document the MiniMax API-key validation behavior.

Checks:

- `zig fmt src/auth/auth.zig src/api/me.zig src/registry/root.zig src/registry/account_ops.zig src/registry/import.zig src/registry/import_helpers.zig src/workflows/login.zig tests/api_me_test.zig tests/auth_test.zig`
- `zig test -ODebug --dep codex_auth -Mroot=tests/api_me_test.zig -ODebug -Mcodex_auth=src/root.zig -lc --cache-dir <isolated-cache>`
- `zig test -ODebug --dep codex_auth -Mroot=tests/auth_test.zig -ODebug -Mcodex_auth=src/root.zig -lc --cache-dir <isolated-cache>`
- `zig test -ODebug --dep codex_auth -Mroot=tests/api_http_test.zig -ODebug -Mcodex_auth=src/root.zig -lc --cache-dir <isolated-cache>`
- `zig build --build-file <repo>/build.zig --cache-dir <isolated-cache> run -- list`
- `git diff --check`

The full isolated test suite compiled and passed 432 tests with 8 skipped; its only failure was the pre-existing timing-sensitive partial-output timeout test, which passed when rerun directly.
