### PR TITLE
feat: display credits balance in list

### DIFF
--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -17,7 +17,7 @@ codex-auth list --json
 - Syncs the current `auth.json` into the registry before rendering when the current auth file is parseable.
 - Shows selectable row numbers using the same ordering as `switch` and `remove`.
 - Groups rows by email when the same email owns multiple account snapshots.
-- Non-live output shows `ACCOUNT`, `PLAN`, `RESET CREDITS`, `5H`, `WEEKLY`, and `LAST ACTIVITY`.
+- Non-live output shows `ACCOUNT`, `PLAN`, `CREDITS`, `RESET CREDITS`, `5H`, `WEEKLY`, and `LAST ACTIVITY`.
 
 ## Refresh Modes
 
@@ -36,7 +36,8 @@ When local-only refresh is active, only the active account can be updated from l
 - Singleton rows with both alias and account name render as `alias(account name, email)`.
 - Grouped rows keep the shared email in the header; child rows with both alias and account name render as `alias(account name)`.
 - Usage cells show remaining percent and reset time when that data is known.
-- In non-live output, `RESET CREDITS` shows the stored reset-credit count when remote usage refresh provides it.
+- In non-live output, `CREDITS` shows the integer part of the current `credits.balance` value.
+- `RESET CREDITS` remains a separate field that shows the stored reset-credit count when remote usage refresh provides it.
 - Remote refresh failures can render row overlays such as `401`, `403`, `TimedOut`, or `MissingAuth`.
 - `LAST ACTIVITY` is based on the last stored usage update time.
 - `--json` returns accounts in the same display order and includes the same row numbers shown by the table.

--- a/src/api/usage.zig
+++ b/src/api/usage.zig
@@ -249,7 +249,7 @@ fn codeFromNestedObject(root_obj: std.json.ObjectMap, key: []const u8) ?[]const 
 }
 
 pub fn parseUsageResponse(allocator: std.mem.Allocator, body: []const u8) !?registry.RateLimitSnapshot {
-    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{ .parse_numbers = false });
     defer parsed.deinit();
 
     const root_obj = switch (parsed.value) {
@@ -288,7 +288,8 @@ pub fn parseUsageResponse(allocator: std.mem.Allocator, body: []const u8) !?regi
         }
     }
 
