### PR TITLE
fix(auth): refresh stale OAuth snapshots before use

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -80,6 +80,7 @@ pub fn build(b: *std.Build) void {
         "tests/api_me_test.zig",
         "tests/api_usage_test.zig",
         "tests/auth_test.zig",
+        "tests/oauth_refresh_test.zig",
         "tests/cli_behavior_test.zig",
         "tests/cli_picker_test.zig",
         "tests/compat_fs_test.zig",

--- a/build.zig
+++ b/build.zig
@@ -61,11 +61,24 @@ pub fn build(b: *std.Build) void {
         .root_module = fake_codex_module,
     });
     const install_fake_codex = b.addInstallArtifact(fake_codex_exe, .{});
+    const refresh_process_module = b.createModule(.{
+        .root_source_file = b.path("tests/refresh_process.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+        .imports = &.{.{ .name = "codex_auth", .module = package_module }},
+    });
+    const refresh_process_exe = b.addExecutable(.{
+        .name = "refresh-process",
+        .root_module = refresh_process_module,
+    });
+    const install_refresh_process = b.addInstallArtifact(refresh_process_exe, .{});
     const test_helpers_step = b.step("test-helpers", "Install test helper binaries");
     test_helpers_step.dependOn(b.getInstallStep());
     test_helpers_step.dependOn(&install_fake_curl.step);
     test_helpers_step.dependOn(&install_fake_curl_fail.step);
     test_helpers_step.dependOn(&install_fake_codex.step);
+    test_helpers_step.dependOn(&install_refresh_process.step);
 
     const run_cmd = b.addRunArtifact(exe);
     if (b.args) |args| {

--- a/src/api/http.zig
+++ b/src/api/http.zig
@@ -22,6 +22,9 @@ pub const ChildCaptureResult = types.ChildCaptureResult;
 
 pub const runGetJsonCommand = curl.runGetJsonCommand;
 pub const runBearerGetJsonCommand = curl.runBearerGetJsonCommand;
+pub const runPostJsonCommand = curl.runPostJsonCommand;
+pub const buildPostJsonInvocation = curl.buildPostJsonInvocation;
+pub const CurlPostInvocation = curl.CurlPostInvocation;
 pub const runGetJsonBatchCommand = curl.runGetJsonBatchCommand;
 pub const ensureCurlExecutableAvailable = curl.ensureCurlExecutableAvailable;
 pub const resolveCurlExecutableAlloc = curl.resolveCurlExecutableAlloc;

--- a/src/api/http_curl.zig
+++ b/src/api/http_curl.zig
@@ -93,6 +93,71 @@ pub fn runBearerGetJsonCommand(
     return runCurlBearerGetJsonCommand(allocator, endpoint, access_token);
 }
 
+pub fn runPostJsonCommand(
+    allocator: std.mem.Allocator,
+    endpoint: []const u8,
+    json_body: []const u8,
+) !HttpResult {
+    const curl_executable = try resolveCurlExecutableForLaunchAlloc(allocator);
+    defer allocator.free(curl_executable);
+
+    var invocation = try buildPostJsonInvocation(allocator, curl_executable, endpoint, json_body);
+    defer invocation.deinit(allocator);
+
+    const result = runChildCaptureWithInputAndOutputLimit(
+        allocator,
+        invocation.argv.items,
+        invocation.stdin_config.items,
+        child_process_timeout_ms_value,
+        null,
+        default_max_output_bytes,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        error.FileNotFound => return error.CurlRequired,
+        else => return err,
+    };
+    defer result.deinit(allocator);
+    if (result.timed_out) return error.TimedOut;
+    switch (result.term) {
+        .exited => |code| if (code != 0) {
+            if (code == curl_timeout_exit_code) return error.TimedOut;
+            return error.RequestFailed;
+        },
+        else => return error.RequestFailed,
+    }
+    const parsed = try parseCurlHttpOutput(allocator, result.stdout);
+    return .{ .body = parsed.body, .status_code = parsed.status_code };
+}
+
+pub const CurlPostInvocation = struct {
+    argv: std.ArrayList([]const u8),
+    stdin_config: std.ArrayList(u8),
+
+    pub fn deinit(self: *CurlPostInvocation, allocator: std.mem.Allocator) void {
+        self.argv.deinit(allocator);
+        self.stdin_config.deinit(allocator);
+        self.* = undefined;
+    }
+};
+
+pub fn buildPostJsonInvocation(
+    allocator: std.mem.Allocator,
+    curl_executable: []const u8,
+    endpoint: []const u8,
+    json_body: []const u8,
+) !CurlPostInvocation {
+    var invocation: CurlPostInvocation = .{ .argv = .empty, .stdin_config = .empty };
+    errdefer invocation.deinit(allocator);
+    try appendCurlBaseArgs(allocator, &invocation.argv, curl_executable);
+    try appendCurlConfigLine(allocator, &invocation.stdin_config, "url", endpoint);
+    try appendCurlConfigLine(allocator, &invocation.stdin_config, "request", "POST");
+    try appendCurlConfigLine(allocator, &invocation.stdin_config, "header", "Content-Type: application/json");
+    try appendCurlConfigLine(allocator, &invocation.stdin_config, "header", "Accept: application/json");
+    try appendCurlConfigLine(allocator, &invocation.stdin_config, "header", "User-Agent: " ++ user_agent);
+    try appendCurlConfigLine(allocator, &invocation.stdin_config, "data", json_body);
+    return invocation;
+}
+
 pub fn runGetJsonBatchCommand(
     allocator: std.mem.Allocator,
     endpoint: []const u8,

--- a/src/auth/oauth_refresh.zig
+++ b/src/auth/oauth_refresh.zig
@@ -1,0 +1,245 @@
+const std = @import("std");
+const app_runtime = @import("../core/runtime.zig");
+const auth = @import("auth.zig");
+const http = @import("../api/http.zig");
+const registry = @import("../registry/root.zig");
+const sensitive_file = @import("../core/sensitive_file.zig");
+
+pub const token_endpoint = "https://auth.openai.com/oauth/token";
+pub const client_id = "app_EMoamEEZ73f0CkXaXp7hrann";
+pub const refresh_window_seconds: i64 = 5 * 60;
+pub const fallback_max_age_seconds: i64 = 8 * 24 * 60 * 60;
+
+pub const FailureClass = enum { permanent, protocol, transient };
+pub const Outcome = enum { fresh, refreshed };
+
+pub fn classifyFailure(status: ?u16, body: []const u8) FailureClass {
+    if (hasPermanentErrorCode(body)) return .permanent;
+    const value = status orelse return .transient;
+    if (value == 429 or value >= 500) return .transient;
+    if (value == 400 or value == 401 or value == 403) return .protocol;
+    return if (value >= 400) .protocol else .transient;
+}
+
+fn hasPermanentErrorCode(body: []const u8) bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, std.heap.page_allocator, body, .{}) catch return false;
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |value| value,
+        else => return false,
+    };
+    if (obj.get("error")) |value| switch (value) {
+        .string => |text| return isPermanentCode(text),
+        .object => |nested| if (nested.get("code")) |code| switch (code) {
+            .string => |text| return isPermanentCode(text),
+            else => {},
+        },
+        else => {},
+    };
+    if (obj.get("code")) |value| switch (value) {
+        .string => |text| return isPermanentCode(text),
+        else => {},
+    };
+    return false;
+}
+
+fn isPermanentCode(value: []const u8) bool {
+    return std.mem.eql(u8, value, "invalid_grant") or
+        std.mem.eql(u8, value, "refresh_token_expired") or
+        std.mem.eql(u8, value, "refresh_token_reused") or
+        std.mem.eql(u8, value, "refresh_token_invalidated");
+}
+
+pub fn shouldRefreshAuthData(allocator: std.mem.Allocator, data: []const u8, now_seconds: i64) bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch return false;
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |value| value,
+        else => return false,
+    };
+    const tokens = switch (obj.get("tokens") orelse return false) {
+        .object => |value| value,
+        else => return false,
+    };
+    const access = switch (tokens.get("access_token") orelse return fallbackStale(obj, now_seconds)) {
+        .string => |value| value,
+        else => return fallbackStale(obj, now_seconds),
+    };
+    const payload = auth.decodeJwtPayload(allocator, access) catch return fallbackStale(obj, now_seconds);
+    defer allocator.free(payload);
+    var claims = std.json.parseFromSlice(std.json.Value, allocator, payload, .{}) catch return fallbackStale(obj, now_seconds);
+    defer claims.deinit();
+    const claims_obj = switch (claims.value) {
+        .object => |value| value,
+        else => return fallbackStale(obj, now_seconds),
+    };
+    const exp = switch (claims_obj.get("exp") orelse return fallbackStale(obj, now_seconds)) {
+        .integer => |value| value,
+        .float => |value| @as(i64, @intFromFloat(value)),
+        else => return fallbackStale(obj, now_seconds),
+    };
+    return exp <= now_seconds + refresh_window_seconds;
+}
+
+fn fallbackStale(obj: std.json.ObjectMap, now_seconds: i64) bool {
+    const value = obj.get("last_refresh") orelse return true;
+    const text = switch (value) {
+        .string => |s| s,
+        else => return true,
+    };
+    const refreshed = parseTimestampSeconds(text) orelse return true;
+    return now_seconds - refreshed >= fallback_max_age_seconds;
+}
+
+pub fn refreshAccount(allocator: std.mem.Allocator, codex_home: []const u8, account_key: []const u8, active: bool, force: bool) !Outcome {
+    try registry.ensureAccountsDir(allocator, codex_home);
+    const file_key = try registry.accountFileKey(allocator, account_key);
+    defer allocator.free(file_key);
+    const lock_name = try std.fmt.allocPrint(allocator, "{s}.refresh.lock", .{file_key});
+    defer allocator.free(lock_name);
+    const lock_path = try std.fs.path.join(allocator, &.{ codex_home, "accounts", lock_name });
+    defer allocator.free(lock_path);
+    const snapshot_path = try registry.accountAuthPath(allocator, codex_home, account_key);
+    defer allocator.free(snapshot_path);
+    const observed = try readFile(allocator, snapshot_path);
+    defer allocator.free(observed);
+    var lock_file = try std.Io.Dir.cwd().createFile(app_runtime.io(), lock_path, .{ .truncate = false, .permissions = sensitive_file.permissions });
+    defer lock_file.close(app_runtime.io());
+    lock_file.lock(app_runtime.io(), .exclusive) catch |err| switch (err) {
+        error.FileLocksUnsupported => return error.RefreshLockUnsupported,
+        else => return err,
+    };
+    defer lock_file.unlock(app_runtime.io());
+
+    const before = try readFile(allocator, snapshot_path);
+    defer allocator.free(before);
+    if (!std.mem.eql(u8, observed, before)) return .fresh;
+    const now = std.Io.Timestamp.now(app_runtime.io(), .real).toSeconds();
+    if (!force and !shouldRefreshAuthData(allocator, before, now)) return .fresh;
+
+    const updated = try requestAndApply(allocator, before, now);
+    defer allocator.free(updated);
+    if (active and try activeAuthMatchesAccount(allocator, codex_home, account_key)) {
+        const active_path = try registry.activeAuthPath(allocator, codex_home);
+        defer allocator.free(active_path);
+        try sensitive_file.writeAtomic(active_path, updated);
+    }
+    try sensitive_file.writeAtomic(snapshot_path, updated);
+    return .refreshed;
+}
+
+fn activeAuthMatchesAccount(allocator: std.mem.Allocator, codex_home: []const u8, account_key: []const u8) !bool {
+    const active_path = try registry.activeAuthPath(allocator, codex_home);
+    defer allocator.free(active_path);
+    const active_data = readFile(allocator, active_path) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    defer allocator.free(active_data);
+    const info = auth.parseAuthInfoData(allocator, active_data) catch return false;
+    defer info.deinit(allocator);
+    const record_key = info.record_key orelse return false;
+    return std.mem.eql(u8, record_key, account_key);
+}
+
+fn requestAndApply(allocator: std.mem.Allocator, data: []const u8, now: i64) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |value| value,
+        else => return error.InvalidAuthJson,
+    };
+    const tokens = switch (obj.get("tokens") orelse return error.MissingTokens) {
+        .object => |value| value,
+        else => return error.MissingTokens,
+    };
+    const refresh_token = switch (tokens.get("refresh_token") orelse return error.MissingRefreshToken) {
+        .string => |value| value,
+        else => return error.MissingRefreshToken,
+    };
+
+    var request_writer: std.Io.Writer.Allocating = .init(allocator);
+    defer request_writer.deinit();
+    try std.json.Stringify.value(.{ .client_id = client_id, .grant_type = "refresh_token", .refresh_token = refresh_token }, .{}, &request_writer.writer);
+    const response = http.runPostJsonCommand(allocator, token_endpoint, request_writer.written()) catch |err| switch (err) {
+        error.TimedOut, error.RequestFailed => return error.RefreshTransient,
+        else => return err,
+    };
+    defer allocator.free(response.body);
+    if (response.status_code == null or response.status_code.? < 200 or response.status_code.? >= 300) {
+        return switch (classifyFailure(response.status_code, response.body)) {
+            .permanent => error.RefreshLoginRequired,
+            .protocol => error.RefreshProtocolFailure,
+            .transient => error.RefreshTransient,
+        };
+    }
+    return try applyRefreshResponse(allocator, data, response.body, now);
+}
+
+pub fn applyRefreshResponse(allocator: std.mem.Allocator, data: []const u8, response_body: []const u8, now: i64) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidAuthJson;
+    const obj = &parsed.value.object;
+    const tokens_value = obj.getPtr("tokens") orelse return error.MissingTokens;
+    if (tokens_value.* != .object) return error.MissingTokens;
+    const tokens = &tokens_value.object;
+    var response_json = try std.json.parseFromSlice(std.json.Value, allocator, response_body, .{});
+    defer response_json.deinit();
+    const response_obj = switch (response_json.value) {
+        .object => |value| value,
+        else => return error.InvalidRefreshResponse,
+    };
+    inline for (.{ "id_token", "access_token", "refresh_token" }) |field| {
+        if (response_obj.get(field)) |value| switch (value) {
+            .string => try tokens.put(allocator, field, value),
+            else => return error.InvalidRefreshResponse,
+        };
+    }
+    const timestamp = try formatTimestamp(allocator, now);
+    defer allocator.free(timestamp);
+    try obj.put(allocator, "last_refresh", .{ .string = timestamp });
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    try std.json.Stringify.value(parsed.value, .{ .whitespace = .indent_2 }, &out.writer);
+    try out.writer.writeAll("\n");
+    return try out.toOwnedSlice();
+}
+
+fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const file = try std.Io.Dir.cwd().openFile(app_runtime.io(), path, .{});
+    defer file.close(app_runtime.io());
+    var buffer: [4096]u8 = undefined;
+    var reader = file.reader(app_runtime.io(), &buffer);
+    return try reader.interface.allocRemaining(allocator, .limited(10 * 1024 * 1024));
+}
+
+fn formatTimestamp(allocator: std.mem.Allocator, seconds: i64) ![]u8 {
+    if (seconds < 0) return error.InvalidTimestamp;
+    const epoch = std.time.epoch.EpochSeconds{ .secs = @intCast(seconds) };
+    const year_day = epoch.getEpochDay().calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_seconds = epoch.getDaySeconds();
+    return std.fmt.allocPrint(allocator, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}Z", .{
+        year_day.year,                 month_day.month.numeric(),        month_day.day_index + 1,
+        day_seconds.getHoursIntoDay(), day_seconds.getMinutesIntoHour(), day_seconds.getSecondsIntoMinute(),
+    });
+}
+
+fn parseTimestampSeconds(s: []const u8) ?i64 {
+    if (s.len < 20 or s[4] != '-' or s[7] != '-' or s[10] != 'T' or s[13] != ':' or s[16] != ':' or s[19] != 'Z') return null;
+    const year = std.fmt.parseInt(i64, s[0..4], 10) catch return null;
+    const month = std.fmt.parseInt(i64, s[5..7], 10) catch return null;
+    const day = std.fmt.parseInt(i64, s[8..10], 10) catch return null;
+    const hour = std.fmt.parseInt(i64, s[11..13], 10) catch return null;
+    const minute = std.fmt.parseInt(i64, s[14..16], 10) catch return null;
+    const second = std.fmt.parseInt(i64, s[17..19], 10) catch return null;
+    if (month < 1 or month > 12 or day < 1 or day > 31 or hour > 23 or minute > 59 or second > 59) return null;
+    const adjusted_year = year - (if (month <= 2) @as(i64, 1) else 0);
+    const era = @divFloor(if (adjusted_year >= 0) adjusted_year else adjusted_year - 399, 400);
+    const yoe = adjusted_year - era * 400;
+    const mp = month + (if (month > 2) @as(i64, -3) else 9);
+    const doy = @divFloor(153 * mp + 2, 5) + day - 1;
+    const days = era * 146097 + yoe * 365 + @divFloor(yoe, 4) - @divFloor(yoe, 100) + doy - 719468;
+    return (((days * 24) + hour) * 60 + minute) * 60 + second;
+}