-    if (snapshot.primary == null and snapshot.secondary == null and snapshot.reset_credits == null) {
+    const has_credit_balance = if (snapshot.credits) |credits| credits.balance != null else false;
+    if (snapshot.primary == null and snapshot.secondary == null and snapshot.reset_credits == null and !has_credit_balance) {
         if (snapshot.credits) |*credits| {
             if (credits.balance) |balance| allocator.free(balance);
         }
@@ -303,10 +304,7 @@ fn parseResetCredits(v: std.json.Value) ?i64 {
         .object => |o| o,
         else => return null,
     };
-    return switch (obj.get("available_count") orelse return null) {
-        .integer => |i| i,
-        else => null,
-    };
+    return parseIntValue(obj.get("available_count") orelse return null);
 }
 
 fn parseWindow(v: std.json.Value) ?registry.RateLimitWindow {
@@ -315,23 +313,17 @@ fn parseWindow(v: std.json.Value) ?registry.RateLimitWindow {
         else => return null,
     };
 
-    const used_percent = if (obj.get("used_percent")) |used| switch (used) {
-        .float => |f| f,
-        .integer => |i| @as(f64, @floatFromInt(i)),
-        else => return null,
-    } else return null;
+    const used_percent = if (obj.get("used_percent")) |used| parseFloatValue(used) else null;
+    if (used_percent == null) return null;
 
-    const window_minutes = if (obj.get("limit_window_seconds")) |seconds| switch (seconds) {
-        .integer => |value| ceilMinutes(value),
-        else => null,
-    } else null;
-    const resets_at = if (obj.get("reset_at")) |reset_at| switch (reset_at) {
-        .integer => |value| value,
-        else => null,
-    } else null;
+    const window_minutes = if (obj.get("limit_window_seconds")) |seconds|
+        if (parseIntValue(seconds)) |value| ceilMinutes(value) else null
+    else
+        null;
+    const resets_at = if (obj.get("reset_at")) |reset_at| parseIntValue(reset_at) else null;
 
     return .{
-        .used_percent = used_percent,
+        .used_percent = used_percent.?,
         .window_minutes = window_minutes,
         .resets_at = resets_at,
     };
@@ -351,15 +343,40 @@ fn parseCredits(allocator: std.mem.Allocator, v: std.json.Value) !?registry.Cred
         .bool => |b| b,
         else => false,
     } else false;
-    const balance = if (obj.get("balance")) |value| switch (value) {
-        .string => |s| if (s.len == 0) null else try allocator.dupe(u8, s),
-        else => null,
-    } else null;
+    const balance = if (obj.get("balance")) |value| try parseBalance(allocator, value) else null;
 
     return .{
         .has_credits = has_credits,
         .unlimited = unlimited,
         .balance = balance,
+    };
+}
+
+fn parseBalance(allocator: std.mem.Allocator, value: std.json.Value) !?[]u8 {
+    return switch (value) {
+        .string => |s| if (s.len == 0) null else try allocator.dupe(u8, s),
+        .integer => |i| try std.fmt.allocPrint(allocator, "{d}", .{i}),
+        .float => |f| if (std.math.isFinite(f)) try std.fmt.allocPrint(allocator, "{d}", .{f}) else null,
+        .number_string => |s| if (s.len == 0) null else try allocator.dupe(u8, s),
+        else => null,
+    };
+}
+
+fn parseFloatValue(value: std.json.Value) ?f64 {
+    return switch (value) {
+        .float => |f| if (std.math.isFinite(f)) f else null,
+        .integer => |i| @as(f64, @floatFromInt(i)),
+        .number_string, .string => |s| std.fmt.parseFloat(f64, s) catch null,
+        else => null,
+    };
+}
+
+fn parseIntValue(value: std.json.Value) ?i64 {
+    return switch (value) {
+        .integer => |i| i,
+        .number_string, .string => |s| std.fmt.parseInt(i64, s, 10) catch null,
+        .float => |f| if (std.math.isFinite(f) and @floor(f) == f and f >= @as(f64, @floatFromInt(std.math.minInt(i64))) and f <= @as(f64, @floatFromInt(std.math.maxInt(i64)))) @as(i64, @intFromFloat(f)) else null,
+        else => null,
     };
 }
 

--- a/src/tui/table.zig
+++ b/src/tui/table.zig
@@ -76,6 +76,21 @@ fn usageCellFullTextAlloc(
     return formatRateLimitFullAlloc(window);
 }
 
+fn creditsCellAlloc(
+    allocator: std.mem.Allocator,
+    usage: ?registry.RateLimitSnapshot,
+    usage_override: ?[]const u8,
+) ![]u8 {
+    if (usage_override) |value| return allocator.dupe(u8, value);
+    if (usage) |snapshot| {
+        if (snapshot.credits) |credits| {
+            if (credits.balance) |balance| return integerCreditBalanceAlloc(allocator, balance);
+            if (credits.unlimited) return allocator.dupe(u8, "unlimited");
+        }
+    }
+    return allocator.dupe(u8, "-");
+}
+
 fn resetCreditsCellAlloc(
     allocator: std.mem.Allocator,
     usage: ?registry.RateLimitSnapshot,
@@ -86,13 +101,26 @@ fn resetCreditsCellAlloc(
     return if (count) |value| std.fmt.allocPrint(allocator, "{d}", .{value}) else allocator.dupe(u8, "-");
 }
 
+fn integerCreditBalanceAlloc(allocator: std.mem.Allocator, balance: []const u8) ![]u8 {
+    // Do not round up the displayed balance (for example, 5.99 remains 5).
+    const trimmed = std.mem.trim(u8, balance, " \t\r\n");
+    const dot = std.mem.indexOfScalar(u8, trimmed, '.') orelse return allocator.dupe(u8, trimmed);
+    const integer_part = trimmed[0..dot];
+    if (integer_part.len == 0 or
+        (integer_part.len == 1 and (integer_part[0] == '+' or integer_part[0] == '-')))
+    {
+        return allocator.dupe(u8, "0");
+    }
+    return allocator.dupe(u8, integer_part);
+}
+
 pub fn writeAccountsTableWithUsageOverrides(
     out: *std.Io.Writer,
     reg: *registry.Registry,
     use_color: bool,
     usage_overrides: ?[]const ?[]const u8,
 ) !void {
-    const headers = [_][]const u8{ "ACCOUNT", "PLAN", "RESET CREDITS", "5H", "WEEKLY", "LAST ACTIVITY" };
+    const headers = [_][]const u8{ "ACCOUNT", "PLAN", "CREDITS", "RESET CREDITS", "5H", "WEEKLY", "LAST ACTIVITY" };
     var widths = [_]usize{
         headers[0].len,
         headers[1].len,
@@ -100,6 +128,7 @@ pub fn writeAccountsTableWithUsageOverrides(
         headers[3].len,
         headers[4].len,
         headers[5].len,
+        headers[6].len,
     };
     const now = std.Io.Timestamp.now(app_runtime.io(), .real).toSeconds();
     var display = try display_rows.buildDisplayRows(std.heap.page_allocator, reg, null);
@@ -117,6 +146,8 @@ pub fn writeAccountsTableWithUsageOverrides(
             const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
             const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
             const usage_override = usageOverrideForAccount(usage_overrides, account_idx);
+            const credits_str = try creditsCellAlloc(std.heap.page_allocator, rec.last_usage, usage_override);
+            defer std.heap.page_allocator.free(credits_str);
             const reset_credits_str = try resetCreditsCellAlloc(std.heap.page_allocator, rec.last_usage, usage_override);
             defer std.heap.page_allocator.free(reset_credits_str);
             const rate_5h_str = try usageCellFullTextAlloc(std.heap.page_allocator, rate_5h, usage_override);
@@ -127,10 +158,11 @@ pub fn writeAccountsTableWithUsageOverrides(
             defer std.heap.page_allocator.free(last_str);
 
             widths[1] = @max(widths[1], plan.len);
-            widths[2] = @max(widths[2], reset_credits_str.len);
-            widths[3] = @max(widths[3], rate_5h_str.len);
-            widths[4] = @max(widths[4], rate_week_str.len);
-            widths[5] = @max(widths[5], last_str.len);
+            widths[2] = @max(widths[2], credits_str.len);
+            widths[3] = @max(widths[3], reset_credits_str.len);
+            widths[4] = @max(widths[4], rate_5h_str.len);
+            widths[5] = @max(widths[5], rate_week_str.len);
+            widths[6] = @max(widths[6], last_str.len);
         }
     }
 
@@ -144,12 +176,14 @@ pub fn writeAccountsTableWithUsageOverrides(
     defer std.heap.page_allocator.free(h2);
     const h3 = try truncateAlloc(headers[3], widths[3]);
     defer std.heap.page_allocator.free(h3);
-    const header_week = if (widths[4] >= "WEEKLY".len) "WEEKLY" else if (widths[4] >= "WEEK".len) "WEEK" else "W";
-    const h4 = try truncateAlloc(header_week, widths[4]);
+    const h4 = try truncateAlloc(headers[4], widths[4]);
     defer std.heap.page_allocator.free(h4);
-    const header_last = if (widths[5] >= "LAST ACTIVITY".len) "LAST ACTIVITY" else "LAST";
-    const h5 = try truncateAlloc(header_last, widths[5]);
+    const header_week = if (widths[5] >= "WEEKLY".len) "WEEKLY" else if (widths[5] >= "WEEK".len) "WEEK" else "W";
+    const h5 = try truncateAlloc(header_week, widths[5]);
     defer std.heap.page_allocator.free(h5);
+    const header_last = if (widths[6] >= "LAST ACTIVITY".len) "LAST ACTIVITY" else "LAST";
+    const h6 = try truncateAlloc(header_last, widths[6]);
+    defer std.heap.page_allocator.free(h6);
 
     if (use_color) try out.writeAll(ansi.cyan);
     try writeRepeat(out, ' ', prefix_len);
@@ -164,6 +198,8 @@ pub fn writeAccountsTableWithUsageOverrides(
     try writePadded(out, h4, widths[4]);
     try out.writeAll("  ");
     try writePadded(out, h5, widths[5]);
+    try out.writeAll("  ");
+    try writePadded(out, h6, widths[6]);
     try out.writeAll("\n");
     if (use_color) try out.writeAll(ansi.reset);
     if (use_color) try out.writeAll(ansi.dim);
@@ -179,11 +215,13 @@ pub fn writeAccountsTableWithUsageOverrides(
             const rate_5h = resolveRateWindow(rec.last_usage, 300, true);
             const rate_week = resolveRateWindow(rec.last_usage, 10080, false);
             const usage_override = usageOverrideForAccount(usage_overrides, account_idx);
+            const credits_str = try creditsCellAlloc(std.heap.page_allocator, rec.last_usage, usage_override);
+            defer std.heap.page_allocator.free(credits_str);
             const reset_credits_str = try resetCreditsCellAlloc(std.heap.page_allocator, rec.last_usage, usage_override);
             defer std.heap.page_allocator.free(reset_credits_str);
-            const rate_5h_str = try usageCellTextAlloc(std.heap.page_allocator, rate_5h, widths[3], usage_override);
+            const rate_5h_str = try usageCellTextAlloc(std.heap.page_allocator, rate_5h, widths[4], usage_override);
             defer std.heap.page_allocator.free(rate_5h_str);
-            const rate_week_str = try usageCellTextAlloc(std.heap.page_allocator, rate_week, widths[4], usage_override);
+            const rate_week_str = try usageCellTextAlloc(std.heap.page_allocator, rate_week, widths[5], usage_override);
             defer std.heap.page_allocator.free(rate_week_str);
             const last = try timefmt.formatRelativeTimeOrDashAlloc(std.heap.page_allocator, rec.last_usage_at, now);
             defer std.heap.page_allocator.free(last);
@@ -193,13 +231,15 @@ pub fn writeAccountsTableWithUsageOverrides(
             defer std.heap.page_allocator.free(account_cell);
             const plan_cell = try truncateAlloc(plan, widths[1]);
             defer std.heap.page_allocator.free(plan_cell);
-            const reset_credits_cell = try truncateAlloc(reset_credits_str, widths[2]);
+            const credits_cell = try truncateAlloc(credits_str, widths[2]);
+            defer std.heap.page_allocator.free(credits_cell);
+            const reset_credits_cell = try truncateAlloc(reset_credits_str, widths[3]);
             defer std.heap.page_allocator.free(reset_credits_cell);
-            const rate_5h_cell = try truncateAlloc(rate_5h_str, widths[3]);
+            const rate_5h_cell = try truncateAlloc(rate_5h_str, widths[4]);
             defer std.heap.page_allocator.free(rate_5h_cell);
-            const rate_week_cell = try truncateAlloc(rate_week_str, widths[4]);
+            const rate_week_cell = try truncateAlloc(rate_week_str, widths[5]);
             defer std.heap.page_allocator.free(rate_week_cell);
-            const last_cell = try truncateAlloc(last, widths[5]);
+            const last_cell = try truncateAlloc(last, widths[6]);
             defer std.heap.page_allocator.free(last_cell);
             if (use_color) {
                 if (row.is_active) {
@@ -216,13 +256,15 @@ pub fn writeAccountsTableWithUsageOverrides(
             try out.writeAll("  ");
             try writePadded(out, plan_cell, widths[1]);
             try out.writeAll("  ");
-            try writePadded(out, reset_credits_cell, widths[2]);
+            try writePadded(out, credits_cell, widths[2]);
             try out.writeAll("  ");
-            try writePadded(out, rate_5h_cell, widths[3]);
+            try writePadded(out, reset_credits_cell, widths[3]);
             try out.writeAll("  ");
-            try writePadded(out, rate_week_cell, widths[4]);
+            try writePadded(out, rate_5h_cell, widths[4]);
             try out.writeAll("  ");
-            try writePadded(out, last_cell, widths[5]);
+            try writePadded(out, rate_week_cell, widths[5]);
+            try out.writeAll("  ");
+            try writePadded(out, last_cell, widths[6]);
             try out.writeAll("\n");
             if (use_color) try out.writeAll(ansi.reset);
             selectable_counter += 1;
@@ -306,14 +348,14 @@ fn writeRepeat(out: *std.Io.Writer, ch: u8, count: usize) !void {
     }
 }
 
-fn listTotalWidth(widths: *const [6]usize, prefix_len: usize, sep_len: usize) usize {
+fn listTotalWidth(widths: *const [7]usize, prefix_len: usize, sep_len: usize) usize {
     var sum: usize = prefix_len;
     for (widths) |w| sum += w;
     sum += sep_len * (widths.len - 1);
     return sum;
 }
 
-fn adjustListWidths(widths: *[6]usize, prefix_len: usize, sep_len: usize) void {
+fn adjustListWidths(widths: *[7]usize, prefix_len: usize, sep_len: usize) void {
     const term_cols = terminalWidth();
     if (term_cols == 0) return;
     const total = listTotalWidth(widths, prefix_len, sep_len);
@@ -321,7 +363,8 @@ fn adjustListWidths(widths: *[6]usize, prefix_len: usize, sep_len: usize) void {
 
     const min_email: usize = 10;
     const min_plan: usize = 4;
-    const min_resets: usize = 1;
+    const min_credits: usize = 1;
+    const min_reset_credits: usize = 1;
     const min_rate: usize = 1;
     const min_last: usize = 4;
 
@@ -344,16 +387,16 @@ fn adjustListWidths(widths: *[6]usize, prefix_len: usize, sep_len: usize) void {
     }
     if (over == 0) return;
 
-    if (widths[2] > min_resets) {
-        const reducible = widths[2] - min_resets;
+    if (widths[2] > min_credits) {
+        const reducible = widths[2] - min_credits;
         const reduce = @min(reducible, over);
         widths[2] -= reduce;
         over -= reduce;
     }
     if (over == 0) return;
 
-    if (widths[3] > min_rate) {
-        const reducible = widths[3] - min_rate;
+    if (widths[3] > min_reset_credits) {
+        const reducible = widths[3] - min_reset_credits;
         const reduce = @min(reducible, over);
         widths[3] -= reduce;
         over -= reduce;
@@ -368,10 +411,18 @@ fn adjustListWidths(widths: *[6]usize, prefix_len: usize, sep_len: usize) void {
     }
     if (over == 0) return;
 
-    if (widths[5] > min_last) {
-        const reducible = widths[5] - min_last;
+    if (widths[5] > min_rate) {
+        const reducible = widths[5] - min_rate;
         const reduce = @min(reducible, over);
         widths[5] -= reduce;
+        over -= reduce;
+    }
+    if (over == 0) return;
+
+    if (widths[6] > min_last) {
+        const reducible = widths[6] - min_last;
+        const reduce = @min(reducible, over);
+        widths[6] -= reduce;
         over -= reduce;
     }
 }

--- a/tests/api_usage_test.zig
+++ b/tests/api_usage_test.zig
@@ -67,7 +67,7 @@ test "parse usage api response maps live usage windows and plan" {
     try std.testing.expectEqual(@as(?i64, 3), snapshot.reset_credits);
 }
 
-test "parse usage api response without windows is ignored" {
+test "parse usage api response keeps numeric credits without windows" {
     const gpa = std.testing.allocator;
     const body =
         \\{
@@ -76,13 +76,33 @@ test "parse usage api response without windows is ignored" {
         \\  "credits": {
         \\    "has_credits": true,
         \\    "unlimited": false,
-        \\    "balance": "1.00"
+        \\    "balance": 1.00
         \\  }
         \\}
     ;
 
-    const snapshot = try usage_api.parseUsageResponse(gpa, body);
-    try std.testing.expect(snapshot == null);
+    const snapshot = (try usage_api.parseUsageResponse(gpa, body)) orelse return error.TestExpectedEqual;
+    defer registry.freeRateLimitSnapshot(gpa, &snapshot);
+    try std.testing.expect(snapshot.primary == null);
+    try std.testing.expect(snapshot.secondary == null);
+    try std.testing.expectEqualStrings("1.00", snapshot.credits.?.balance.?);
+}
+
+test "parse usage api response keeps string credits without windows" {
+    const gpa = std.testing.allocator;
+    const body =
+        \\{
+        \\  "credits": {
+        \\    "has_credits": true,
+        \\    "unlimited": false,
+        \\    "balance": "12.50"
+        \\  }
+        \\}
+    ;
+
+    const snapshot = (try usage_api.parseUsageResponse(gpa, body)) orelse return error.TestExpectedEqual;
+    defer registry.freeRateLimitSnapshot(gpa, &snapshot);
+    try std.testing.expectEqualStrings("12.50", snapshot.credits.?.balance.?);
 }
 
 test "parse usage api response keeps reset credits without windows" {

--- a/tests/tui_table_test.zig
+++ b/tests/tui_table_test.zig
@@ -143,7 +143,37 @@ test "writeAccountsTable keeps usage headers short" {
     try std.testing.expect(std.mem.indexOf(u8, output, "USAGE") == null);
 }
 
-test "writeAccountsTable shows reset credits column" {
+test "writeAccountsTable shows integer credits balance column" {
+    const gpa = std.testing.allocator;
+    var reg = makeTestRegistry();
+    defer reg.deinit(gpa);
+
+    try appendTestAccount(gpa, &reg, "user-1::acc-1", "user@example.com", "", .plus);
+    reg.accounts.items[0].last_usage = .{
+        .primary = null,
+        .secondary = null,
+        .credits = .{
+            .has_credits = true,
+            .unlimited = false,
+            .balance = try gpa.dupe(u8, "5.3900"),
+        },
+        .reset_credits = 2,
+        .plan_type = .plus,
+    };
+
+    var buffer: [2048]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buffer);
+    try writeAccountsTable(&writer, &reg, false);
+
+    const output = writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, output, "CREDITS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "RESET CREDITS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "Plus  5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "5.39") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "2") != null);
+}
+
+test "writeAccountsTable shows reset credits independently" {
     const gpa = std.testing.allocator;
     var reg = makeTestRegistry();
     defer reg.deinit(gpa);
@@ -162,8 +192,10 @@ test "writeAccountsTable shows reset credits column" {
     try writeAccountsTable(&writer, &reg, false);
 
     const output = writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, output, "CREDITS") != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "RESET CREDITS") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "Plus  2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "Plus  -") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "2") != null);
 }
 
 test "writeAccountsTable shows usage override statuses for failed refreshes" {


### PR DESCRIPTION
## Summary
- Display credits.balance in a dedicated CREDITS column for codex-auth list.
- Keep RESET CREDITS unchanged as a separate value.
- Preserve numeric usage responses and display the integer portion without rounding.

## Validation
- API parsing tests: 9/9 passed.
- Table tests and zig build run -- list are blocked locally by a Zig 0.16.0 Windows ARM64 translate-c.exe failure while translating C system headers (time.h).