--- a/src/auth/oauth_refresh.zig
+++ b/src/auth/oauth_refresh.zig
@@ -92,6 +92,28 @@ fn fallbackStale(obj: std.json.ObjectMap, now_seconds: i64) bool {
 }
 
 pub fn refreshAccount(allocator: std.mem.Allocator, codex_home: []const u8, account_key: []const u8, active: bool, force: bool) !Outcome {
+    return refreshAccountWith(
+        allocator,
+        codex_home,
+        account_key,
+        active,
+        force,
+        std.Io.Timestamp.now(app_runtime.io(), .real).toSeconds(),
+        http.runPostJsonCommand,
+        lockExclusive,
+    );
+}
+
+pub fn refreshAccountWith(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    account_key: []const u8,
+    active: bool,
+    force: bool,
+    now: i64,
+    requester: anytype,
+    locker: anytype,
+) !Outcome {
     try registry.ensureAccountsDir(allocator, codex_home);
     const file_key = try registry.accountFileKey(allocator, account_key);
     defer allocator.free(file_key);
@@ -105,7 +127,7 @@ pub fn refreshAccount(allocator: std.mem.Allocator, codex_home: []const u8, acco
     defer allocator.free(observed);
     var lock_file = try std.Io.Dir.cwd().createFile(app_runtime.io(), lock_path, .{ .truncate = false, .permissions = sensitive_file.permissions });
     defer lock_file.close(app_runtime.io());
-    lock_file.lock(app_runtime.io(), .exclusive) catch |err| switch (err) {
+    locker(lock_file) catch |err| switch (err) {
         error.FileLocksUnsupported => return error.RefreshLockUnsupported,
         else => return err,
     };
@@ -114,10 +136,9 @@ pub fn refreshAccount(allocator: std.mem.Allocator, codex_home: []const u8, acco
     const before = try readFile(allocator, snapshot_path);
     defer allocator.free(before);
     if (!std.mem.eql(u8, observed, before)) return .fresh;
-    const now = std.Io.Timestamp.now(app_runtime.io(), .real).toSeconds();
     if (!force and !shouldRefreshAuthData(allocator, before, now)) return .fresh;
 
-    const updated = try requestAndApply(allocator, before, now);
+    const updated = try requestAndApply(allocator, before, now, requester);
     defer allocator.free(updated);
     if (active and try activeAuthMatchesAccount(allocator, codex_home, account_key)) {
         const active_path = try registry.activeAuthPath(allocator, codex_home);
@@ -126,6 +147,10 @@ pub fn refreshAccount(allocator: std.mem.Allocator, codex_home: []const u8, acco
     }
     try sensitive_file.writeAtomic(snapshot_path, updated);
     return .refreshed;
+}
+
+fn lockExclusive(file: std.Io.File) !void {
+    try file.lock(app_runtime.io(), .exclusive);
 }
 
 fn activeAuthMatchesAccount(allocator: std.mem.Allocator, codex_home: []const u8, account_key: []const u8) !bool {
@@ -142,7 +167,7 @@ fn activeAuthMatchesAccount(allocator: std.mem.Allocator, codex_home: []const u8
     return std.mem.eql(u8, record_key, account_key);
 }
 
-fn requestAndApply(allocator: std.mem.Allocator, data: []const u8, now: i64) ![]u8 {
+fn requestAndApply(allocator: std.mem.Allocator, data: []const u8, now: i64, requester: anytype) ![]u8 {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, data, .{});
     defer parsed.deinit();
     const obj = switch (parsed.value) {
@@ -161,7 +186,7 @@ fn requestAndApply(allocator: std.mem.Allocator, data: []const u8, now: i64) ![]
     var request_writer: std.Io.Writer.Allocating = .init(allocator);
     defer request_writer.deinit();
     try std.json.Stringify.value(.{ .client_id = client_id, .grant_type = "refresh_token", .refresh_token = refresh_token }, .{}, &request_writer.writer);
-    const response = http.runPostJsonCommand(allocator, token_endpoint, request_writer.written()) catch |err| switch (err) {
+    const response = requester(allocator, token_endpoint, request_writer.written()) catch |err| switch (err) {
         error.TimedOut, error.RequestFailed => return error.RefreshTransient,
         else => return err,
     };

--- a/src/core/sensitive_file.zig
+++ b/src/core/sensitive_file.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const app_runtime = @import("runtime.zig");
+
+pub const permissions: std.Io.File.Permissions = switch (builtin.os.tag) {
+    .windows => .default_file,
+    else => .fromMode(0o600),
+};
+
+pub fn writeAtomic(path: []const u8, data: []const u8) !void {
+    if (builtin.os.tag == .windows) return writeReplace(path, data);
+
+    var buffer: [4096]u8 = undefined;
+    var atomic = try std.Io.Dir.cwd().createFileAtomic(app_runtime.io(), path, .{
+        .replace = true,
+        .permissions = permissions,
+    });
+    defer atomic.deinit(app_runtime.io());
+    var writer = atomic.file.writer(app_runtime.io(), &buffer);
+    try writer.interface.writeAll(data);
+    try writer.interface.flush();
+    try atomic.file.sync(app_runtime.io());
+    try atomic.replace(app_runtime.io());
+    try harden(path);
+}
+
+fn writeReplace(path: []const u8, data: []const u8) !void {
+    const allocator = std.heap.page_allocator;
+    const nonce = std.Io.Timestamp.now(app_runtime.io(), .real).toNanoseconds();
+    const temp = try std.fmt.allocPrint(allocator, "{s}.tmp.{d}", .{ path, nonce });
+    defer allocator.free(temp);
+    const backup = try std.fmt.allocPrint(allocator, "{s}.bak.{d}", .{ path, nonce });
+    defer allocator.free(backup);
+
+    {
+        var file = try std.Io.Dir.cwd().createFile(app_runtime.io(), temp, .{ .truncate = true, .permissions = permissions });
+        defer file.close(app_runtime.io());
+        try file.writeStreamingAll(app_runtime.io(), data);
+        try file.sync(app_runtime.io());
+    }
+    const had_original = blk: {
+        std.Io.Dir.cwd().rename(path, std.Io.Dir.cwd(), backup, app_runtime.io()) catch |err| switch (err) {
+            error.FileNotFound => break :blk false,
+            else => return err,
+        };
+        break :blk true;
+    };
+    errdefer {
+        std.Io.Dir.cwd().deleteFile(app_runtime.io(), temp) catch {};
+        if (had_original) std.Io.Dir.cwd().rename(backup, std.Io.Dir.cwd(), path, app_runtime.io()) catch {};
+    }
+    try std.Io.Dir.cwd().rename(temp, std.Io.Dir.cwd(), path, app_runtime.io());
+    if (had_original) try std.Io.Dir.cwd().deleteFile(app_runtime.io(), backup);
+    try harden(path);
+}
+
+fn harden(path: []const u8) !void {
+    if (builtin.os.tag == .windows) return;
+    const file = try std.Io.Dir.cwd().openFile(app_runtime.io(), path, .{ .mode = .read_write });
+    defer file.close(app_runtime.io());
+    try file.setPermissions(app_runtime.io(), permissions);
+}

--- a/src/registry/storage_write.zig
+++ b/src/registry/storage_write.zig
@@ -1,6 +1,4 @@
 const std = @import("std");
-const app_runtime = @import("../core/runtime.zig");
-const builtin = @import("builtin");
 const clean = @import("clean.zig");
 const common = @import("common.zig");
 
@@ -9,10 +7,10 @@ const Registry = common.Registry;
 const current_schema_version = common.current_schema_version;
 const ensureAccountsDir = common.ensureAccountsDir;
 const hardenSensitiveFile = common.hardenSensitiveFile;
-const private_file_permissions = common.private_file_permissions;
 const registryPath = common.registryPath;
 const backupRegistryIfChanged = clean.backupRegistryIfChanged;
 const fileEqualsBytes = clean.fileEqualsBytes;
+const sensitive_file = @import("../core/sensitive_file.zig");
 
 pub fn saveRegistry(allocator: std.mem.Allocator, codex_home: []const u8, reg: *Registry) !void {
     reg.schema_version = current_schema_version;
@@ -43,61 +41,8 @@ pub fn saveRegistry(allocator: std.mem.Allocator, codex_home: []const u8, reg: *
     try writeRegistryFileAtomic(path, data);
 }
 
-fn writeRegistryFileReplace(path: []const u8, data: []const u8) !void {
-    const allocator = std.heap.page_allocator;
-    const temp_path = try std.fmt.allocPrint(allocator, "{s}.tmp.{d}", .{ path, @as(i128, std.Io.Timestamp.now(app_runtime.io(), .real).toNanoseconds()) });
-    defer allocator.free(temp_path);
-    const backup_path = try std.fmt.allocPrint(allocator, "{s}.bak.{d}", .{ path, @as(i128, std.Io.Timestamp.now(app_runtime.io(), .real).toNanoseconds()) });
-    defer allocator.free(backup_path);
-
-    {
-        var file = try std.Io.Dir.cwd().createFile(app_runtime.io(), temp_path, .{
-            .truncate = true,
-            .permissions = private_file_permissions,
-        });
-        defer file.close(app_runtime.io());
-        try file.writeStreamingAll(app_runtime.io(), data);
-        try file.sync(app_runtime.io());
-    }
-
-    const had_original = blk: {
-        std.Io.Dir.cwd().rename(path, std.Io.Dir.cwd(), backup_path, app_runtime.io()) catch |err| switch (err) {
-            error.FileNotFound => break :blk false,
-            else => return err,
-        };
-        break :blk true;
-    };
-    errdefer {
-        std.Io.Dir.cwd().deleteFile(app_runtime.io(), temp_path) catch {};
-        if (had_original) {
-            std.Io.Dir.cwd().rename(backup_path, std.Io.Dir.cwd(), path, app_runtime.io()) catch {};
-        }
-    }
-    try std.Io.Dir.cwd().rename(temp_path, std.Io.Dir.cwd(), path, app_runtime.io());
-    if (had_original) {
-        std.Io.Dir.cwd().deleteFile(app_runtime.io(), backup_path) catch |err| switch (err) {
-            error.FileNotFound => {},
-            else => return err,
-        };
-    }
-    try hardenSensitiveFile(path);
-}
-
 fn writeRegistryFileAtomic(path: []const u8, data: []const u8) !void {
-    if (builtin.os.tag == .windows) {
-        return writeRegistryFileReplace(path, data);
-    }
-    var buf: [4096]u8 = undefined;
-    var atomic_file = try std.Io.Dir.cwd().createFileAtomic(app_runtime.io(), path, .{
-        .replace = true,
-        .permissions = private_file_permissions,
-    });
-    defer atomic_file.deinit(app_runtime.io());
-    var file_writer = atomic_file.file.writer(app_runtime.io(), &buf);
-    try file_writer.interface.writeAll(data);
-    try file_writer.interface.flush();
-    try atomic_file.replace(app_runtime.io());
-    try hardenSensitiveFile(path);
+    try sensitive_file.writeAtomic(path, data);
 }
 
 const RegistryOut = struct {

--- a/src/root.zig
+++ b/src/root.zig
@@ -7,6 +7,7 @@ pub const api = struct {
 
 pub const auth = struct {
     pub const core = @import("auth/auth.zig");
+    pub const oauth_refresh = @import("auth/oauth_refresh.zig");
 };
 
 pub const cli = @import("cli/root.zig");
@@ -17,6 +18,7 @@ pub const core = struct {
     pub const compat_fs = @import("core/compat_fs.zig");
     pub const io_util = @import("core/io_util.zig");
     pub const runtime = @import("core/runtime.zig");
+    pub const sensitive_file = @import("core/sensitive_file.zig");
 };
 
 pub const registry = @import("registry/root.zig");

--- a/src/workflows/live_runtime.zig
+++ b/src/workflows/live_runtime.zig
@@ -7,6 +7,7 @@ const targets = @import("targets.zig");
 const workflow_env = @import("env.zig");
 const live_types = @import("live_types.zig");
 const live_display = @import("live_display.zig");
+const oauth_refresh = @import("../auth/oauth_refresh.zig");
 
 const ForegroundUsageRefreshTarget = targets.ForegroundUsageRefreshTarget;
 const SwitchLiveRefreshPolicy = live_types.SwitchLiveRefreshPolicy;
@@ -400,6 +401,15 @@ pub fn switchLiveRuntimeApplySelection(
         try registry.saveRegistry(allocator, runtime.codex_home, &reg);
     }
 
+    if (runtime.api_mode != .skip_api) {
+        const is_active = if (reg.active_account_key) |key| std.mem.eql(u8, key, account_key) else false;
+        _ = oauth_refresh.refreshAccount(allocator, runtime.codex_home, account_key, is_active, false) catch |err| switch (err) {
+            error.RefreshLoginRequired, error.RefreshProtocolFailure => return error.LoginRequired,
+            error.MissingRefreshToken, error.MissingTokens => {},
+            error.OutOfMemory => return err,
+            else => std.log.warn("OAuth refresh was unavailable; switching anyway so Codex can recover the login: {s}", .{@errorName(err)}),
+        };
+    }
     try registry.activateAccountByKey(allocator, runtime.codex_home, &reg, account_key);
     try registry.saveRegistry(allocator, runtime.codex_home, &reg);
 

--- a/src/workflows/switch.zig
+++ b/src/workflows/switch.zig
@@ -5,6 +5,7 @@ const live_flow = @import("live.zig");
 const preflight = @import("preflight.zig");
 const query_mod = @import("query.zig");
 const results = @import("results.zig");
+const oauth_refresh = @import("../auth/oauth_refresh.zig");
 
 const ensureLiveTty = preflight.ensureLiveTty;
 const resolveSwitchQueryLocally = query_mod.resolveSwitchQueryLocally;
@@ -56,6 +57,7 @@ pub fn handleSwitch(allocator: std.mem.Allocator, codex_home: []const u8, opts: 
                 return err;
             };
             if (selected_account_key == null) return;
+            if (opts.api_mode != .skip_api) try refreshSwitchTarget(allocator, codex_home, &loaded.display.reg, selected_account_key.?);
             try registry.activateAccountByKey(allocator, codex_home, &loaded.display.reg, selected_account_key.?);
             try registry.saveRegistry(allocator, codex_home, &loaded.display.reg);
             try cli.output.printSwitchedAccount(allocator, &loaded.display.reg, selected_account_key.?);
@@ -147,6 +149,7 @@ fn handleSwitchQuery(
         },
     };
     if (selected_account_key == null) return;
+    try refreshSwitchTarget(allocator, codex_home, &reg, selected_account_key.?);
     try registry.activateAccountByKey(allocator, codex_home, &reg, selected_account_key.?);
     try registry.saveRegistry(allocator, codex_home, &reg);
     try cli.output.printSwitchedAccount(allocator, &reg, selected_account_key.?);
@@ -187,6 +190,7 @@ fn handleSwitchPrevious(
         }
     }
 
+    try refreshSwitchTarget(allocator, codex_home, &reg, previous_account_key);
     try registry.activateAccountByKey(allocator, codex_home, &reg, previous_account_key);
     try registry.saveRegistry(allocator, codex_home, &reg);
     try cli.output.printSwitchedAccount(allocator, &reg, previous_account_key);
@@ -224,6 +228,7 @@ fn handleSwitchQueryJson(
         },
     };
 
+    refreshSwitchTarget(allocator, codex_home, &reg, selected_account_key) catch |err| return printJsonMutationError(err);
     registry.activateAccountByKey(allocator, codex_home, &reg, selected_account_key) catch |err| return printJsonMutationError(err);
     registry.saveRegistry(allocator, codex_home, &reg) catch |err| return printJsonMutationError(err);
 
@@ -234,6 +239,19 @@ fn handleSwitchQueryJson(
     ) catch |err| return printJsonWorkflowError(err);
     defer result.deinit(allocator);
     try cli.json_output.printSwitchResult(&result);
+}
+
+fn refreshSwitchTarget(allocator: std.mem.Allocator, codex_home: []const u8, reg: *registry.Registry, account_key: []const u8) !void {
+    const is_active = if (reg.active_account_key) |key| std.mem.eql(u8, key, account_key) else false;
+    _ = oauth_refresh.refreshAccount(allocator, codex_home, account_key, is_active, false) catch |err| switch (err) {
+        error.RefreshLoginRequired, error.RefreshProtocolFailure => return error.LoginRequired,
+        error.MissingRefreshToken, error.MissingTokens => return,
+        error.OutOfMemory => return err,
+        else => {
+            std.log.warn("OAuth refresh was unavailable; switching anyway so Codex can recover the login: {s}", .{@errorName(err)});
+            return;
+        },
+    };
 }
 
 fn printJsonWorkflowError(err: anyerror) anyerror {

--- a/src/workflows/usage.zig
+++ b/src/workflows/usage.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const registry = @import("../registry/root.zig");
 const sessions = @import("../session.zig");
 const usage_api = @import("../api/usage.zig");
+const oauth_refresh = @import("../auth/oauth_refresh.zig");
 
 const foreground_usage_refresh_concurrency: usize = 5;
 pub const max_usage_override_display_width: usize = 25;
@@ -368,6 +369,16 @@ pub fn refreshForegroundUsageForDisplayWithApiFetchersWithPoolInitUsingApiEnable
                 if (!std.mem.eql(u8, account.account_key, key)) continue;
             }
             if (skipsChatGptUsage(&account)) continue;
+            const is_active = if (reg.active_account_key) |key| std.mem.eql(u8, key, account.account_key) else false;
+            _ = oauth_refresh.refreshAccount(allocator, codex_home, account.account_key, is_active, false) catch |err| switch (err) {
+                error.RefreshLoginRequired, error.RefreshProtocolFailure, error.RefreshLockUnsupported => {
+                    worker_results[idx] = .{ .requested = true, .error_name = @errorName(err) };
+                    continue;
+                },
+                error.RefreshTransient, error.TimedOut, error.RequestFailed, error.CurlRequired => {},
+                error.OutOfMemory => return err,
+                else => {},
+            };
             try fetch_account_indices.append(auth_path_arena, idx);
         }
         if (fetch_account_indices.items.len == 0) break :batch_fetch;
@@ -402,6 +413,33 @@ pub fn refreshForegroundUsageForDisplayWithApiFetchersWithPoolInitUsingApiEnable
 
         for (batch_results, 0..) |*batch_result, fetch_idx| {
             const idx = fetch_account_indices.items[fetch_idx];
+            if (batch_result.status_code == 401 and batch_result.error_code != null and
+                std.mem.eql(u8, batch_result.error_code.?.text(), "token_expired"))
+            {
+                const account = &reg.accounts.items[idx];
+                const is_active = if (reg.active_account_key) |key| std.mem.eql(u8, key, account.account_key) else false;
+                const refreshed: ?oauth_refresh.Outcome = refresh_attempt: {
+                    break :refresh_attempt oauth_refresh.refreshAccount(allocator, codex_home, account.account_key, is_active, true) catch |err| switch (err) {
+                        error.RefreshLoginRequired, error.RefreshProtocolFailure, error.RefreshLockUnsupported => {
+                            batch_result.error_name = @errorName(err);
+                            break :refresh_attempt null;
+                        },
+                        error.OutOfMemory => return err,
+                        else => break :refresh_attempt null,
+                    };
+                };
+                if (refreshed != null and refreshed.? == .refreshed) {
+                    const replay = usage_fetcher(allocator, auth_paths[fetch_idx]) catch |err| {
+                        batch_result.error_name = @errorName(err);
+                        continue;
+                    };
+                    batch_result.snapshot = replay.snapshot;
+                    batch_result.status_code = replay.status_code;
+                    batch_result.error_code = replay.error_code;
+                    batch_result.missing_auth = replay.missing_auth;
+                    batch_result.error_name = null;
+                }
+            }
             worker_results[idx] = .{
                 .requested = true,
                 .status_code = batch_result.status_code,
@@ -655,10 +693,38 @@ fn foregroundUsageRefreshWorker(
         return;
     };
 
-    const fetch_result = usage_fetcher(arena, auth_path) catch |err| {
+    const account_key = reg.accounts.items[account_idx].account_key;
+    const is_active = if (reg.active_account_key) |key| std.mem.eql(u8, key, account_key) else false;
+    _ = oauth_refresh.refreshAccount(arena, codex_home, account_key, is_active, false) catch |err| switch (err) {
+        error.RefreshLoginRequired, error.RefreshProtocolFailure, error.RefreshLockUnsupported => {
+            results[account_idx] = .{ .requested = true, .error_name = @errorName(err) };
+            return;
+        },
+        error.OutOfMemory => {
+            results[account_idx] = .{ .requested = true, .error_name = @errorName(err) };
+            return;
+        },
+        else => {},
+    };
+
+    var fetch_result = usage_fetcher(arena, auth_path) catch |err| {
         results[account_idx] = .{ .requested = true, .error_name = @errorName(err) };
         return;
     };
+    if (fetch_result.status_code == 401 and fetch_result.error_code != null and
+        std.mem.eql(u8, fetch_result.error_code.?.text(), "token_expired"))
+    {
+        const refresh_outcome = oauth_refresh.refreshAccount(arena, codex_home, account_key, is_active, true) catch |err| {
+            results[account_idx] = .{ .requested = true, .error_name = @errorName(err) };
+            return;
+        };
+        if (refresh_outcome == .refreshed) {
+            fetch_result = usage_fetcher(arena, auth_path) catch |err| {
+                results[account_idx] = .{ .requested = true, .error_name = @errorName(err) };
+                return;
+            };
+        }
+    }
 
     var result: ForegroundUsageWorkerResult = .{
         .requested = true,

--- a/tests/api_http_test.zig
+++ b/tests/api_http_test.zig
@@ -12,6 +12,22 @@ const runChildCaptureWithOutputLimit = http.runChildCaptureWithOutputLimit;
 const ensureExecutableAvailableAlloc = http.ensureExecutableAvailableAlloc;
 const resolveExecutablePathEntryForLaunchAlloc = http.resolveExecutablePathEntryForLaunchAlloc;
 
+test "POST JSON keeps sensitive body out of argv and carries it through stdin config" {
+    const allocator = std.testing.allocator;
+    const secret = "refresh-token-secret";
+    const body = "{\"refresh_token\":\"" ++ secret ++ "\"}";
+    var invocation = try http.buildPostJsonInvocation(allocator, "/usr/bin/curl", "https://auth.example/token", body);
+    defer invocation.deinit(allocator);
+
+    for (invocation.argv.items) |arg| {
+        try std.testing.expect(std.mem.indexOf(u8, arg, secret) == null);
+        try std.testing.expect(std.mem.indexOf(u8, arg, body) == null);
+    }
+    try std.testing.expect(std.mem.indexOf(u8, invocation.stdin_config.items, secret) != null);
+    try std.testing.expect(std.mem.indexOf(u8, invocation.stdin_config.items, body) == null);
+    try std.testing.expect(std.mem.indexOf(u8, invocation.stdin_config.items, "refresh_token") != null);
+}
+
 test "batch child output limit scales with request count" {
     try std.testing.expectEqual(default_max_output_bytes, computeBatchChildOutputLimitBytes(1));
     try std.testing.expectEqual(default_max_output_bytes * 2, computeBatchChildOutputLimitBytes(2));

--- a/tests/cli_integration_test.zig
+++ b/tests/cli_integration_test.zig
@@ -31,6 +31,59 @@ const SeedAccount = struct {
 const future_primary_reset_at: i64 = 4_102_444_800;
 const future_secondary_reset_at: i64 = 4_103_049_600;
 
+test "Scenario: Given two processes refresh one stale snapshot then only one rotates the refresh token" {
+    const allocator = std.testing.allocator;
+    const project_root = try projectRootAlloc(allocator);
+    defer allocator.free(project_root);
+    try buildCliBinary(allocator, project_root);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const codex_home_z = try tmp.dir.realPathFileAlloc(app_runtime.io(), ".", allocator);
+    defer allocator.free(codex_home_z);
+    const codex_home: []const u8 = codex_home_z;
+    try registry.ensureAccountsDir(allocator, codex_home);
+    const snapshot_path = try registry.accountAuthPath(allocator, codex_home, "acct");
+    defer allocator.free(snapshot_path);
+    try std.Io.Dir.cwd().writeFile(app_runtime.io(), .{
+        .sub_path = snapshot_path,
+        .data = "{\"tokens\":{\"access_token\":\"e30.eyJleHAiOjB9.x\",\"refresh_token\":\"original\"},\"last_refresh\":\"1970-01-01T00:00:00Z\"}",
+    });
+    const marker_path = try std.fs.path.join(allocator, &.{ codex_home, "request.marker" });
+    defer allocator.free(marker_path);
+    const helper_path = try builtRefreshProcessPathAlloc(allocator, project_root);
+    defer allocator.free(helper_path);
+    const argv = &.{ helper_path, codex_home, marker_path };
+
+    var first = try std.process.spawn(fs.io(), .{
+        .argv = argv,
+        .cwd = .{ .path = project_root },
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    errdefer first.kill(fs.io());
+    var second = try std.process.spawn(fs.io(), .{
+        .argv = argv,
+        .cwd = .{ .path = project_root },
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    errdefer second.kill(fs.io());
+    const first_term = try first.wait(fs.io());
+    const second_term = try second.wait(fs.io());
+    switch (first_term) {
+        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
+        else => return error.TestUnexpectedResult,
+    }
+    switch (second_term) {
+        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
+        else => return error.TestUnexpectedResult,
+    }
+    try std.Io.Dir.cwd().access(app_runtime.io(), marker_path, .{});
+}
+
 fn projectRootAlloc(allocator: std.mem.Allocator) ![]u8 {
     const project_root = getEnvVarOwned(allocator, cli_integration_project_root_env) catch |err| switch (err) {
         error.EnvironmentVariableNotFound => null,
@@ -393,6 +446,17 @@ fn builtFakeCodexPathAlloc(allocator: std.mem.Allocator, project_root: []const u
 
     const prefix = install_prefix orelse return fs.path.join(allocator, &[_][]const u8{ project_root, "zig-out", "bin", exe_name });
     return fs.path.join(allocator, &[_][]const u8{ prefix, "bin", exe_name });
+}
+
+fn builtRefreshProcessPathAlloc(allocator: std.mem.Allocator, project_root: []const u8) ![]u8 {
+    const exe_name = if (builtin.os.tag == .windows) "refresh-process.exe" else "refresh-process";
+    const install_prefix = getEnvVarOwned(allocator, cli_integration_install_prefix_env) catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    defer if (install_prefix) |dir| allocator.free(dir);
+    const prefix = install_prefix orelse return fs.path.join(allocator, &.{ project_root, "zig-out", "bin", exe_name });
+    return fs.path.join(allocator, &.{ prefix, "bin", exe_name });
 }
 
 fn prependPathEntryAlloc(allocator: std.mem.Allocator, entry: []const u8) ![]u8 {

--- a/tests/oauth_refresh_test.zig
+++ b/tests/oauth_refresh_test.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const refresh = @import("codex_auth").auth.oauth_refresh;
+const sensitive_file = @import("codex_auth").core.sensitive_file;
+const app_runtime = @import("codex_auth").core.runtime;
+const builtin = @import("builtin");
+
+fn authWithExp(allocator: std.mem.Allocator, exp: i64) ![]u8 {
+    const claims = try std.fmt.allocPrint(allocator, "{{\"exp\":{d}}}", .{exp});
+    defer allocator.free(claims);
+    const encoded_len = std.base64.url_safe_no_pad.Encoder.calcSize(claims.len);
+    const encoded = try allocator.alloc(u8, encoded_len);
+    defer allocator.free(encoded);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(encoded, claims);
+    return std.fmt.allocPrint(allocator, "{{\"tokens\":{{\"access_token\":\"e30.{s}.x\"}},\"last_refresh\":\"2026-08-01T00:00:00Z\",\"unknown\":true}}", .{encoded});
+}
+
+test "OAuth refresh policy uses the five minute access token window" {
+    const allocator = std.testing.allocator;
+    const fresh = try authWithExp(allocator, 10_301);
+    defer allocator.free(fresh);
+    const near_expiry = try authWithExp(allocator, 10_300);
+    defer allocator.free(near_expiry);
+    try std.testing.expect(!refresh.shouldRefreshAuthData(allocator, fresh, 10_000));
+    try std.testing.expect(refresh.shouldRefreshAuthData(allocator, near_expiry, 10_000));
+}
+
+test "OAuth refresh policy falls back to eight day last refresh only for undecodable tokens" {
+    const allocator = std.testing.allocator;
+    const old = "{\"tokens\":{\"access_token\":\"invalid\"},\"last_refresh\":\"2026-08-01T00:00:00Z\"}";
+    const recent = "{\"tokens\":{\"access_token\":\"invalid\"},\"last_refresh\":\"2026-08-08T23:59:59Z\"}";
+    const now: i64 = 1_786_233_600;
+    try std.testing.expect(refresh.shouldRefreshAuthData(allocator, old, now));
+    try std.testing.expect(!refresh.shouldRefreshAuthData(allocator, recent, now));
+}
+
+test "OAuth refresh failure classification accepts supported payload shapes" {
+    try std.testing.expectEqual(refresh.FailureClass.permanent, refresh.classifyFailure(400, "{\"error\":{\"code\":\"refresh_token_expired\"}}"));
+    try std.testing.expectEqual(refresh.FailureClass.permanent, refresh.classifyFailure(400, "{\"error\":\"invalid_grant\"}"));
+    try std.testing.expectEqual(refresh.FailureClass.permanent, refresh.classifyFailure(401, "{\"code\":\"refresh_token_reused\"}"));
+    try std.testing.expectEqual(refresh.FailureClass.protocol, refresh.classifyFailure(403, "{\"error\":\"unknown\"}"));
+    try std.testing.expectEqual(refresh.FailureClass.transient, refresh.classifyFailure(429, "{}"));
+    try std.testing.expectEqual(refresh.FailureClass.transient, refresh.classifyFailure(503, "{}"));
+}
+
+test "OAuth refresh response rotates returned tokens and preserves omitted and unknown fields" {
+    const allocator = std.testing.allocator;
+    const original = "{\"tokens\":{\"id_token\":\"old-id\",\"access_token\":\"old-access\",\"refresh_token\":\"old-refresh\",\"account_id\":\"acct\"},\"unknown\":{\"keep\":true}}";
+    const complete = try refresh.applyRefreshResponse(allocator, original, "{\"id_token\":\"new-id\",\"access_token\":\"new-access\",\"refresh_token\":\"rotated\"}", 0);
+    defer allocator.free(complete);
+    try std.testing.expect(std.mem.indexOf(u8, complete, "\"refresh_token\": \"rotated\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, complete, "\"unknown\"") != null);
+
+    const partial = try refresh.applyRefreshResponse(allocator, original, "{\"access_token\":\"new-access\"}", 0);
+    defer allocator.free(partial);
+    try std.testing.expect(std.mem.indexOf(u8, partial, "\"refresh_token\": \"old-refresh\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, partial, "\"id_token\": \"old-id\"") != null);
+}
+
+test "sensitive atomic writes replace content and enforce POSIX owner-only permissions" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realPathFileAlloc(app_runtime.io(), ".", allocator);
+    defer allocator.free(dir_path);
+    const path = try std.fs.path.join(allocator, &.{ dir_path, "auth.json" });
+    defer allocator.free(path);
+    try sensitive_file.writeAtomic(path, "first");
+    try sensitive_file.writeAtomic(path, "second");
+    const stat = try std.Io.Dir.cwd().statFile(app_runtime.io(), path, .{});
+    try std.testing.expectEqual(@as(std.posix.mode_t, 0o600), stat.permissions.toMode() & 0o777);
+    const file = try std.Io.Dir.cwd().openFile(app_runtime.io(), path, .{});
+    defer file.close(app_runtime.io());
+    var buffer: [16]u8 = undefined;
+    var reader = file.reader(app_runtime.io(), &buffer);
+    const content = try reader.interface.allocRemaining(allocator, .limited(16));
+    defer allocator.free(content);
+    try std.testing.expectEqualStrings("second", content);
+}

--- a/tests/oauth_refresh_test.zig
+++ b/tests/oauth_refresh_test.zig
@@ -3,6 +3,35 @@ const refresh = @import("codex_auth").auth.oauth_refresh;
 const sensitive_file = @import("codex_auth").core.sensitive_file;
 const app_runtime = @import("codex_auth").core.runtime;
 const builtin = @import("builtin");
+const http = @import("codex_auth").api.http;
+
+const ConcurrentRequester = struct {
+    var calls: std.atomic.Value(usize) = .init(0);
+
+    fn request(allocator: std.mem.Allocator, _: []const u8, _: []const u8) anyerror!http.HttpResult {
+        _ = calls.fetchAdd(1, .seq_cst);
+        const deadline = std.Io.Timestamp.now(app_runtime.io(), .real).toMilliseconds() + 100;
+        while (std.Io.Timestamp.now(app_runtime.io(), .real).toMilliseconds() < deadline) {
+            std.Thread.yield() catch {};
+        }
+        return .{
+            .body = try allocator.dupe(u8, "{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.x\",\"refresh_token\":\"rotated\"}"),
+            .status_code = 200,
+        };
+    }
+};
+
+fn lockExclusive(file: std.Io.File) anyerror!void {
+    try file.lock(app_runtime.io(), .exclusive);
+}
+
+fn unsupportedLock(_: std.Io.File) anyerror!void {
+    return error.FileLocksUnsupported;
+}
+
+fn unexpectedRequest(_: std.mem.Allocator, _: []const u8, _: []const u8) anyerror!http.HttpResult {
+    return error.UnexpectedRequest;
+}
 
 fn authWithExp(allocator: std.mem.Allocator, exp: i64) ![]u8 {
     const claims = try std.fmt.allocPrint(allocator, "{{\"exp\":{d}}}", .{exp});
@@ -76,4 +105,58 @@ test "sensitive atomic writes replace content and enforce POSIX owner-only permi
     const content = try reader.interface.allocRemaining(allocator, .limited(16));
     defer allocator.free(content);
     try std.testing.expectEqualStrings("second", content);
+}
+
+test "concurrent refresh callers collapse refresh token rotation to one request" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const codex_home_z = try tmp.dir.realPathFileAlloc(app_runtime.io(), ".", allocator);
+    defer allocator.free(codex_home_z);
+    const codex_home: []const u8 = codex_home_z;
+    try registryTestSnapshot(allocator, codex_home, "acct");
+    ConcurrentRequester.calls.store(0, .seq_cst);
+
+    const Runner = struct {
+        fn run(home: []const u8) void {
+            _ = refresh.refreshAccountWith(
+                std.heap.smp_allocator,
+                home,
+                "acct",
+                false,
+                false,
+                1,
+                ConcurrentRequester.request,
+                lockExclusive,
+            ) catch unreachable;
+        }
+    };
+    const first = try std.Thread.spawn(.{}, Runner.run, .{codex_home});
+    const second = try std.Thread.spawn(.{}, Runner.run, .{codex_home});
+    first.join();
+    second.join();
+    try std.testing.expectEqual(@as(usize, 1), ConcurrentRequester.calls.load(.seq_cst));
+}
+
+test "unsupported file locking fails closed before token transport" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const codex_home_z = try tmp.dir.realPathFileAlloc(app_runtime.io(), ".", allocator);
+    defer allocator.free(codex_home_z);
+    const codex_home: []const u8 = codex_home_z;
+    try registryTestSnapshot(allocator, codex_home, "acct");
+    try std.testing.expectError(
+        error.RefreshLockUnsupported,
+        refresh.refreshAccountWith(allocator, codex_home, "acct", false, true, 1, unexpectedRequest, unsupportedLock),
+    );
+}
+
+fn registryTestSnapshot(allocator: std.mem.Allocator, codex_home: []const u8, account_key: []const u8) !void {
+    const registry = @import("codex_auth").registry;
+    try registry.ensureAccountsDir(allocator, codex_home);
+    const path = try registry.accountAuthPath(allocator, codex_home, account_key);
+    defer allocator.free(path);
+    try sensitive_file.writeAtomic(path, "{\"tokens\":{\"access_token\":\"e30.eyJleHAiOjB9.x\",\"refresh_token\":\"original\"},\"last_refresh\":\"1970-01-01T00:00:00Z\"}");
 }

--- a/tests/refresh_process.zig
+++ b/tests/refresh_process.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+const codex_auth = @import("codex_auth");
+
+const app_runtime = codex_auth.core.runtime;
+const http = codex_auth.api.http;
+const refresh = codex_auth.auth.oauth_refresh;
+
+var request_marker_path: []const u8 = &.{};
+
+fn request(allocator: std.mem.Allocator, _: []const u8, _: []const u8) anyerror!http.HttpResult {
+    var marker = try std.Io.Dir.cwd().createFile(app_runtime.io(), request_marker_path, .{ .exclusive = true });
+    defer marker.close(app_runtime.io());
+    try marker.writeStreamingAll(app_runtime.io(), "requested\n");
+
+    const deadline = std.Io.Timestamp.now(app_runtime.io(), .real).toMilliseconds() + 100;
+    while (std.Io.Timestamp.now(app_runtime.io(), .real).toMilliseconds() < deadline) {
+        std.Thread.yield() catch {};
+    }
+    return .{
+        .body = try allocator.dupe(u8, "{\"access_token\":\"e30.eyJleHAiOjQxMDI0NDQ4MDB9.x\",\"refresh_token\":\"rotated\"}"),
+        .status_code = 200,
+    };
+}
+
+fn lockExclusive(file: std.Io.File) anyerror!void {
+    try file.lock(app_runtime.io(), .exclusive);
+}
+
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    if (args.len != 3) return error.InvalidArguments;
+    request_marker_path = args[2];
+    _ = try refresh.refreshAccountWith(
+        init.gpa,
+        args[1],
+        "acct",
+        false,
+        false,
+        1,
+        request,
+        lockExclusive,
+    );
+}


### PR DESCRIPTION
## Summary

- refresh stale managed OAuth snapshots before API-backed usage and account activation
- serialize refresh-token rotation with a persistent per-account file lock
- persist refreshed auth atomically, updating active `auth.json` before its managed snapshot
- force one refresh and replay one usage request after `401 token_expired`
- keep refresh tokens in curl stdin config rather than argv, environment variables, or temporary files

## Behavior

Access tokens refresh within five minutes of `exp`. When `exp` cannot be decoded, `last_refresh` older than eight days is the fallback. Refresh responses replace every returned token, including rotated refresh tokens, while preserving omitted tokens and unknown auth fields.

Known expired, reused, invalidated, and OAuth `invalid_grant` failures require login. Other 400/401/403 responses are non-retryable protocol failures. Transport failures, timeouts, 429s, and 5xx responses are transient; the token endpoint is never retried automatically.

Switching blocks on permanent auth failure. Transient refresh failure emits a warning and still activates the target so official Codex recovery remains available. `--skip-api` does not refresh.

This addresses the failure modes discussed in #79, #110, and #145. It does not claim to close reports that the regression tests do not reproduce.

## Verification

- `zig build test`: 439 passed, 8 platform-specific skips
- two independent refresh processes collapse onto one token request
- injected `FileLocksUnsupported` fails before token transport
- isolated `zig build run -- list`
- ReleaseSafe cross-compilation for `x86_64-windows-gnu` and `x86_64-linux-gnu`
- `git diff --check`
- source/test-boundary checks from `docs/tests.md`

The existing inline tests in `src/cli/live_tui.zig` predate this diff; this change adds no source-inline tests or test-only production exports.

## Security notes

The refresh request body is supplied only through curl stdin configuration. POSIX sensitive writes use atomic replacement and enforce mode `0600`. Windows retains the repository existing temp/backup/replace strategy and security model; this change does not add Windows ACL hardening.
